### PR TITLE
[FIX] server: prevent brokenpipeError

### DIFF
--- a/server/odoo_language_server.py
+++ b/server/odoo_language_server.py
@@ -28,8 +28,11 @@ class OdooLanguageServer(LanguageServer):
         super().__init__(name=EXTENSION_NAME, version=EXTENSION_VERSION)
 
     def report_server_error(self, error: Exception, source):
-        odoo_server.show_message_log(traceback.format_exc(), MessageType.Error)
-        odoo_server.send_notification("Odoo/displayCrashNotification", {"crashInfo": traceback.format_exc()})
+        try:
+            odoo_server.show_message_log(traceback.format_exc(), MessageType.Error)
+            odoo_server.send_notification("Odoo/displayCrashNotification", {"crashInfo": traceback.format_exc()})
+        except BrokenPipeError:
+            exit(1)
 
     def launch_thread(self, target, args):
         thread = threading.Thread(target=_prepare_ctxt_thread, args=(self, target, args))

--- a/server/python_utils.py
+++ b/server/python_utils.py
@@ -217,7 +217,7 @@ def send_error_on_traceback(func):
             try:
                 odoo_server.show_message_log(traceback.format_exc(), MessageType.Error)
                 odoo_server.send_notification("Odoo/displayCrashNotification", {"crashInfo": traceback.format_exc()})
-            except Exception:
+            except BrokenPipeError:
                 #it was the last chance... We prefer to close the server here as it seems there is an issue with the communication
                 exit(1)
     return wrapper_func


### PR DESCRIPTION
Prevent brokenpipe Error from filling the whole disk space, if an error occur in pygls code while the server is disconnected from the client.

Fixes: https://github.com/odoo/odoo-ls/issues/82