### PR TITLE
[FIX] server: avoid unwrap on base class werak upgrade

### DIFF
--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -1786,7 +1786,9 @@ impl Symbol {
                 let bases = symbol.borrow().as_class_sym().bases.clone();
                 for base in bases.iter() {
                     //no comodel as we will process only model in base class (overrided _name?)
-                    Symbol::all_members(&base.upgrade().unwrap(), session, result, false, from_module.clone(), acc, false);
+                    if let Some(base) = base.upgrade() {
+                        Symbol::all_members(&base, session, result, false, from_module.clone(), acc, false);
+                    }
                 }
             },
             _ => {


### PR DESCRIPTION
weak are used to reflect that some links can be invalid, we should not unwrap them. It shows however that a dependency may be missing, but either that a rebuild is pending, so as we don't know, we just ignore the invalid base