### PR TITLE
[FIX] server: right return value for get_loaded_part_tree

### DIFF
--- a/server/core/odoo.py
+++ b/server/core/odoo.py
@@ -405,7 +405,7 @@ class Odoo():
         # (odoo/addons/test/models, "test.py"). the first element is a symbol. return None, None if not in the project
         addonSymbol = self.symbols.get_symbol(["odoo", "addons"])
         if not addonSymbol:
-            return ()
+            return None, None
         symbol = addonSymbol
         for dir_path in [self.instance.odooPath] + addonSymbol.paths:
             if path.startswith(dir_path):


### PR DESCRIPTION
get_loaded_part_tree should always return a tuple of size 2, not ()