### PR TITLE
Update Welcome Webview

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -197,8 +197,24 @@ export function activate(context: ExtensionContext): void {
         const userConfigAffected = event.affectsConfiguration("Odoo.userDefinedConfigurations");
         if (selectedConfigAffected || userConfigAffected) setStatusConfig(odooStatusBar);
     })
+    
+    context.subscriptions.push(
+        commands.registerCommand("odoo.openWelcomeView", () => {
+            WelcomeWebView.render(context);
+        })
+    );
 
-    WelcomeWebView.render(context.extensionUri);
+    switch (context.globalState.get('Odoo.displayWelcomeView', null)) {
+        case null:
+            context.globalState.update('Odoo.displayWelcomeView', false);
+            WelcomeWebView.render(context);
+            break;
+        case true:
+            WelcomeWebView.render(context);
+            break;
+    }
+    
+
     const config = getCurrentConfig();
     if (config) {
         console.log(config);

--- a/client/webview-ui/welcomeWebView.js
+++ b/client/webview-ui/welcomeWebView.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-undef */
+// file: webview-ui/main.js
+
+const vscode = acquireVsCodeApi();
+
+window.addEventListener("load", main);
+
+function main() {
+  const showWelcomeCheckbox = document.getElementById("displayOdooWelcomeOnStart");
+  showWelcomeCheckbox.addEventListener("change", changeDisplayWelcomeValue);
+}
+
+function changeDisplayWelcomeValue() {
+    vscode.postMessage({
+        command: "changeWelcomeDisplayValue",
+        toggled: document.getElementById("displayOdooWelcomeOnStart").checked
+    });
+}

--- a/package.json
+++ b/package.json
@@ -21,15 +21,23 @@
       {
         "command": "odoo.addConfiguration",
         "title": "Add Configuration",
+        "category": "Odoo",
         "icon": "$(add)"
       },
       {
         "command": "odoo.openConfiguration",
-        "title": "Open configuration"
+        "title": "Open configuration",
+        "category": "Odoo"
       },
       {
         "command": "odoo.clickStatusBar",
-        "title": "Status Bar Click"
+        "title": "Change Configuration",
+        "category": "Odoo"
+      },
+      {
+        "command": "odoo.openWelcomeView",
+        "title": "Open the Welcome page",
+        "category": "Odoo"
       }
     ],
     "viewsContainers": {


### PR DESCRIPTION
The Welcome webview would open up each time you started up the extension. It will now only open up once when starting the extension for the first time.
The user also now has the option to toggle a checkbox to display the webview each time the extension is loaded.
A new command that allows the user to manually display the welcome webview has also been added.