### PR TITLE
[IMP] server: handle decorators, relational fields and update hooks

### DIFF
--- a/server/error_code.md
+++ b/server/error_code.md
@@ -217,5 +217,5 @@ In relational fields, comodel_name supplied exists but not in dependencies
 In relational fields, comodel_name does not exist in current configuration
 
 ### OLS30326
-"Related field not same type"
+"Related field is not of the same type"
 Type of references field in related keyword argument does not match the current field

--- a/server/error_code.md
+++ b/server/error_code.md
@@ -202,3 +202,6 @@ In a search domain, when using a dot separator on a Date field, you can use the 
 "Invalid search domain field: Invalid dot notation".
 In a search domain, when using a dot separator, it should be used either on a Date or Relational field.
 If you used a relational field and get this error, check that the comodel of this field is valid.
+
+### OLS30323
+"Field does not exist on model"

--- a/server/error_code.md
+++ b/server/error_code.md
@@ -205,3 +205,9 @@ If you used a relational field and get this error, check that the comodel of thi
 
 ### OLS30323
 "Field does not exist on model"
+
+### OLS30324
+"Field comodel_name not in dependencies"
+
+### OLS30325
+"Field comodel_name does not exist"

--- a/server/error_code.md
+++ b/server/error_code.md
@@ -66,14 +66,14 @@ See the error message to get the details from Ruff
 ### OLS30101
 
 "This model is not in the dependencies of your module."
-With the Environment (often via self.env), you are trying to get a recordset of a model that is not defined in the current module or in the dependencies of the current module.
+With the Environment (often via self.env), or in @api.returns, you are trying to get a recordset of a model that is not defined in the current module or in the dependencies of the current module.
 Even if it could work, this is strongly not recommended, as the model you are referring to could be not available on a live database.
 Do not forget that even if your model is in an auto-installed module, it can be uninstalled by a user.
 
 ### OLS30102
 
 "Unknown model. Check your addons path"
-With the Environment (often via self.env), you are trying to get a recordset of a model that is unknown by OdooLS. It means that if the model exists in the codebase, OdooLS
+With the Environment (often via self.env), or in @api.returns, you are trying to get a recordset of a model that is unknown by OdooLS. It means that if the model exists in the codebase, OdooLS
 is not aware of it. Check the addons path you provided to be sure that the module declaring this model is in an addon path.
 
 ### OLS30103

--- a/server/error_code.md
+++ b/server/error_code.md
@@ -24,18 +24,18 @@ Check your python environment, the effective your sys.path and your addon paths.
 
 "XXXX not found".
 The symbol you used as a base class can not be resolved.
-Be sure that the symbol is refering to a valid python class.
+Be sure that the symbol is referring to a valid python class.
 
 ### OLS20003
 
 "XXXX not found".
 The symbol you used as a base class is not a class, or not evaluated to a class.
-Be sure that the symbol is refering to a valid python class.
+Be sure that the symbol is referring to a valid python class.
 
 ### OLS20004
 
 "Failed to evaluate XXXX".
-The extension failed to evaluate a symbol. This occurs more specificaly when the extension detect a loop in the imports.
+The extension failed to evaluate a symbol. This occurs more specifically when the extension detect a loop in the imports.
 If your code is working fine, it can happen if you use too many "import *" that can break the extension flow for now.
 
 ### OLS20005
@@ -67,7 +67,7 @@ See the error message to get the details from Ruff
 
 "This model is not in the dependencies of your module."
 With the Environment (often via self.env), you are trying to get a recordset of a model that is not defined in the current module or in the dependencies of the current module.
-Even if it could work, this is strongly not recommended, as the model you are refering to could be not available on a live database.
+Even if it could work, this is strongly not recommended, as the model you are referring to could be not available on a live database.
 Do not forget that even if your model is in an auto-installed module, it can be uninstalled by a user.
 
 ### OLS30102
@@ -96,13 +96,13 @@ The extension found some classes inheriting this model, but didn't find any clas
 
 ### OLS30201
 
-"A manifest shoul only contains one dictionnary".
-A \_\_manifest\_\_.py file should be evaluated with a literal_eval to a single dictionnary. Do not store any other information in it.
+"A manifest should only contains one dictionary".
+A \_\_manifest\_\_.py file should be evaluated with a literal_eval to a single dictionary. Do not store any other information in it.
 
 ### OLS30302
 
 "Do not use dict unpacking to build your manifest".
-Dict unpacking should be avoided. Do not create a dictionnary with values that must be unpacked like in ```{"a";1, **d}```
+Dict unpacking should be avoided. Do not create a dictionary with values that must be unpacked like in ```{"a";1, **d}```
 
 ### OLS30303
 

--- a/server/error_code.md
+++ b/server/error_code.md
@@ -205,12 +205,16 @@ If you used a relational field and get this error, check that the comodel of thi
 
 ### OLS30323
 "Field does not exist on model"
+In related keyword argument or decorators api.onchange/depends/constrains, the field provided
+should exist and be able to be resolved from current module
 
 ### OLS30324
 "Field comodel_name not in dependencies"
+In relational fields, comodel_name supplied exists but not in dependencies
 
 ### OLS30325
 "Field comodel_name does not exist"
+In relational fields, comodel_name does not exist in current configuration
 
 ### OLS30326
 "Related field not same type"

--- a/server/error_code.md
+++ b/server/error_code.md
@@ -211,3 +211,7 @@ If you used a relational field and get this error, check that the comodel of thi
 
 ### OLS30325
 "Field comodel_name does not exist"
+
+### OLS30326
+"Related field not same type"
+Type of references field in related keyword argument does not match the current field

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -414,7 +414,7 @@ impl Evaluation {
             EvaluationSymbolPtr::WEAK(_) => {
                 //take the weak by get_symbol instead of the match
                 let symbol_eval = self.symbol.get_symbol(session, &mut None, &mut vec![], Some(function.clone()));
-                let out_of_scope = Symbol::follow_ref(&symbol_eval, session, &mut None, true, false, Some(function.clone()), &mut vec![]);
+                let out_of_scope = Symbol::follow_ref(&symbol_eval, session, &mut None, false, false, Some(function.clone()), &mut vec![]);
                 for sym in out_of_scope {
                     if !sym.is_expired_if_weak() {
                         res.push(Evaluation {

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -933,7 +933,6 @@ impl Evaluation {
             ExprOrIdent::Expr(Expr::Attribute(expr)) => {
                 let (base_evals, diags) = Evaluation::eval_from_ast(session, &expr.value, parent.clone(), max_infer);
                 diagnostics.extend(diags);
-                // TODO handle multiple base_evals
                 if base_evals.is_empty() {
                     return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                 }
@@ -967,9 +966,6 @@ impl Evaluation {
                                 });
                             }
                         }
-                    }
-                    if !evals.is_empty(){
-                        break; // Only check next evaluations if we fail to get attrs from first evaluation
                     }
                 }
             },

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -1236,7 +1236,7 @@ impl Evaluation {
         let mut found_pos_arg_with_kw = arg_index;
         let to_skip = min(min_arg_for_kword, vararg_index);
         for arg in exprCall.arguments.keywords.iter() {
-            if let Some(arg_identifier) = &arg.arg { //if None, arg is a dictionnary of keywords, like in self.func(a, b, **any_kwargs)
+            if let Some(arg_identifier) = &arg.arg { //if None, arg is a dictionary of keywords, like in self.func(a, b, **any_kwargs)
                 let mut found_one = false;
                 for func_arg in function.args.iter().skip(to_skip as usize) {
                     if func_arg.symbol.upgrade().unwrap().borrow().name().to_string() == arg_identifier.id {

--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -226,7 +226,7 @@ impl FileMgr {
         }
     }
 
-    pub fn text_range_to_range(&mut self, session: &mut SessionInfo, path: &String, range: &TextRange) -> Range {
+    pub fn text_range_to_range(&self, session: &mut SessionInfo, path: &String, range: &TextRange) -> Range {
         let file = self.files.get(path);
         if let Some(file) = file {
             return Range {
@@ -278,7 +278,7 @@ impl FileMgr {
 
     pub fn clear(session: &mut SessionInfo) {
         let file_mgr = session.sync_odoo.get_file_mgr();
-        let file_mgr = file_mgr.borrow_mut();
+        let file_mgr = file_mgr.borrow();
         for file in file_mgr.files.values().clone() {
             if !file_mgr.is_in_workspace(&file.borrow().uri) {
                 continue;

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -125,7 +125,7 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: &Rc<Re
             if name_symbol.is_none() {
                 if !name.contains(".") && from_symbol.is_some() {
                     //check the last name is not a symbol in the file
-                    let name_symbol_vec = from_symbol.as_ref().unwrap().borrow_mut().get_symbol(&(vec![], vec![name.clone()]), u32::MAX);
+                    let name_symbol_vec = from_symbol.as_ref().unwrap().borrow().get_symbol(&(vec![], vec![name.clone()]), u32::MAX);
                     name_symbol = name_symbol_vec.last().cloned();
                 }
                 if name_symbol.is_none() {
@@ -166,7 +166,7 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: &Rc<Re
         None);
         if name_symbol.is_none() { //If not a file/package, try to look up in symbols in current file (second parameter of get_symbol)
             //TODO what if multiple values?
-            name_symbol = next_symbol.as_ref().unwrap().borrow_mut().get_symbol(&(vec![], name_last_name), u32::MAX).get(0).cloned();
+            name_symbol = next_symbol.as_ref().unwrap().borrow().get_symbol(&(vec![], name_last_name), u32::MAX).get(0).cloned();
             if name_symbol.is_none() {
                 result[name_index as usize].symbol = fallback_sym.as_ref().unwrap_or(&source_root).clone();
                 continue;
@@ -248,7 +248,7 @@ fn _get_or_create_symbol(session: &mut SessionInfo, for_entry: &Rc<RefCell<Entry
     for branch in names.iter() {
         match sym {
             Some(ref s) => {
-                let mut next_symbol = s.borrow_mut().get_symbol(&(vec![branch.clone()], vec![]), u32::MAX);
+                let mut next_symbol = s.borrow().get_symbol(&(vec![branch.clone()], vec![]), u32::MAX);
                 if next_symbol.is_empty() && matches!(s.borrow().typ(), SymType::ROOT | SymType::NAMESPACE | SymType::PACKAGE(_) | SymType::COMPILED | SymType::DISK_DIR) {
                     next_symbol = match _resolve_new_symbol(session, s.clone(), &branch, asname.clone()) {
                         Ok(v) => vec![v],
@@ -449,7 +449,7 @@ pub fn get_all_valid_names(session: &mut SessionInfo, source_file_symbol: &Rc<Re
     }
     for (index, branch) in names.iter().enumerate() {
         if index != names.len() -1 {
-            let mut next_symbol = sym.as_ref().unwrap().borrow_mut().get_symbol(&(vec![branch.clone()], vec![]), u32::MAX);
+            let mut next_symbol = sym.as_ref().unwrap().borrow().get_symbol(&(vec![branch.clone()], vec![]), u32::MAX);
             if next_symbol.is_empty() {
                 next_symbol = match _resolve_new_symbol(session, sym.as_ref().unwrap().clone(), &branch, None) {
                     Ok(v) => vec![v],

--- a/server/src/core/model.rs
+++ b/server/src/core/model.rs
@@ -122,6 +122,18 @@ impl Model {
         res
     }
 
+    pub fn model_in_deps(&self, session: &mut SessionInfo, from_module: &Rc<RefCell<Symbol>>) -> bool {
+        for sym in self.symbols.iter() {
+            if !sym.borrow().as_class_sym()._model.as_ref().unwrap().inherit.contains(&sym.borrow().as_class_sym()._model.as_ref().unwrap().name) {
+                let dir_name = sym.borrow().find_module().unwrap().borrow().as_module_package().dir_name.clone();
+                if ModuleSymbol::is_in_deps(session, from_module, &dir_name) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     pub fn get_full_model_symbols(model_rc: Rc<RefCell<Model>>, session: &mut SessionInfo, from_module: Rc<RefCell<Symbol>>) -> PtrWeakHashSet<Weak<RefCell<Symbol>>> {
         let mut symbol_set  = PtrWeakHashSet::new();
         let mut already_in = HashSet::new();

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -813,6 +813,10 @@ impl SyncOdoo {
         false
     }
 
+    pub fn is_in_main_entry(session: &mut SessionInfo, path: &Vec<Yarn>) -> bool{
+        path.starts_with(session.sync_odoo.main_entry_tree.as_slice())
+    }
+
     pub fn refresh_evaluations(session: &mut SessionInfo) {
         let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
         for entry in ep_mgr.borrow().iter_all() {

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -400,7 +400,7 @@ impl SyncOdoo {
     fn build_modules(session: &mut SessionInfo) {
         {
             let addons_symbol = session.sync_odoo.get_symbol(session.sync_odoo.config.odoo_path.as_ref().unwrap(), &tree(vec!["odoo", "addons"], vec![]), u32::MAX)[0].clone();
-            let addons_path = addons_symbol.borrow_mut().paths().clone();
+            let addons_path = addons_symbol.borrow().paths().clone();
             for addon_path in addons_path.iter() {
                 info!("searching modules in {}", addon_path);
                 if PathBuf::from(addon_path).exists() {
@@ -715,7 +715,7 @@ impl SyncOdoo {
         false
     }
 
-    pub fn get_file_mgr(&mut self) -> Rc<RefCell<FileMgr>> {
+    pub fn get_file_mgr(&self) -> Rc<RefCell<FileMgr>> {
         self.file_mgr.clone()
     }
 
@@ -733,7 +733,7 @@ impl SyncOdoo {
                 let parent = path_symbol.borrow().parent().clone().unwrap().upgrade().unwrap();
                 if clean_cache {
                     FileMgr::delete_path(session, &path.sanitize());
-                    let mut to_del = Vec::from_iter(path_symbol.borrow_mut().all_module_symbol().map(|x| x.clone()));
+                    let mut to_del = Vec::from_iter(path_symbol.borrow().all_module_symbol().map(|x| x.clone()));
                     let mut index = 0;
                     while index < to_del.len() {
                         FileMgr::delete_path(session, &to_del[index].borrow().paths()[0]);
@@ -1244,7 +1244,7 @@ impl Odoo {
         if let Ok(path) = params.text_document.uri.to_file_path() {
             session.log_message(MessageType::INFO, format!("File closed: {}", path.sanitize()));
             session.sync_odoo.opened_files.retain(|x| x != &path.sanitize());
-            let file_info = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&path.to_str().unwrap().to_string());
+            let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path.to_str().unwrap().to_string());
             if let Some(file_info) = file_info {
                 file_info.borrow_mut().opened = false;
             }
@@ -1430,7 +1430,7 @@ impl Odoo {
         ));
         let path = FileMgr::uri2pathname(params.text_document.uri.as_str());
         if params.text_document.uri.to_string().ends_with(".py") || params.text_document.uri.to_string().ends_with(".pyi") {
-            let file_info = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&path);
+            let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path);
             if let Some(file_info) = file_info {
                 if file_info.borrow().ast.is_some() {
                     return Ok(DocumentSymbolFeature::get_symbols(session, &file_info));

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -195,7 +195,7 @@ impl PythonArchBuilder {
                     let evaluated_type = evaluated_type.get_symbol_as_weak(session, &mut None, &mut self.diagnostics, None).weak;
                     if !evaluated_type.is_expired() {
                         let evaluated_type = evaluated_type.upgrade().unwrap();
-                        let evaluated_type_file = evaluated_type.borrow_mut().get_file().unwrap().clone().upgrade().unwrap();
+                        let evaluated_type_file = evaluated_type.borrow().get_file().unwrap().clone().upgrade().unwrap();
                         if !Rc::ptr_eq(&self.file, &evaluated_type_file) {
                             self.file.borrow_mut().add_dependency(&mut evaluated_type_file.borrow_mut(), self.current_step, BuildSteps::ARCH);
                         }

--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -69,6 +69,12 @@ impl PythonArchBuilderHooks {
                             warn!("Found __get__ function for field of name ({})", name);
                         }
                     }
+                    // ----------- __init__ ------------
+                    let get_sym = sym.get_symbol(&(vec![], vec![S!("__init__")]), u32::MAX);
+                    if get_sym.is_empty() {
+                        let range = sym.range().clone();
+                        sym.add_new_function(session, &S!("__init__"), &range, &range.end());
+                    }
                 }
             }
             _ => {}

--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -70,7 +70,7 @@ impl PythonArchBuilderHooks {
                         }
                     }
                     // ----------- __init__ ------------
-                    let get_sym = sym.get_symbol(&(vec![], vec![S!("__init__")]), u32::MAX);
+                    let get_sym = sym.get_symbol(&(vec![], vec![Sy!("__init__")]), u32::MAX);
                     if get_sym.is_empty() {
                         let range = sym.range().clone();
                         sym.add_new_function(session, &S!("__init__"), &range, &range.end());

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -1094,7 +1094,8 @@ impl PythonArchEval {
     }
 
     /// Read function decorators and set evaluations where applicable
-    /// - api.returns -> self -> Self, string -> model name if exists
+    /// - api.returns -> self -> Self, string -> model name if exists + validate
+    /// - validates api.depends/onchange/constrains
     fn handle_func_decorators(
         &mut self,
         session: &mut SessionInfo,

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -80,7 +80,7 @@ impl PythonArchEval {
             panic!("Trying to eval_arch a symbol without any path")
         }
         let path = self.file.borrow().get_symbol_first_path();
-        let file_info_rc = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&path).expect("File not found in cache").clone();
+        let file_info_rc = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path).expect("File not found in cache").clone();
         let file_info = (*file_info_rc).borrow();
         if file_info.ast.is_some() {
             let (ast, maybe_func_stmt) = match self.file_mode {
@@ -349,7 +349,7 @@ impl PythonArchEval {
                     let file_sym = sym_ref.borrow().get_file();
                     if file_sym.is_some() {
                         let rc_file_sym = file_sym.as_ref().unwrap().upgrade().unwrap();
-                        if rc_file_sym.borrow_mut().build_status(BuildSteps::ARCH_EVAL) == BuildStatus::PENDING && session.sync_odoo.is_in_rebuild(&rc_file_sym, BuildSteps::ARCH_EVAL) {
+                        if rc_file_sym.borrow().build_status(BuildSteps::ARCH_EVAL) == BuildStatus::PENDING && session.sync_odoo.is_in_rebuild(&rc_file_sym, BuildSteps::ARCH_EVAL) {
                             session.sync_odoo.remove_from_rebuild_arch_eval(&rc_file_sym);
                             let mut builder = PythonArchEval::new(self.entry_point.clone(), rc_file_sym);
                             builder.eval_arch(session);
@@ -380,7 +380,7 @@ impl PythonArchEval {
             &mut Some(&mut self.diagnostics));
 
         for _import_result in import_results.iter() {
-            let variable = self.sym_stack.last().unwrap().borrow_mut().get_positioned_symbol(&_import_result.name, &_import_result.range);
+            let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&_import_result.name, &_import_result.range);
             let Some(variable) = variable.clone() else {
                 continue;
             };
@@ -444,7 +444,7 @@ impl PythonArchEval {
             if let Some(ref expr) = assign.value {
                 self.visit_expr(session, expr);
             }
-            let variable = self.sym_stack.last().unwrap().borrow_mut().get_positioned_symbol(&Yarn::from(assign.target.id.to_string()), &assign.target.range);
+            let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&Yarn::from(assign.target.id.to_string()), &assign.target.range);
             if let Some(variable_rc) = variable {
                 let parent = variable_rc.borrow().parent().unwrap().upgrade().unwrap().clone();
                 let (eval, diags) = if let Some(ref annotation) = assign.annotation {
@@ -594,7 +594,7 @@ impl PythonArchEval {
     }
 
     fn visit_class_def(&mut self, session: &mut SessionInfo, class_stmt: &StmtClassDef) {
-        let variable = self.sym_stack.last().unwrap().borrow_mut().get_positioned_symbol(&Yarn::from(class_stmt.name.to_string()), &class_stmt.range);
+        let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&Yarn::from(class_stmt.name.to_string()), &class_stmt.range);
         if variable.is_none() {
             panic!("Class not found");
         }
@@ -611,7 +611,7 @@ impl PythonArchEval {
     }
 
     fn visit_func_def(&mut self, session: &mut SessionInfo, func_stmt: &StmtFunctionDef) {
-        let variable = self.sym_stack.last().unwrap().borrow_mut().get_positioned_symbol(&Yarn::from(func_stmt.name.to_string()), &func_stmt.range);
+        let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&Yarn::from(func_stmt.name.to_string()), &func_stmt.range);
         if variable.is_none() {
             panic!("Function symbol not found");
         }
@@ -722,7 +722,7 @@ impl PythonArchEval {
                                 let iter = iter[0].borrow();
                                 let eval_iter = &iter.evaluations().unwrap()[0];
                                 if for_stmt.target.is_name_expr() { //only handle simple variable for now
-                                    let variable = self.sym_stack.last().unwrap().borrow_mut().get_positioned_symbol(&Yarn::from(for_stmt.target.as_name_expr().unwrap().id.to_string()), &for_stmt.target.range());
+                                    let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&Yarn::from(for_stmt.target.as_name_expr().unwrap().id.to_string()), &for_stmt.target.range());
                                     variable.as_ref().unwrap().borrow_mut().evaluations_mut().unwrap().clear();
                                     let symbol = &eval_iter.symbol.get_symbol_as_weak(session, &mut Some(HashMap::from([(S!("parent_for"), ContextValue::SYMBOL(Rc::downgrade(&symbol_type_rc)))])), &mut vec![], None);
                                     variable.as_ref().unwrap().borrow_mut().evaluations_mut().unwrap().push(
@@ -828,7 +828,7 @@ impl PythonArchEval {
             if let Some(var) = item.optional_vars.as_ref() {
                 match &**var {
                     Expr::Name(expr_name) => {
-                        let variable = self.sym_stack.last().unwrap().borrow_mut().get_positioned_symbol(&Yarn::from(expr_name.id.to_string()), &expr_name.range());
+                        let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&Yarn::from(expr_name.id.to_string()), &expr_name.range());
                         if let Some(variable_rc) = variable {
                             let parent = variable_rc.borrow().parent().unwrap().upgrade().unwrap().clone();
                             let (eval, diags) = Evaluation::eval_from_ast(session, &item.context_expr, parent, &with_stmt.range.start());

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -1123,7 +1123,7 @@ impl PythonArchEval {
                 } else if dec_sym_tree == (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("onchange")]) ||
                         dec_sym_tree == (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("constrains")]){
                     self.handle_api_simple_field_decorator(session, func_sym.clone(), decorator_args);
-                } else if dec_sym_tree == (vec![yarn!("odoo"), yarn!("api")], vec![yarn!("depends")]){
+                } else if dec_sym_tree == (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("depends")]){
                     self.handle_api_nested_field_decorator(session, func_sym.clone(), decorator_args);
                 }
             }

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -454,7 +454,7 @@ impl PythonArchEval {
                 } else {
                     panic!("either value or annotation should exists");
                 };
-                variable_rc.borrow_mut().set_evaluations(eval);
+                variable_rc.borrow_mut().evaluations_mut().unwrap().extend(eval);
                 self.diagnostics.extend(diags);
                 let mut dep_to_add = vec![];
                 let mut v_mut = variable_rc.borrow_mut();

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -1092,7 +1092,7 @@ impl PythonArchEval {
                 } else if dec_sym_tree == (vec![yarn!("odoo"), yarn!("api")], vec![yarn!("onchange")]) ||
                         dec_sym_tree == (vec![yarn!("odoo"), yarn!("api")], vec![yarn!("constrains")]){
                     self.handle_api_simple_field_decorator(session, func_sym.clone(), decorator_args);
-                }else if dec_sym_tree == (vec![yarn!("odoo"), yarn!("api")], vec![yarn!("depends")]){
+                } else if dec_sym_tree == (vec![yarn!("odoo"), yarn!("api")], vec![yarn!("depends")]){
                     self.handle_api_nested_field_decorator(session, func_sym.clone(), decorator_args);
                 }
             }

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -8,6 +8,8 @@ use lsp_types::Diagnostic;
 use lsp_types::DiagnosticSeverity;
 use lsp_types::NumberOrString;
 use once_cell::sync::Lazy;
+use ruff_python_ast::Arguments;
+use ruff_python_ast::Expr;
 use crate::core::odoo::SyncOdoo;
 use crate::core::evaluation::Context;
 use crate::core::symbols::symbol::Symbol;
@@ -19,6 +21,7 @@ use crate::S;
 use super::entry_point::EntryPoint;
 use super::evaluation::{ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationSymbol, EvaluationSymbolWeak};
 use super::file_mgr::FileMgr;
+use super::python_arch_eval::PythonArchEval;
 use super::symbols::module_symbol::ModuleSymbol;
 
 type PythonArchEvalHookFile = fn (odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>);
@@ -102,6 +105,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("bool")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -109,6 +113,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("int")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -116,6 +121,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("float")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -123,6 +129,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("float")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -130,6 +137,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -137,6 +145,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -144,6 +153,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("markupsafe")], vec![Sy!("Markup")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -151,6 +161,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("datetime")], vec![Sy!("date")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -158,6 +169,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("datetime")], vec![Sy!("datetime")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -165,6 +177,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("bytes")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -172,6 +185,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("bytes")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -179,6 +193,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -186,6 +201,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -193,6 +209,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("object")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -200,6 +217,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("object")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -207,6 +225,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol.clone(), (vec![Sy!("builtins")], vec![Sy!("object")]));
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), false);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
@@ -214,34 +233,22 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
         PythonArchEvalHooks::_update_get_eval_relational(symbol.clone());
-    }},
-    PythonArchEvalFileHook {odoo_entry: true,
-                            file_tree: vec![Sy!("odoo"), Sy!("fields")],
-                            content_tree: vec![Sy!("Many2many")],
-                            if_exist_only: true,
-                            func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
-        PythonArchEvalHooks::_update_get_eval_relational(symbol.clone());
-    }},
-    PythonArchEvalFileHook {odoo_entry: true,
-                            file_tree: vec![Sy!("odoo"), Sy!("fields")],
-                            content_tree: vec![Sy!("Many2one")],
-                            if_exist_only: true,
-                            func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
-        PythonArchEvalHooks::_update_init_comodel_relational(symbol.clone());
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), true);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
                             content_tree: vec![Sy!("One2many")],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
-        PythonArchEvalHooks::_update_init_comodel_relational(symbol.clone());
+                PythonArchEvalHooks::_update_field_init(symbol.clone(), true);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                             file_tree: vec![Sy!("odoo"), Sy!("fields")],
                             content_tree: vec![Sy!("Many2many")],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
-        PythonArchEvalHooks::_update_init_comodel_relational(symbol.clone());
+        PythonArchEvalHooks::_update_get_eval_relational(symbol.clone());
+        PythonArchEvalHooks::_update_field_init(symbol.clone(), true);
     }},
 ]});
 
@@ -592,38 +599,7 @@ impl PythonArchEvalHooks {
         let Some(class_sym) = class_sym_weak.upgrade() else {return None};
         let related_field_name = related_field.as_string();
         let from_module = class_sym.borrow().find_module();
-        let mut parent_object = Some(class_sym.clone());
-        let mut syms = vec![];
-        let split_expr: Vec<String> = related_field_name.split(".").map(|x| x.to_string()).collect();
-        for (ix, name) in split_expr.iter().enumerate() {
-            if parent_object.is_none() {
-                break;
-            }
-            let (symbols, _diagnostics) = parent_object.clone().unwrap().borrow().get_member_symbol(session,
-                &name.to_string(),
-                from_module.clone(),
-                false,
-                true,
-                true,
-                false);
-            if ix == split_expr.len() - 1 {
-                syms = symbols;
-                break;
-            } else if symbols.is_empty() {
-                break;
-            }
-            parent_object = None;
-            for s in symbols.iter() {
-                if !s.borrow().is_specific_field(session, &["Many2one", "One2many", "Many2many"]) {
-                    break;
-                }
-                let models = s.borrow().as_variable().get_relational_model(session, from_module.clone());
-                if models.len() == 1 {
-                    parent_object = Some(models[0].clone());
-                    break;
-                }
-            }
-        }
+        let syms = PythonArchEval::get_nested_sub_field(session, &related_field_name, class_sym.clone(), from_module.clone());
         if let Some(symbol) = syms.first(){
             return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Rc::downgrade(symbol), context: HashMap::new(), instance: Some(true), is_super: false}))
         }
@@ -693,46 +669,41 @@ impl PythonArchEvalHooks {
         }]);
     }
 
-    fn eval_init_relational(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<Rc<RefCell<Symbol>>>) -> Option<EvaluationSymbolPtr>
+    fn find_special_arguments<'a>(parameters: &'a Arguments, find_comdel_name: bool) -> Option<(&'a Expr, String)> {
+        let find_in_kwargs = |arg_name: &str, context_name: String| parameters.keywords.iter().find_map(|keyword| {
+            keyword.arg
+                .as_ref().filter(|kw_arg| kw_arg.id == arg_name)
+                .map(|_| (&keyword.value, context_name.clone()))
+        });
+
+        if find_comdel_name {
+            if let Some(first_param) = parameters.args.get(0) {
+                return Some((first_param, S!("comodel")))
+            }
+        }
+        find_in_kwargs("comodel_name", S!("comodel")).or_else(|| find_in_kwargs("related", S!("related")))
+    }
+
+    fn eval_init_common(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &mut Option<Context>, _diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<Rc<RefCell<Symbol>>>, relational: bool) -> Option<EvaluationSymbolPtr>
     {
-        if context.is_none() {
+        let Some(context) = maybe_context else {return None};
+
+        let Some(parameters) = context.get(&S!("parameters")).map(|ps| ps.as_arguments()) else {return None};
+
+        let Some((field_name_expr, context_name)) = PythonArchEvalHooks::find_special_arguments(&parameters, relational) else {
             return None;
-        }
-        let parameters = context.as_ref().unwrap().get(&S!("parameters"));
-        if parameters.is_none() {
-            return None;
-        }
-        let parameters = parameters.unwrap().as_arguments();
-        let (comodel, context_name) = if let Some(first_param) = parameters.args.get(0) {
-            (first_param, S!("comodel"))
-        } else {
-            let mut comodel_name = None;
-            let mut related_name = None;
-            for keyword in parameters.keywords {
-                let Some (kw_arg) = keyword.arg else {continue};
-                if kw_arg.id == "comodel_name" {
-                    comodel_name = Some(keyword.value);
-                } else if kw_arg.id == "related" {
-                    related_name = Some(keyword.value);
-                }
-            }
-            if let Some(comodel_name) = comodel_name {
-                (&comodel_name.clone(), S!("comodel"))
-            } else if let Some(related_name) = related_name {
-                (&related_name.clone(), S!("related"))
-            }
-            else {
-                return None;
-            }
         };
-        let parent = Symbol::get_scope_symbol(file_symbol.unwrap().clone(),
-            context.as_ref().unwrap().get(&S!("range")).unwrap().as_text_range().start().to_u32(),
-            false);
-        let comodel_string_evals = Evaluation::expr_to_str(session, comodel, parent.clone(), &parameters.range.start(), &mut vec![]);
-        if let Some(comodel_string_value) = comodel_string_evals.0 {
+
+        let parent = Symbol::get_scope_symbol(
+            file_symbol.unwrap().clone(),
+            context.get(&S!("range")).unwrap().as_text_range().start().to_u32(),
+            false
+        );
+        let maybe_related_string = Evaluation::expr_to_str(session, &field_name_expr, parent.clone(), &parameters.range.start(), &mut vec![]).0;
+        if let Some(related_string) = maybe_related_string {
             return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak {
                 weak: evaluation_sym.get_weak().weak.clone(),
-                context: HashMap::from([(context_name, ContextValue::STRING(comodel_string_value.to_string())), (S!("field_parent"), ContextValue::SYMBOL(Rc::downgrade(&parent)))]),
+                context: HashMap::from([(context_name, ContextValue::STRING(related_string.to_string())), (S!("field_parent"), ContextValue::SYMBOL(Rc::downgrade(&parent)))]),
                 instance: Some(true),
                 is_super: false
             }));
@@ -740,7 +711,15 @@ impl PythonArchEvalHooks {
         None
     }
 
-    fn _update_init_comodel_relational(symbol: Rc<RefCell<Symbol>>) {
+    fn eval_init(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<Rc<RefCell<Symbol>>>) -> Option<EvaluationSymbolPtr> {
+        return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, false)
+    }
+
+    fn eval_init_relational(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<Rc<RefCell<Symbol>>>) -> Option<EvaluationSymbolPtr> {
+        return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, true)
+    }
+
+    fn _update_field_init(symbol: Rc<RefCell<Symbol>>, relational: bool) {
         let init_sym = symbol.borrow().get_symbol(&(vec![], vec![Sy!("__init__")]), u32::MAX);
         if init_sym.is_empty() {
             return;
@@ -750,7 +729,7 @@ impl PythonArchEvalHooks {
                 Rc::downgrade(&symbol), //use the weak to keep reference to the class for the hook.
                 Some(true),
                 HashMap::new(),
-                Some(PythonArchEvalHooks::eval_init_relational)
+                Some(if relational {PythonArchEvalHooks::eval_init_relational} else {PythonArchEvalHooks::eval_init})
             ),
             value: None,
             range: None,

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -287,68 +287,31 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__iter__")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().evaluations_mut().unwrap().clear();
-        symbol.borrow_mut().evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(None),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_env")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut with_env = symbol.borrow_mut();
-        with_env.evaluations_mut().unwrap().clear();
-        with_env.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("sudo")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut sudo = symbol.borrow_mut();
-        sudo.evaluations_mut().unwrap().clear();
-        sudo.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("create")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut create = symbol.borrow_mut();
-        create.evaluations_mut().unwrap().clear();
-        create.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("search")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
         let mut search: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        search.evaluations_mut().unwrap().clear();
-        search.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
         let func = search.as_func_mut();
         if func.args.len() > 1 {
             if let Some(arg_symbol) = func.args.get(1).unwrap().symbol.upgrade() {
@@ -364,99 +327,43 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("browse")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut browse: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        browse.evaluations_mut().unwrap().clear();
-        browse.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_company")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut browse: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        browse.evaluations_mut().unwrap().clear();
-        browse.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_context")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut browse: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        browse.evaluations_mut().unwrap().clear();
-        browse.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_prefetch")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut browse: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        browse.evaluations_mut().unwrap().clear();
-        browse.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_user")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut browse: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        browse.evaluations_mut().unwrap().clear();
-        browse.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_env")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut browse: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        browse.evaluations_mut().unwrap().clear();
-        browse.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("exists")]),
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut browse: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        browse.evaluations_mut().unwrap().clear();
-        browse.evaluations_mut().unwrap().push(Evaluation {
-            symbol: EvaluationSymbol::new_self(
-                None,
-            ),
-            range: None,
-            value: None
-        });
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                             tree: (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Id"), Sy!("__get__")]), //We have to put it at function level hook to remove evaluation from existing code

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -580,7 +580,7 @@ impl PythonArchEvalHooks {
         }
         let return_sym = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &tree, u32::MAX);
         if return_sym.is_empty() {
-            let file = symbol.borrow_mut().get_file().clone();
+            let file = symbol.borrow().get_file().clone();
             file.as_ref().unwrap().upgrade().unwrap().borrow_mut().not_found_paths_mut().push((BuildSteps::ARCH_EVAL, flatten_tree(&tree)));
             entry_point.borrow_mut().not_found_symbols.insert(symbol);
             return;

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -631,7 +631,7 @@ impl PythonArchEvalHooks {
     }
 
     fn eval_relational_with_comodel(session: &mut SessionInfo, comodel: &ContextValue, context: &Context) -> Option<EvaluationSymbolPtr>{
-        let comodel = yarn!("{}", comodel.unwrap().as_string());
+        let comodel = yarn!("{}", comodel.as_string());
         let comodel_sym = session.sync_odoo.models.get(&comodel).cloned();
         if let Some(comodel_sym) = comodel_sym {
             let module = context.get(&S!("module"));

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -47,7 +47,7 @@ impl PythonOdooBuilder {
         if DEBUG_ODOO_BUILDER {
             info!("Loading Odoo content for: {}", path);
         }
-        let file_info = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&path).expect("File not found in cache").clone();
+        let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path).expect("File not found in cache").clone();
         if file_info.borrow().ast.is_none() {
             symbol.set_build_status(BuildSteps::ODOO, BuildStatus::DONE);
             return;
@@ -61,7 +61,7 @@ impl PythonOdooBuilder {
     }
 
     fn _load(&mut self, session: &mut SessionInfo) {
-        let symbol = self.symbol.borrow_mut();
+        let symbol = self.symbol.borrow();
         let iterator = symbol.get_sorted_symbols();
         if !session.sync_odoo.has_odoo_main_entry {
             return;

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -334,7 +334,7 @@ impl PythonValidator {
 
     fn _check_model(&mut self, session: &mut SessionInfo, class: &Rc<RefCell<Symbol>>) {
         let class_ref = class.borrow();
-        let Some(ref model_name) = class_ref.as_class_sym()._model else {
+        let Some(model_data) = class_ref.as_class_sym()._model.as_ref() else {
             return;
         };
         if self.current_module.is_none() {
@@ -369,7 +369,7 @@ impl PythonValidator {
                                 Some(DiagnosticSeverity::ERROR),
                                 Some(NumberOrString::String(S!("OLS30323"))),
                                 Some(EXTENSION_NAME.to_string()),
-                                format!("Field {related_field_name} does not exist on model {}", model_name.name),
+                                format!("Field {related_field_name} does not exist on model {}", model_data.name),
                                 None,
                                 None,
                             ));

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -53,13 +53,13 @@ impl PythonValidator {
         if matches!(file_symbol.typ(), SymType::PACKAGE(_)) {
             path = PathBuf::from(path).join("__init__.py").sanitize() + file_symbol.as_package().i_ext().as_str();
         }
-        let file_info_rc = odoo.get_file_mgr().borrow_mut().get_file_info(&path).expect("File not found in cache").clone();
+        let file_info_rc = odoo.get_file_mgr().borrow().get_file_info(&path).expect("File not found in cache").clone();
         file_info_rc
     }
 
     /* Validate the symbol. The dependencies must be done before any validation. */
     pub fn validate(&mut self, session: &mut SessionInfo) {
-        let symbol = self.sym_stack[0].borrow_mut();
+        let symbol = self.sym_stack[0].borrow();
         self.current_module = symbol.find_module();
         if symbol.build_status(BuildSteps::VALIDATION) != BuildStatus::PENDING {
             return;
@@ -278,7 +278,7 @@ impl PythonValidator {
                 } else {
                     alias.asname.as_ref().unwrap().clone().to_string()
                 };
-                let variable = self.sym_stack.last().unwrap().borrow_mut().get_positioned_symbol(&Yarn::from(var_name), &alias.range);
+                let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&Yarn::from(var_name), &alias.range);
                 if let Some(variable) = variable {
                     for evaluation in variable.borrow().evaluations().as_ref().unwrap().iter() {
                         let eval_sym = evaluation.symbol.get_symbol(session, &mut None, &mut self.diagnostics, Some(file_symbol.clone()));

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -396,7 +396,7 @@ impl PythonValidator {
                                 Some(DiagnosticSeverity::ERROR),
                                 Some(NumberOrString::String(S!("OLS30326"))),
                                 Some(EXTENSION_NAME.to_string()),
-                                format!("Related field not same type"),
+                                format!("Related field is not of the same type"),
                                 None,
                                 None,
                             ));

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -356,7 +356,7 @@ impl PythonValidator {
                 let eval_weaks = Symbol::follow_ref(&symbol, session, &mut None, true, false, None, &mut vec![]);
                 for eval_weak in eval_weaks.iter() {
                     let Some(symbol) = eval_weak.upgrade_weak() else {continue};
-                    if !symbol.borrow().is_field_class(){
+                    if !symbol.borrow().is_field_class(session){
                         continue;
                     }
                     if let Some(related_field_name) = eval_weak.as_weak().context.get(&S!("related")).map(|ctx_val| ctx_val.as_string()) {

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -379,11 +379,11 @@ impl PythonValidator {
                         let Some(module) = class_ref.find_module() else {
                             continue;
                         };
-                        if !ModuleSymbol::is_in_deps(session, &module, &comodel_field_name){
+                        if !ModuleSymbol::is_in_deps(session, &module, &yarn!("{}", comodel_field_name)){
                             let Some(special_arg_range) = eval_weak.as_weak().context.get(&S!("special_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };
-                            if let Some(model) = session.sync_odoo.models.get(&comodel_field_name){
+                            if let Some(model) = session.sync_odoo.models.get(&yarn!("{}", comodel_field_name)){
                                 let Some(ref from_module) = maybe_from_module else {continue};
                                 if !model.clone().borrow().model_in_deps(session, from_module) {
                                     self.diagnostics.push(Diagnostic::new(

--- a/server/src/core/symbols/module_symbol.rs
+++ b/server/src/core/symbols/module_symbol.rs
@@ -199,7 +199,7 @@ impl ModuleSymbol {
                 Some(DiagnosticSeverity::ERROR),
                 Some(NumberOrString::String(S!("OLS30201"))),
                 Some(EXTENSION_NAME.to_string()),
-                "A manifest should only contains one dictionnary".to_string(),
+                "A manifest should only contains one dictionary".to_string(),
                 None,
                 None,
             ));

--- a/server/src/core/symbols/module_symbol.rs
+++ b/server/src/core/symbols/module_symbol.rs
@@ -168,7 +168,7 @@ impl ModuleSymbol {
             module.loaded = true;
             loaded.push(module.dir_name.clone());
             let manifest_path = PathBuf::from(module.root_path.clone()).join("__manifest__.py");
-            let manifest_file_info = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&manifest_path.sanitize()).expect("file not found in cache").clone();
+            let manifest_file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize()).expect("file not found in cache").clone();
             let mut manifest_file_info = (*manifest_file_info).borrow_mut();
             manifest_file_info.replace_diagnostics(crate::constants::BuildSteps::ARCH, diagnostics);
             manifest_file_info.publish_diagnostics(session);

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -2252,7 +2252,7 @@ impl Symbol {
                     from_module = self.find_module();
                 }
                 if let Some(from_module) = from_module {
-                    let model_symbols = model.clone().borrow().get_full_model_symbols(session, from_module.clone());
+                    let model_symbols = Model::get_full_model_symbols(model.clone(), session, from_module.clone());
                     for model_symbol in model_symbols {
                         if self.is_equal(&model_symbol) || visited_classes.contains(&model_symbol){
                             continue;
@@ -2269,14 +2269,14 @@ impl Symbol {
                         }
                     }
                     for model_inherits_symbol in model.clone().borrow().get_inherits_models(session, Some(from_module.clone())) {
-                        //only fields are visibles on inherits, not methods
-                        let model_symbols = model_inherits_symbol.borrow().get_full_model_symbols(session, from_module.clone());
+                        //only fields are visible on inherits, not methods
+                        let model_symbols = Model::get_full_model_symbols(model_inherits_symbol, session, from_module.clone());
                         for model_symbol in model_symbols {
                             if self.is_equal(&model_symbol) || visited_classes.contains(&model_symbol){
                                 continue;
                             }
                             visited_classes.insert(model_symbol.clone());
-                            let (attributs, att_diagnostic) = model_symbol.borrow()._get_member_symbol_helper(session, name, None, true, only_fields, all, false, visited_classes);
+                            let (attributs, att_diagnostic) = model_symbol.borrow()._get_member_symbol_helper(session, name, None, true, true, all, false, visited_classes);
                             diagnostics.extend(att_diagnostic);
                             if all {
                                 extend_result(attributs);

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -2166,6 +2166,16 @@ impl Symbol {
         false
     }
 
+    pub fn is_specific_field_class(&self, session: &mut SessionInfo, field_names: &[&str]) -> bool {
+        let tree = flatten_tree(&self.get_main_entry_tree(session));
+        if tree.len() == 3 && tree[0] == "odoo" && tree[1] == "fields" {
+            if field_names.contains(&tree[2].as_str()) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn is_specific_field(&self, session: &mut SessionInfo, field_names: &[&str]) -> bool {
         match self.typ() {
             SymType::VARIABLE => {
@@ -2175,11 +2185,8 @@ impl Symbol {
                         let eval_weaks = Symbol::follow_ref(&symbol, session, &mut None, true, false, None, &mut vec![]);
                         for eval_weak in eval_weaks.iter() {
                             if let Some(symbol) = eval_weak.upgrade_weak() {
-                                let tree = flatten_tree(&symbol.borrow().get_main_entry_tree(session));
-                                if tree.len() == 3 && tree[0] == "odoo" && tree[1] == "fields" {
-                                    if field_names.contains(&tree[2].as_str()) {
-                                        return true;
-                                    }
+                                if symbol.borrow().is_specific_field_class(session, field_names){
+                                    return true;
                                 }
                             }
                         }

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -710,12 +710,12 @@ fn complete_attribut(session: &mut SessionInfo, file: &Rc<RefCell<Symbol>>, attr
             //TODO shouldn't we set and clean context here?
             let parent_sym_eval = parent_eval.symbol.get_symbol(session, &mut None, &mut vec![], Some(scope.clone()));
             if !parent_sym_eval.is_expired_if_weak() {
+                let from_module = file.borrow().find_module().clone();
                 let parent_sym_types = Symbol::follow_ref(&parent_sym_eval, session, &mut None, false, false, None, &mut vec![]);
                 for parent_sym_type in parent_sym_types.iter() {
                     if let Some(parent_sym) = parent_sym_type.upgrade_weak() {
                         let mut all_symbols: HashMap<Yarn, Vec<(Rc<RefCell<Symbol>>, Option<Yarn>)>> = HashMap::new();
-                        let from_module = file.borrow().find_module().clone();
-                        Symbol::all_members(&parent_sym, session, &mut all_symbols, true, from_module, &mut None, parent_sym_eval.as_weak().is_super);
+                        Symbol::all_members(&parent_sym, session, &mut all_symbols, true, from_module.clone(), &mut None, parent_sym_eval.as_weak().is_super);
                         for (_symbol_name, symbols) in all_symbols {
                             //we could use symbol_name to remove duplicated names, but it would hide functions vs variables
                             if _symbol_name.starts_with(attr.attr.id.as_str()) {

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -502,7 +502,7 @@ fn complete_decorator_call(
     for decorator_eval in dec_evals.iter(){
         let EvaluationSymbolPtr::WEAK(decorator_eval_sym_weak) = decorator_eval.symbol.get_symbol(session, &mut None, &mut vec![], None)  else {continue};
         let Some(dec_sym) = decorator_eval_sym_weak.weak.upgrade() else {continue};
-        let dec_sym_tree = dec_sym.borrow().get_tree();
+        let dec_sym_tree = dec_sym.borrow().get_main_entry_tree(session);
         let expected_types = if dec_sym_tree == (vec![S!("odoo"), S!("api")], vec![S!("onchange")]) ||
             dec_sym_tree == (vec![S!("odoo"), S!("api")], vec![S!("constrains")]){
             &vec![ExpectedType::SIMPLE_FIELD]

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -8,6 +8,7 @@ use ruff_text_size::{Ranged, TextSize};
 use crate::constants::SymType;
 use crate::core::evaluation::{Context, ContextValue, Evaluation, EvaluationSymbol, EvaluationValue, EvaluationSymbolPtr, EvaluationSymbolWeak};
 use crate::core::import_resolver;
+use crate::core::odoo::SyncOdoo;
 use crate::core::python_arch_eval_hooks::PythonArchEvalHooks;
 use crate::core::symbols::module_symbol::ModuleSymbol;
 use crate::threads::SessionInfo;
@@ -502,12 +503,15 @@ fn complete_decorator_call(
     for decorator_eval in dec_evals.iter(){
         let EvaluationSymbolPtr::WEAK(decorator_eval_sym_weak) = decorator_eval.symbol.get_symbol(session, &mut None, &mut vec![], None)  else {continue};
         let Some(dec_sym) = decorator_eval_sym_weak.weak.upgrade() else {continue};
-        let dec_sym_tree = dec_sym.borrow().get_main_entry_tree(session);
-        let expected_types = if dec_sym_tree == (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("onchange")]) ||
-            dec_sym_tree == (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("constrains")]){
-            &vec![ExpectedType::SIMPLE_FIELD]
-        } else if dec_sym_tree == (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("depends")]){
-            &vec![ExpectedType::NESTED_FIELD(None)]
+        let dec_sym_tree = dec_sym.borrow().get_tree();
+        let expected_types = if dec_sym_tree.0.ends_with(&[Sy!("odoo"), Sy!("api")]){
+            if [vec![Sy!("onchange")], vec![Sy!("constrains")]].contains(&dec_sym_tree.1) && SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0){
+                &vec![ExpectedType::SIMPLE_FIELD]
+            } else if dec_sym_tree.1 == vec![Sy!("depends")] && SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0){
+                &vec![ExpectedType::NESTED_FIELD(None)]
+            } else {
+                continue;
+            }
         } else {
             continue;
         };

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -710,7 +710,7 @@ fn complete_attribut(session: &mut SessionInfo, file: &Rc<RefCell<Symbol>>, attr
             //TODO shouldn't we set and clean context here?
             let parent_sym_eval = parent_eval.symbol.get_symbol(session, &mut None, &mut vec![], Some(scope.clone()));
             if !parent_sym_eval.is_expired_if_weak() {
-                let parent_sym_types = Symbol::follow_ref(&parent_sym_eval, session, &mut None, true, false, None, &mut vec![]);
+                let parent_sym_types = Symbol::follow_ref(&parent_sym_eval, session, &mut None, false, false, None, &mut vec![]);
                 for parent_sym_type in parent_sym_types.iter() {
                     if let Some(parent_sym) = parent_sym_type.upgrade_weak() {
                         let mut all_symbols: HashMap<Yarn, Vec<(Rc<RefCell<Symbol>>, Option<Yarn>)>> = HashMap::new();
@@ -742,7 +742,7 @@ fn complete_subscript(session: &mut SessionInfo, file: &Rc<RefCell<Symbol>>, exp
     for eval in subscripted.iter() {
         let eval_symbol = eval.symbol.get_symbol(session, &mut None, &mut vec![], Some(scope.clone()));
         if !eval_symbol.is_expired_if_weak() {
-            let symbol_types = Symbol::follow_ref(&eval_symbol, session, &mut None, true, false, None, &mut vec![]);
+            let symbol_types = Symbol::follow_ref(&eval_symbol, session, &mut None, false, false, None, &mut vec![]);
             for symbol_type in symbol_types.iter() {
                 if let Some(symbol_type) = symbol_type.upgrade_weak() {
                     let borrowed = symbol_type.borrow();
@@ -868,7 +868,7 @@ fn build_completion_item_from_symbol(session: &mut SessionInfo, symbol: &Rc<RefC
         Rc::downgrade(symbol),
         None,
         false,
-    )), session, &mut None, true, true, None, &mut vec![]);
+    )), session, &mut None, false, true, None, &mut vec![]);
     let mut label_details = Some(CompletionItemLabelDetails {
         detail: None,
         description: None,

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -661,7 +661,7 @@ fn complete_string_literal(session: &mut SessionInfo, file: &Rc<RefCell<Symbol>>
                                 current_module.clone(),
                                 false,
                                 true,
-                                false,
+                                true,
                                 false);
                             if symbols.is_empty() {
                                 break;
@@ -673,10 +673,12 @@ fn complete_string_literal(session: &mut SessionInfo, file: &Rc<RefCell<Symbol>>
                                     //only handle it if there is only one main symbol for this model
                                     if models.len() == 1 {
                                         obj = Some(models[0].clone());
+                                        break;
                                     }
                                 }
                                 if s.borrow().is_specific_field(session, &["Date"]) {
                                     date_mode = true;
+                                    break;
                                 }
                             }
                         }

--- a/server/src/features/definition.rs
+++ b/server/src/features/definition.rs
@@ -29,7 +29,9 @@ impl DefinitionFeature {
             return  false;
         };
         let Some(call_expr) = call_expr else { return false };
-        let string_domain_fields= FeaturesUtils::find_domain_field_symbols(session, &field_name, call_expr, offset, field_range, file_symbol);
+        let string_domain_fields= FeaturesUtils::find_parameter_symbols(
+            session, Symbol::get_scope_symbol(file_symbol.clone(), offset as u32, false), file_symbol.borrow().find_module(), &field_name, call_expr, offset, field_range
+        );
         string_domain_fields.iter().for_each(|field|{
             if let Some(file_sym) = field.borrow().get_file().and_then(|file_sym_weak| file_sym_weak.upgrade()){
                 let path = file_sym.borrow().paths()[0].clone();
@@ -79,7 +81,9 @@ impl DefinitionFeature {
             return  false;
         };
         let Some(call_expr) = call_expr else { return false };
-        let compute_symbols= FeaturesUtils::find_compute_field_symbols(session, &value, call_expr, offset, file_symbol);
+        let compute_symbols= FeaturesUtils::find_compute_field_symbols(
+            session, Symbol::get_scope_symbol(file_symbol.clone(), offset as u32, false), file_symbol.borrow().find_module(), &value, call_expr
+        );
         compute_symbols.iter().for_each(|field|{
             if let Some(file_sym) = field.borrow().get_file().and_then(|file_sym_weak| file_sym_weak.upgrade()){
                 let path = file_sym.borrow().paths()[0].clone();

--- a/server/src/features/definition.rs
+++ b/server/src/features/definition.rs
@@ -35,7 +35,7 @@ impl DefinitionFeature {
         string_domain_fields.iter().for_each(|field|{
             if let Some(file_sym) = field.borrow().get_file().and_then(|file_sym_weak| file_sym_weak.upgrade()){
                 let path = file_sym.borrow().paths()[0].clone();
-                let range = session.sync_odoo.get_file_mgr().borrow_mut().text_range_to_range(session, &path, &field.borrow().range());
+                let range = session.sync_odoo.get_file_mgr().borrow().text_range_to_range(session, &path, &field.borrow().range());
                 links.push(Location{uri: FileMgr::pathname2uri(&path), range});
             }
         });
@@ -62,7 +62,7 @@ impl DefinitionFeature {
             let class_symbol = class_symbol_rc.borrow();
             if let Some(model_file_sym) = class_symbol.get_file().and_then(|model_file_sym_weak| model_file_sym_weak.upgrade()){
                 let path = model_file_sym.borrow().paths()[0].clone();
-                let range = session.sync_odoo.get_file_mgr().borrow_mut().text_range_to_range(session, &path, &class_symbol.range());
+                let range = session.sync_odoo.get_file_mgr().borrow().text_range_to_range(session, &path, &class_symbol.range());
                 model_found = true;
                 links.push(Location{uri: FileMgr::pathname2uri(&path), range});
             }
@@ -87,7 +87,7 @@ impl DefinitionFeature {
         compute_symbols.iter().for_each(|field|{
             if let Some(file_sym) = field.borrow().get_file().and_then(|file_sym_weak| file_sym_weak.upgrade()){
                 let path = file_sym.borrow().paths()[0].clone();
-                let range = session.sync_odoo.get_file_mgr().borrow_mut().text_range_to_range(session, &path, &field.borrow().range());
+                let range = session.sync_odoo.get_file_mgr().borrow().text_range_to_range(session, &path, &field.borrow().range());
                 links.push(Location{uri: FileMgr::pathname2uri(&path), range});
             }
         });
@@ -138,7 +138,7 @@ impl DefinitionFeature {
                     };
                     let range = match symbol.borrow().typ() {
                         SymType::PACKAGE(_) | SymType::FILE | SymType::NAMESPACE | SymType::DISK_DIR => Range::default(),
-                        _ => session.sync_odoo.get_file_mgr().borrow_mut().text_range_to_range(session, &full_path, &symbol.borrow().range()),
+                        _ => session.sync_odoo.get_file_mgr().borrow().text_range_to_range(session, &full_path, &symbol.borrow().range()),
                     };
                     links.push(Location{uri: FileMgr::pathname2uri(&full_path), range});
                 }

--- a/server/src/features/definition.rs
+++ b/server/src/features/definition.rs
@@ -29,7 +29,7 @@ impl DefinitionFeature {
             return  false;
         };
         let Some(call_expr) = call_expr else { return false };
-        let string_domain_fields= FeaturesUtils::find_parameter_symbols(
+        let string_domain_fields= FeaturesUtils::find_argument_symbols(
             session, Symbol::get_scope_symbol(file_symbol.clone(), offset as u32, false), file_symbol.borrow().find_module(), &field_name, call_expr, offset, field_range
         );
         string_domain_fields.iter().for_each(|field|{

--- a/server/src/features/definition.rs
+++ b/server/src/features/definition.rs
@@ -29,7 +29,7 @@ impl DefinitionFeature {
             return  false;
         };
         let Some(call_expr) = call_expr else { return false };
-        let string_domain_fields= FeaturesUtils::find_argument_symbols(
+        let string_domain_fields = FeaturesUtils::find_argument_symbols(
             session, Symbol::get_scope_symbol(file_symbol.clone(), offset as u32, false), file_symbol.borrow().find_module(), &field_name, call_expr, offset, field_range
         );
         string_domain_fields.iter().for_each(|field|{
@@ -81,7 +81,7 @@ impl DefinitionFeature {
             return  false;
         };
         let Some(call_expr) = call_expr else { return false };
-        let compute_symbols= FeaturesUtils::find_compute_field_symbols(
+        let compute_symbols = FeaturesUtils::find_compute_field_symbols(
             session, Symbol::get_scope_symbol(file_symbol.clone(), offset as u32, false), file_symbol.borrow().find_module(), &value, call_expr
         );
         compute_symbols.iter().for_each(|field|{

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -176,7 +176,7 @@ impl FeaturesUtils {
                 let func = callable_sym.borrow();
 
                 // Check if we are in api.onchange/constrains/depends
-                let func_sym_tree = func.get_tree();
+                let func_sym_tree = func.get_main_entry_tree(session);
                 if func_sym_tree == (vec![S!("odoo"), S!("api")], vec![S!("onchange")]) ||
                     func_sym_tree == (vec![S!("odoo"), S!("api")], vec![S!("constrains")]){
                     parameter_symbols.extend(

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -217,7 +217,7 @@ impl FeaturesUtils {
             }
             // BLOCK 1: (type) **name** -> inferred_type
             let mut context = Some(eval_symbol.as_weak().context.clone());
-            let type_refs = Symbol::follow_ref(&eval_symbol, session, &mut context, true, false, None, &mut vec![]);
+            let type_refs = Symbol::follow_ref(&eval_symbol, session, &mut context, false, false, None, &mut vec![]);
             value += FeaturesUtils::build_block_1(session, &symbol, &type_refs, &mut context).as_str();
             // BLOCK 2: useful links
             for typ in type_refs.iter() {
@@ -385,7 +385,7 @@ impl FeaturesUtils {
                                         let mut type_names = HashSet::new();
                                         for eval in func_eval.iter() {
                                             let eval_symbol = eval.symbol.get_symbol(session, context, &mut vec![], None);
-                                            let weak_eval_symbols = Symbol::follow_ref(&eval_symbol, session, context, true, false, None, &mut vec![]);
+                                            let weak_eval_symbols = Symbol::follow_ref(&eval_symbol, session, context, false, false, None, &mut vec![]);
                                             for weak_eval_symbol in weak_eval_symbols.iter() {
                                                 let type_name = if let Some(s_type) = weak_eval_symbol.upgrade_weak() {
                                                     let typ = s_type.borrow();


### PR DESCRIPTION
What's Done in this PR: ( To Be Completed)
- Handle api.depends, returns, constrains, on change
  - Validation
  - Autocompletion
  - Hover, go to definition 
- Related fields
  - Evaluation related relational fields, by updating hooks
  - Validate related kwarg, field existence and field type matching
  - Hover, Definition, Completion for related kwarg
- Comodel arg
  - Hover, Definition, Completion
  - Validation for comodel model existence
***
 Fixes
- Fix get_full_model_symbols to be complete and also refactored for better performance and readability
- attribute evaluation processes all base_eval values
- Remove unnecessary borrow_mut around the code base to avoid already borrowed errors