### PR TITLE
[FIX] server: improve messages managements to not block threads and b…

### DIFF
--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -6,6 +6,7 @@ pub const EXTENSION_VERSION: &str = "0.2.8";
 
 pub const DEBUG_ODOO_BUILDER: bool = false;
 pub const DEBUG_MEMORY: bool = false;
+pub const DEBUG_THREADS: bool = false;
 
 pub type Tree = (Vec<String>, Vec<String>);
 

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -773,7 +773,12 @@ impl Odoo {
         let config_params = ConfigurationParams {
             items: vec![configuration_item],
         };
-        let config = session.send_request::<ConfigurationParams, Vec<serde_json::Value>>(WorkspaceConfiguration::METHOD, config_params).unwrap().unwrap();
+        let config = match session.send_request::<ConfigurationParams, Vec<serde_json::Value>>(WorkspaceConfiguration::METHOD, config_params) {
+            Ok(config) => config.unwrap(),
+            Err(_) => {
+                return Err(S!("Unable to get configuration from client, client not available"));
+            }
+        };
         let config = config.get(0);
         if !config.is_some() {
             session.log_message(MessageType::ERROR, String::from("No config found for Odoo. Exiting..."));

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -7,7 +7,7 @@ use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_panic::panic_hook;
 use tracing_subscriber::{fmt, FmtSubscriber, layer::SubscriberExt};
 
-use std::{env, path::PathBuf};
+use std::{env, path::PathBuf, process};
 
 
 fn main() {
@@ -90,7 +90,10 @@ fn main() {
                 })
             }));
         }));
-        serv.run(cli.clientProcessId);
+        if !serv.run(cli.clientProcessId) {
+            info!(">>>>>>>>>>>>>>>>>> End Session <<<<<<<<<<<<<<<<<<");
+            process::exit(1);
+        }
     } else {
         info!("starting server");
         let mut serv = Server::new_stdio();
@@ -106,7 +109,10 @@ fn main() {
                 })
             }));
         }));
-        serv.run(cli.clientProcessId);
+        if !serv.run(cli.clientProcessId) {
+            info!(">>>>>>>>>>>>>>>>>> End Session <<<<<<<<<<<<<<<<<<");
+            process::exit(1);
+        }
     }
     info!(">>>>>>>>>>>>>>>>>> End Session <<<<<<<<<<<<<<<<<<");
 }

--- a/server/src/threads.rs
+++ b/server/src/threads.rs
@@ -69,6 +69,12 @@ impl <'a> SessionInfo<'a> {
                     }
                 }
             },
+            Ok(Message::Request(r)) => {
+                if r.method == Shutdown::METHOD {
+                    return Err(ServerError::ServerError("Server is shutting down, cancelling request".to_string()));
+                }
+                return Err(ServerError::ServerError("Not a Response.".to_string()))
+            }
             Ok(_) => return Err(ServerError::ServerError("Not a Response.".to_string())),
             Err(_) => return Err(ServerError::ServerError("Server disconnected".to_string())),
         }


### PR DESCRIPTION
…e able to close

Shutdown event was processed by handle_shutdown from lsp_server. However this method doesn't handle response that could come between the answer of the shutdown request and the exit notification. This commit reimplement the shutdown request processing to allow that. Moreover, send_request method was using specific channel to read response, and so generic channel which contains the exit notification was never read and so the threads could never close. Exit notification is now sent in generic and specific channels for all threads