### PR TITLE
[IMP] server: handle new odoo structure on > 18.1

### DIFF
--- a/server/src/core/symbols/file_symbol.rs
+++ b/server/src/core/symbols/file_symbol.rs
@@ -18,6 +18,7 @@ pub struct FileSymbol {
     pub validation_status: BuildStatus,
     pub not_found_paths: Vec<(BuildSteps, Vec<String>)>,
     pub in_workspace: bool,
+    pub self_import: bool,
     pub model_dependencies: PtrWeakHashSet<Weak<RefCell<Model>>>, //always on validation level, as odoo step is always required
     pub dependencies: [Vec<PtrWeakHashSet<Weak<RefCell<Symbol>>>>; 4],
     pub dependents: [Vec<PtrWeakHashSet<Weak<RefCell<Symbol>>>>; 3],
@@ -45,6 +46,7 @@ impl FileSymbol {
             validation_status: BuildStatus::PENDING,
             not_found_paths: vec![],
             in_workspace: false,
+            self_import: false,
             sections: vec![],
             symbols: HashMap::new(),
             ext_symbols: HashMap::new(),

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -320,6 +320,20 @@ impl Symbol {
         }
     }
 
+    pub fn as_namespace(&self) -> &NamespaceSymbol {
+        match self {
+            Symbol::Namespace(n) => n,
+            _ => {panic!("Not a namespace")}
+        }
+    }
+
+    pub fn as_namespace_mut(&mut self) -> &mut NamespaceSymbol {
+        match self {
+            Symbol::Namespace(n) => n,
+            _ => {panic!("Not a namespace")}
+        }
+    }
+
     pub fn as_variable(&self) -> &VariableSymbol {
         match self {
             Symbol::Variable(v) => v,
@@ -926,6 +940,9 @@ impl Symbol {
                     }
                     return Some(ref_sym);
                 }
+            } else if path.is_dir() {
+                let ref_sym = (*parent).borrow_mut().add_new_namespace(session, &name, &path_str);
+                return Some(ref_sym);
             }
         }
         None
@@ -1316,6 +1333,11 @@ impl Symbol {
                 },
                 SymType::PACKAGE(PackageType::PYTHON_PACKAGE) => {
                     if ref_to_unload.borrow().as_python_package().self_import {
+                        session.sync_odoo.must_reload_paths.push((Rc::downgrade(&parent), ref_to_unload.borrow().paths().first().unwrap().clone()));
+                    }
+                },
+                SymType::FILE => {
+                    if ref_to_unload.borrow().as_file().self_import {
                         session.sync_odoo.must_reload_paths.push((Rc::downgrade(&parent), ref_to_unload.borrow().paths().first().unwrap().clone()));
                     }
                 }


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/8b3480b397409e620c746506e89fd2dfc0ec9dc2 is changing the structure of odoo: removing odoo/__init__.py and odoo/addons/__init__.py require these changes to import these symbols