### PR TITLE
Check for missing dependency + Configurable python path

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,12 @@
           ],
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
+        },
+        "Odoo.pythonPath": {
+          "scope": "window",
+          "type": "string",
+          "default": null,
+          "description": "Path to the Python binary the Language Server will run on."
         }
       }
     }


### PR DESCRIPTION
The client will now check if the given python path has the required dependencies to run the Language server. If not, the user will be notified of the missing dependencies.

A Odoo.pythonPath setting has also been added to the settings of the Extension. This field allows the extension to run off the specified python binary. If the field is empty, the user will be notified and the extension will try to run by using the python3 macro. If this field is changed, the user will need to reload their vscode for the changes to take effect, either manually or through the new notification that appears whenever this field is modified.