### PR TITLE
Add getCurrentConfiguration request + Config change notification

### DIFF
--- a/client/extension.ts
+++ b/client/extension.ts
@@ -246,8 +246,11 @@ export function activate(context: ExtensionContext): void {
 
     // Listen to changes to Configurations
     context.subscriptions.push(
-        ConfigurationsChange.event(() => {
+        ConfigurationsChange.event((changes: Array<String> | null) => {
             setStatusConfig(context, odooStatusBar);
+            if (changes && (changes.includes('odooPath') || changes.includes('addons'))) {
+                client.sendNotification("Odoo/configurationChanged");
+            }
         })
     );
 
@@ -255,6 +258,7 @@ export function activate(context: ExtensionContext): void {
     context.subscriptions.push(
         selectedConfigurationChange.event(() => {
             setStatusConfig(context, odooStatusBar);
+            client.sendNotification("Odoo/configurationChanged");
         })
     );
     
@@ -295,6 +299,10 @@ export function activate(context: ExtensionContext): void {
         "Odoo/clientReady",
         {"config": getCurrentConfig(context)}
     );
+
+    context.subscriptions.push(client.onRequest("Odoo/getConfiguration", (params) => {
+        return getCurrentConfig(context);
+    }));
     client.start();
 }
 

--- a/client/views/configurations/configurationWebView.ts
+++ b/client/views/configurations/configurationWebView.ts
@@ -131,6 +131,26 @@ export class ConfigurationWebView {
     }
 
     private _saveConfig(configs: any, odooPath: String, name: String, addons: Array<String>): void {
+        let changes = [];
+        let oldAddons = configs[this.configId]["addons"]
+
+        if (configs[this.configId]["odooPath"] != odooPath) {
+            changes.push("odooPath");
+        }
+        
+        if (oldAddons.length != addons.length) {
+            changes.push("addons");
+        } else {
+            oldAddons.sort();
+            addons.sort();
+            for (let i = 0; i < oldAddons.length; i++) {
+                if (oldAddons[i] != addons[i]) {
+                    changes.push("addons");
+                    break;
+                }
+            }
+        }
+
         configs[this.configId] = {
             "id": this.configId,
             "name": name,
@@ -138,7 +158,7 @@ export class ConfigurationWebView {
             "addons": addons
         };
         this._context.globalState.update("Odoo.configurations", configs);
-        ConfigurationsChange.fire(null);
+        ConfigurationsChange.fire(changes);
     }
 
     /**

--- a/server/core/odoo.py
+++ b/server/core/odoo.py
@@ -101,6 +101,7 @@ class Odoo():
 
             try:
                 Odoo.instance = Odoo()
+                config = ls.lsp.send_request("Odoo/getConfiguration").result()
                 with Odoo.instance.acquire_write(ls):
                     Odoo.instance.symbols.paths = []
                     for path in sys.path:
@@ -111,8 +112,8 @@ class Odoo():
                     Odoo.instance.symbols.paths.append(os.path.join(pathlib.Path(__file__).parent.parent.resolve(), "typeshed", "stdlib"))
                     Odoo.instance.grammar = parso.load_grammar(version="3.8") #TODO config or choose automatically
                     Odoo.instance.start_build_time = time.time()
-                    Odoo.instance.odooPath = ls.config["odooPath"]
-                    Odoo.instance.build_database(ls, ls.config)
+                    Odoo.instance.odooPath = config.odooPath
+                    Odoo.instance.build_database(ls, config)
                     ls.show_message_log("End building database in " + str(time.time() - Odoo.instance.start_build_time) + " seconds")
             except Exception as e:
                 ls.show_message_log(traceback.format_exc())
@@ -155,7 +156,7 @@ class Odoo():
                     os.path.join(self.odooPath, "addons"),
                     #"/home/odoo/Documents/odoo-servers/test_odoo/enterprise",
                     ]
-            addonsSymbol.paths += used_config['addons']
+            addonsSymbol.paths += used_config.addons
             return True
         else:
             ls.show_message_log("Odoo not found at " + self.odooPath, MessageType.Error)

--- a/server/server.py
+++ b/server/server.py
@@ -170,19 +170,14 @@ def did_open(ls, params: DidOpenTextDocumentParams):
     path = get_path_file(params.text_document.uri)
     FileMgr.getFileInfo(path, content, params.text_document.version, opened = True)
 
+@odoo_server.feature("Odoo/configurationChanged")
+def client_config_changed(ls, params=None):
+    print("Config changed")
+    pass
 
 @odoo_server.thread()
 @odoo_server.feature("Odoo/clientReady")
 def client_ready(ls, params=None):
-    print(params)
-    if params:
-        config = params.config
-        ls.config = {
-            "id": config.id,
-            "name": config.name,
-            "odooPath": config.odooPath,
-            "addons": config.addons
-        }
         Odoo.get(ls)
 
 @odoo_server.feature(WORKSPACE_DIAGNOSTIC)


### PR DESCRIPTION
The current configuration can now be fetched by the server through the Odoo/getCurrentConfiguration request which returns a configuration Object.

The client now notifies the server whenever the user selects a different configuration or change their Configuration's addons or odooPath.