### PR TITLE
[FIX] server: do not log BrokenPipeError sent from PyGLS

### DIFF
--- a/server/odoo_language_server.py
+++ b/server/odoo_language_server.py
@@ -28,6 +28,8 @@ class OdooLanguageServer(LanguageServer):
         super().__init__(name=EXTENSION_NAME, version=EXTENSION_VERSION)
 
     def report_server_error(self, error: Exception, source):
+        if isinstance(error, BrokenPipeError):
+            exit(1)
         try:
             odoo_server.show_message_log(traceback.format_exc(), MessageType.Error)
             odoo_server.send_notification("Odoo/displayCrashNotification", {"crashInfo": traceback.format_exc()})


### PR DESCRIPTION
If a BrokenPipeError occurs, it is catched by PyGLS, and do not enter in our try...except. Then we should avoid to log when it is raised by PyGLS.

Fixes #95 