### PR TITLE
[IMP] server, vscode: remove afterDelay option

### DIFF
--- a/server/src/core/config.rs
+++ b/server/src/core/config.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum RefreshMode {
-    AfterDelay,
     OnSave,
     Adaptive,
     Off
@@ -16,7 +15,7 @@ impl FromStr for RefreshMode {
 
     fn from_str(input: &str) -> Result<RefreshMode, Self::Err> {
         match input {
-            "afterDelay"  => Ok(RefreshMode::AfterDelay),
+            "afterDelay"  => Ok(RefreshMode::Adaptive),
             "onSave"  => Ok(RefreshMode::OnSave),
             "adaptive" => Ok(RefreshMode::Adaptive),
             "off"  => Ok(RefreshMode::Off),

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1197,7 +1197,7 @@ impl Odoo {
         session.log_message(MessageType::INFO, format!("File changed: {}", path.sanitize()));
         let version = params.text_document.version;
         if Odoo::update_file_cache(session, path.clone(), Some(&params.content_changes), version) {
-            if (session.sync_odoo.config.refresh_mode != RefreshMode::AfterDelay && session.sync_odoo.config.refresh_mode != RefreshMode::Adaptive) || session.sync_odoo.state_init == InitState::NOT_READY {
+            if (matches!(session.sync_odoo.config.refresh_mode, RefreshMode::Off | RefreshMode::OnSave)) || session.sync_odoo.state_init == InitState::NOT_READY {
                 return
             }
             Odoo::update_file_index(session, path, false, false, false);
@@ -1254,7 +1254,7 @@ impl Odoo {
                 }
                 SyncOdoo::process_rebuilds(session);
             } else {
-                if force_delay || session.sync_odoo.config.refresh_mode == RefreshMode::AfterDelay || session.sync_odoo.config.refresh_mode == RefreshMode::Adaptive {
+                if force_delay || session.sync_odoo.config.refresh_mode == RefreshMode::Adaptive {
                     SessionInfo::request_update_file_index(session, &path, force_delay);
                 }
             }

--- a/vscode/client/extension.ts
+++ b/vscode/client/extension.ts
@@ -40,6 +40,7 @@ import { areUniquelyEqual, buildFinalPythonPath, evaluateOdooPath, getCurrentCon
 import { getConfigurationStructure, stateInit } from "./common/validation";
 import { execSync } from "child_process";
 import {
+    migrateAfterDelay,
     migrateConfigToSettings
 } from "./migration/migrateConfig";
 import { constants } from "fs/promises";
@@ -725,6 +726,7 @@ async function initializeSubscriptions(context: ExtensionContext): Promise<void>
 
 function handleMigration(context){
     migrateConfigToSettings(context)
+    migrateAfterDelay(context)
 }
 
 export async function activate(context: ExtensionContext): Promise<void> {

--- a/vscode/client/migration/migrateConfig.ts
+++ b/vscode/client/migration/migrateConfig.ts
@@ -12,3 +12,8 @@ export async function migrateConfigToSettings(context: ExtensionContext){
         workspace.getConfiguration().update("Odoo.configurations", oldConfig, ConfigurationTarget.Global); // putting it the settings
     }
 }
+export async function migrateAfterDelay(context: ExtensionContext){
+    if (String(workspace.getConfiguration().get("Odoo.serverLogLevel")) == "afterDelay"){
+        workspace.getConfiguration().update("Odoo.serverLogLevel", "adaptive", ConfigurationTarget.Global)
+    }
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -79,13 +79,11 @@
           "default": "adaptive",
           "enum": [
             "onSave",
-            "afterDelay",
             "adaptive",
             "off"
           ],
           "enumDescriptions": [
             "Refreshes the server data when the user saves a file",
-            "Refreshes the server data after a delay (Odoo.autoRefreshDelay)",
             "Refreshed the server immediatly if it will be fast, otherwises during inactivity (based on autoRefreshDelay)",
             "Disables the auto-refresh feature"
           ],


### PR DESCRIPTION
Adpative being more and more accurate, able to use file hash and interruption of process_rebuild, afterDelay begin to be useless and we prefer to remove the option to not handle too many configurations