### PR TITLE
[FIX] server: Return Relational symbol when comodel is not present in…

### DIFF
--- a/server/core/python_arch_eval_odoo_hooks.py
+++ b/server/core/python_arch_eval_odoo_hooks.py
@@ -52,6 +52,8 @@ class EvaluationGet(Evaluation):
 class EvaluationRelational(Evaluation):
 
     def _get_symbol_hook(self, rr_symbol, context):
+        if "comodel_name" not in context:
+            return rr_symbol
         model = Odoo.get().models.get(context["comodel_name"], None)
         if model:
             main_sym = model.get_main_symbols() #module) #TODO use module in context


### PR DESCRIPTION
… context

If 'comodel_name' is not present in context when evaluating a Realtional field (Many2one, etc..), it should return the symbol of the field itself, for the case where the user do a request on a non-instancied expression. Ex: on "fields.Many2one"