### PR TITLE
[FIX] server: quit function validation when ast changes

### DIFF
--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -96,7 +96,9 @@ impl PythonArchBuilder {
                     &AstUtils::find_stmt_from_ast(file_info.ast.as_ref().unwrap(), self.sym_stack[0].borrow().ast_indexes().unwrap()).as_function_def_stmt().unwrap().body
                 }
             };
-            symbol.borrow_mut().set_processed_text_hash(file_info.text_hash);
+            if self.file_mode {
+                symbol.borrow_mut().set_processed_text_hash(file_info.text_hash);
+            }
             self.visit_node(session, &ast);
             self._resolve_all_symbols(session);
             if self.file_mode {
@@ -431,8 +433,6 @@ impl PythonArchBuilder {
             self.sym_stack.push(sym.clone());
             self.visit_node(session, &func_def.body)?;
             self.sym_stack.pop();
-            let file_info_rc = session.sync_odoo.get_file_mgr().borrow().get_file_info(&self.file.borrow().get_symbol_first_path()).unwrap();
-            sym.borrow_mut().set_processed_text_hash(file_info_rc.borrow().text_hash);
             sym.borrow_mut().as_func_mut().arch_status = BuildStatus::DONE;
         }
         Ok(())

--- a/server/src/core/symbols/function_symbol.rs
+++ b/server/src/core/symbols/function_symbol.rs
@@ -48,7 +48,6 @@ pub struct FunctionSymbol {
     pub args: Vec<Argument>,
     pub is_overloaded: bool, //used for @overload decorator. Only indicates if the decorator is present. Use is_overloaded() to know if this function is overloaded
     pub is_class_method: bool, //used for @classmethod decorator
-    pub processed_text_hash: u64,
 
     //Trait SymbolMgr
     //--- Body content
@@ -86,7 +85,6 @@ impl FunctionSymbol {
             args: vec![],
             is_overloaded: false,
             is_class_method: false,
-            processed_text_hash: 0,
         };
         res._init_symbol_mgr();
         res

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -1385,9 +1385,9 @@ impl Symbol {
     pub fn set_processed_text_hash(&mut self, hash: u64){
         match self {
             Symbol::File(f) => f.processed_text_hash = hash,
-            Symbol::Function(f) => f.processed_text_hash = hash,
             Symbol::Package(PackageSymbol::Module(m)) => m.processed_text_hash = hash,
             Symbol::Package(PackageSymbol::PythonPackage(p)) => p.processed_text_hash = hash,
+            Symbol::Function(_) => panic!("set_processed_text_hash called on Function"),
             Symbol::Root(_) => panic!("set_processed_text_hash called on Root"),
             Symbol::Namespace(_) => panic!("set_processed_text_hash called on Namespace"),
             Symbol::Compiled(_) => panic!("set_processed_text_hash called on Compiled"),
@@ -1399,9 +1399,9 @@ impl Symbol {
     pub fn get_processed_text_hash(&self) -> u64{
         match self {
             Symbol::File(f) => f.processed_text_hash,
-            Symbol::Function(f) => f.processed_text_hash,
             Symbol::Package(PackageSymbol::Module(m)) => m.processed_text_hash,
             Symbol::Package(PackageSymbol::PythonPackage(p)) => p.processed_text_hash,
+            Symbol::Function(_) => panic!("get_processed_text_hash called on Function"),
             Symbol::Root(_) => panic!("get_processed_text_hash called on Root"),
             Symbol::Namespace(_) => panic!("get_processed_text_hash called on Namespace"),
             Symbol::Compiled(_) => panic!("get_processed_text_hash called on Compiled"),


### PR DESCRIPTION
And check the processed hash on the parent file,
also remove processed_text_hash from Function symbol as it is not needed anymore