### PR TITLE
[FIX] server: close server if communication is pipe is broken

### DIFF
--- a/server/python_utils.py
+++ b/server/python_utils.py
@@ -214,6 +214,10 @@ def send_error_on_traceback(func):
         try:
             return func(*args, **kwargs)
         except Exception:
-            odoo_server.show_message_log(traceback.format_exc(), MessageType.Error)
-            odoo_server.send_notification("Odoo/displayCrashNotification", {"crashInfo": traceback.format_exc()})
+            try:
+                odoo_server.show_message_log(traceback.format_exc(), MessageType.Error)
+                odoo_server.send_notification("Odoo/displayCrashNotification", {"crashInfo": traceback.format_exc()})
+            except Exception:
+                #it was the last chance... We prefer to close the server here as it seems there is an issue with the communication
+                exit(1)
     return wrapper_func


### PR DESCRIPTION
Actually if the server is left alone (should not happen, but still), the communication is broken, and it starts to log that he can't communicate, then crash, then log, etc... This commit ensure that it doesn't happen and choose to close the server if the communication pipe is broken. This behaviour could be fine-tuned if the server appear to be used independently for multiple client (?)