### PR TITLE
[IMP] server,vscode: update logging file naming

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -40,8 +40,8 @@ fn main() {
     let file_appender = RollingFileAppender::builder()
         .max_log_files(5) // only the most recent 5 log files will be kept
         .rotation(Rotation::HOURLY)
-        .filename_prefix(format!("odoo_logs_{}", std::process::id()))
-        .filename_suffix("log")
+        .filename_prefix("odoo_logs")
+        .filename_suffix(format!("{}.log", std::process::id()))
         .build(log_dir)
         .expect("failed to initialize rolling file appender");
     let (file_writer, _guard) = tracing_appender::non_blocking(file_appender);

--- a/vscode/client/extension.ts
+++ b/vscode/client/extension.ts
@@ -238,8 +238,8 @@ async function changeSelectedConfig(context: ExtensionContext, configId: Number)
 }
 
 async function find_last_log_file(context: ExtensionContext, pid: number) {
-    let prefix = "odoo_logs_" + pid;
-    let suffix = ".log"
+    let prefix = "odoo_logs";
+    let suffix =  `.${pid}.log`
     let cwd = path.join(__dirname, "..", "..");
     if (context.extensionMode === ExtensionMode.Development) {
         cwd = path.join(cwd, "..", "server");


### PR DESCRIPTION
Use odoo_log.\<time\>.\<pid\>.log, instead of odoo_log_\<pid\>.\<time\>.log