### PR TITLE
[IMP] server: use Yarn instead of strings for small names

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ winapi = { version = "0.3.9", features = ["winbase", "processthreadsapi", "synch
 ctrlc = "3.4.4"
 once_cell = "1.20.1"
 itertools = "0.14.0"
+byteyarn = "0.5.1"
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 nix = { version = "0.29.0", features = ["process"] }
 

--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -1,6 +1,8 @@
 #![allow(non_camel_case_types)]
 use core::fmt;
 
+use byteyarn::{yarn, Yarn};
+
 pub const EXTENSION_NAME: &str = "Odoo";
 pub const EXTENSION_VERSION: &str = "0.4.1";
 
@@ -9,13 +11,13 @@ pub const DEBUG_MEMORY: bool = false;
 pub const DEBUG_THREADS: bool = false;
 pub const DEBUG_STEPS: bool = false;
 
-pub type Tree = (Vec<String>, Vec<String>);
+pub type Tree = (Vec<Yarn>, Vec<Yarn>);
 
 pub fn tree(a: Vec<&str>, b: Vec<&str>) -> Tree {
-    (a.iter().map(|x| x.to_string()).collect(), b.iter().map(|x| x.to_string()).collect())
+    (a.iter().map(|x| yarn!("{}", *x)).collect(), b.iter().map(|x| yarn!("{}", *x)).collect())
 }
 
-pub fn flatten_tree(tree: &Tree) -> Vec<String> {
+pub fn flatten_tree(tree: &Tree) -> Vec<Yarn> {
     [tree.0.clone(), tree.1.clone()].concat()
 }
 

--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -1,5 +1,6 @@
 use std::{cell::RefCell, cmp, path::{self, PathBuf}, rc::{Rc, Weak}, u32};
 
+use byteyarn::Yarn;
 use tracing::{error, info};
 use weak_table::PtrWeakHashSet;
 
@@ -101,7 +102,7 @@ impl EntryPointMgr {
     /* Create a new entry to public.
     return the disk_dir symbol of the last FOLDER of the path
      */
-    pub fn add_entry_to_addons(&mut self, path: String, related: Option<Rc<RefCell<EntryPoint>>>, related_addition: Option<Vec<String>>) -> Option<Rc<RefCell<Symbol>>> {
+    pub fn add_entry_to_addons(&mut self, path: String, related: Option<Rc<RefCell<EntryPoint>>>, related_addition: Option<Vec<Yarn>>) -> Option<Rc<RefCell<Symbol>>> {
         info!("Adding new addon entry point: {}", path);
         let entry_point_tree = PathBuf::from(&path).to_tree();
         let mut addon_to_odoo_path = None;
@@ -315,16 +316,16 @@ pub enum EntryPointType {
 #[derive(Debug, Clone)]
 pub struct EntryPoint {
     pub path: String,
-    pub tree: Vec<String>,
+    pub tree: Vec<Yarn>,
     pub typ: EntryPointType,
     pub addon_to_odoo_path: Option<String>, //contains the odoo path if this is an addon entry point
-    pub addon_to_odoo_tree: Option<Vec<String>>, //contains the odoo tree if this is an addon entry point
+    pub addon_to_odoo_tree: Option<Vec<Yarn>>, //contains the odoo tree if this is an addon entry point
     pub root: Rc<RefCell<Symbol>>,
     pub not_found_symbols: PtrWeakHashSet<Weak<RefCell<Symbol>>>,
     pub to_delete: bool,
 }
 impl EntryPoint {
-    pub fn new(path: String, tree: Vec<String>, typ:EntryPointType, addon_to_odoo_path: Option<String>, addon_to_odoo_tree: Option<Vec<String>>) -> Rc<RefCell<Self>> {
+    pub fn new(path: String, tree: Vec<Yarn>, typ:EntryPointType, addon_to_odoo_path: Option<String>, addon_to_odoo_tree: Option<Vec<Yarn>>) -> Rc<RefCell<Self>> {
         let root = Symbol::new_root();
         root.borrow_mut().as_root_mut().weak_self = Some(Rc::downgrade(&root)); // manually set weakself for root symbols
         let res = Rc::new(RefCell::new(Self { path,

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -1,13 +1,14 @@
 use ruff_python_ast::{Arguments, Expr, ExprCall, Identifier, Number, Operator, Parameter, UnaryOp};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use byteyarn::Yarn;
 use weak_table::traits::WeakElement;
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 use std::i32;
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;
-use crate::constants::*;
+use crate::{constants::*, Sy};
 use crate::core::odoo::SyncOdoo;
 use crate::threads::SessionInfo;
 use crate::S;
@@ -243,7 +244,7 @@ impl Evaluation {
         Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
-                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![S!("builtins")], vec![S!("list")]), u32::MAX).last().expect("builtins list not found")),
+                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("list")]), u32::MAX).last().expect("builtins list not found")),
                     context: HashMap::new(),
                     instance: Some(true),
                     is_super: false,
@@ -259,7 +260,7 @@ impl Evaluation {
         Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
-                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![S!("builtins")], vec![S!("tuple")]), u32::MAX).last().expect("builtins list not found")),
+                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("tuple")]), u32::MAX).last().expect("builtins list not found")),
                     context: HashMap::new(),
                     instance: Some(true),
                     is_super: false,
@@ -275,7 +276,7 @@ impl Evaluation {
         Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
-                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![S!("builtins")], vec![S!("dict")]), u32::MAX).last().expect("builtins list not found")),
+                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("dict")]), u32::MAX).last().expect("builtins list not found")),
                     context: HashMap::new(),
                     instance: Some(true),
                     is_super: false,
@@ -291,7 +292,7 @@ impl Evaluation {
         Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
-                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![S!("builtins")], vec![S!("set")]), u32::MAX).last().expect("builtins set not found")),
+                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("set")]), u32::MAX).last().expect("builtins set not found")),
                     context: HashMap::new(),
                     instance: Some(true),
                     is_super: false,
@@ -317,23 +318,23 @@ impl Evaluation {
     pub fn new_constant(odoo: &mut SyncOdoo, values: Expr, range: TextRange) -> Evaluation {
         let tree_value = match &values {
             Expr::StringLiteral(_s) => {
-                (vec![S!("builtins")], vec![S!("str")])
+                (vec![Sy!("builtins")], vec![Sy!("str")])
             },
             Expr::BooleanLiteral(_b) => {
-                (vec![S!("builtins")], vec![S!("bool")])
+                (vec![Sy!("builtins")], vec![Sy!("bool")])
             },
             Expr::NumberLiteral(_n) => {
                 match _n.value {
-                    Number::Float(_) => (vec![S!("builtins")], vec![S!("float")]),
-                    Number::Int(_) => (vec![S!("builtins")], vec![S!("int")]),
-                    Number::Complex { .. } => (vec![S!("builtins")], vec![S!("complex")]),
+                    Number::Float(_) => (vec![Sy!("builtins")], vec![Sy!("float")]),
+                    Number::Int(_) => (vec![Sy!("builtins")], vec![Sy!("int")]),
+                    Number::Complex { .. } => (vec![Sy!("builtins")], vec![Sy!("complex")]),
                 }
             },
             Expr::BytesLiteral(_b) => {
-                (vec![S!("builtins")], vec![S!("bytes")])
+                (vec![Sy!("builtins")], vec![Sy!("bytes")])
             },
             Expr::EllipsisLiteral(_e) => {
-                (vec![S!("builtins")], vec![S!("Ellipsis")])
+                (vec![Sy!("builtins")], vec![Sy!("Ellipsis")])
             },
             Expr::NoneLiteral(_n) => {
                 let mut eval = Evaluation::new_none();
@@ -341,7 +342,7 @@ impl Evaluation {
                 eval.value = Some(EvaluationValue::CONSTANT(values));
                 return eval
             }
-            _ => {(vec![S!("builtins")], vec![S!("object")])}
+            _ => {(vec![Sy!("builtins")], vec![Sy!("object")])}
         };
         let symbol;
         if !values.is_none_literal_expr() {
@@ -720,7 +721,7 @@ impl Evaluation {
                         if base_sym_weak_eval.instance.unwrap_or(false) {
                             //TODO handle call on class instance
                         } else {
-                            if base_sym.borrow().match_tree_from_any_entry(session, &(vec![S!("builtins")], vec![S!("super")])){
+                            if base_sym.borrow().match_tree_from_any_entry(session, &(vec![Sy!("builtins")], vec![Sy!("super")])){
                                 //  - If 1st argument exists, we add that class with symbol_type Super
                                 let super_class = if !expr.arguments.is_empty(){
                                     let (class_eval, diags) = Evaluation::eval_from_ast(session, &expr.arguments.args[0], parent.clone(), max_infer);
@@ -1092,7 +1093,7 @@ impl Evaluation {
                         evals.push(Evaluation {
                             symbol: EvaluationSymbol {
                                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
-                                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![S!("builtins")], vec![S!("bool")]), u32::MAX).last().expect("builtins class not found")),
+                                    weak: Rc::downgrade(&odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("bool")]), u32::MAX).last().expect("builtins class not found")),
                                     context: HashMap::new(),
                                     instance: Some(true),
                                     is_super: false,
@@ -1137,7 +1138,7 @@ impl Evaluation {
                     Evaluation {
                         symbol: EvaluationSymbol {
                             sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
-                                weak: Rc::downgrade(&odoo.get_symbol("", &(vec![S!("builtins")], vec![S!("str")]), u32::MAX).last().expect("builtins class not found")),
+                                weak: Rc::downgrade(&odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("str")]), u32::MAX).last().expect("builtins class not found")),
                                 context: HashMap::new(),
                                 instance: Some(true),
                                 is_super: false,
@@ -1238,7 +1239,7 @@ impl Evaluation {
             if let Some(arg_identifier) = &arg.arg { //if None, arg is a dictionnary of keywords, like in self.func(a, b, **any_kwargs)
                 let mut found_one = false;
                 for func_arg in function.args.iter().skip(to_skip as usize) {
-                    if func_arg.symbol.upgrade().unwrap().borrow().name() == arg_identifier.id {
+                    if func_arg.symbol.upgrade().unwrap().borrow().name().to_string() == arg_identifier.id {
                         diagnostics.extend(Evaluation::validate_func_arg(session, func_arg, &arg.value, on_object.clone(), from_module.clone()));
                         if func_arg.arg_type == ArgumentType::ARG {
                             found_pos_arg_with_kw += 1;

--- a/server/src/core/model.rs
+++ b/server/src/core/model.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::rc::Weak;
+use byteyarn::Yarn;
 use lsp_types::MessageType;
 use weak_table::PtrWeakHashSet;
 use std::collections::HashSet;
@@ -15,9 +16,9 @@ use super::symbols::symbol::Symbol;
 
 #[derive(Debug)]
 pub struct ModelData {
-    pub name: String,
-    pub inherit: Vec<String>,
-    pub inherits: Vec<(String, String)>,
+    pub name: Yarn,
+    pub inherit: Vec<Yarn>,
+    pub inherits: Vec<(Yarn, Yarn)>,
 
     pub description: String,
     pub auto: bool,
@@ -40,7 +41,7 @@ pub struct ModelData {
 impl ModelData {
     pub fn new() -> Self {
         Self {
-            name: String::new(),
+            name: Yarn::new(""),
             inherit: Vec::new(),
             inherits: Vec::new(),
             description: String::new(),
@@ -65,13 +66,13 @@ impl ModelData {
 
 #[derive(Debug)]
 pub struct Model {
-    name: String,
+    name: Yarn,
     symbols: PtrWeakHashSet<Weak<RefCell<Symbol>>>,
     pub dependents: PtrWeakHashSet<Weak<RefCell<Symbol>>>,
 }
 
 impl Model {
-    pub fn new(name: String, symbol: Rc<RefCell<Symbol>>) -> Self {
+    pub fn new(name: Yarn, symbol: Rc<RefCell<Symbol>>) -> Self {
         let mut res = Self {
             name,
             symbols: PtrWeakHashSet::new(),
@@ -184,7 +185,7 @@ impl Model {
     /* Return all symbols that build this model.
         It returns the symbol and an optional string that represents the module name that should be added to dependencies to be used.
     */
-    pub fn all_symbols(&self, session: &mut SessionInfo, from_module: Option<Rc<RefCell<Symbol>>>) -> Vec<(Rc<RefCell<Symbol>>, Option<String>)> {
+    pub fn all_symbols(&self, session: &mut SessionInfo, from_module: Option<Rc<RefCell<Symbol>>>) -> Vec<(Rc<RefCell<Symbol>>, Option<Yarn>)> {
         let mut symbol = Vec::new();
         for s in self.symbols.iter() {
             if let Some(from_module) = from_module.as_ref() {

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::vec;
 use anyhow::Error;
+use byteyarn::{yarn, Yarn};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use ruff_python_ast::{Alias, Expr, ExprNamed, FStringPart, Identifier, Pattern, Stmt, StmtAnnAssign, StmtAssign, StmtClassDef, StmtFor, StmtFunctionDef, StmtIf, StmtMatch, StmtTry, StmtWhile, StmtWith};
 use lsp_types::Diagnostic;
@@ -137,7 +138,7 @@ impl PythonArchBuilder {
                     continue;
                 }
                 let mut all_name_allowed = true;
-                let mut name_filter: Vec<String> = vec![];
+                let mut name_filter: Vec<Yarn> = vec![];
                 if let Some(all) = import_result.symbol.borrow().get_content_symbol("__all__", u32::MAX).symbols.first() {
                     let all_value = Symbol::follow_ref(&EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(
                         Rc::downgrade(all), None, false
@@ -178,7 +179,7 @@ impl PythonArchBuilder {
                 if symbol.typ() != SymType::COMPILED {
                     for (name, loc_syms) in symbol.iter_symbols() {
                         if all_name_allowed || name_filter.contains(&name) {
-                            let variable = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, &name, &import_result.range);
+                            let variable = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, Yarn::from(name.clone()), &import_result.range);
                             let mut loc = variable.borrow_mut();
                             loc.as_variable_mut().is_import_variable = true;
                             loc.as_variable_mut().evaluations = Evaluation::from_sections(&symbol, loc_syms);
@@ -207,7 +208,7 @@ impl PythonArchBuilder {
                 } else {
                     import_name.asname.as_ref().unwrap().clone().to_string()
                 };
-                let mut variable = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, &var_name, &import_name.range);
+                let mut variable = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, Yarn::from(var_name), &import_name.range);
                 variable.borrow_mut().as_variable_mut().is_import_variable = true;
             }
         }
@@ -422,9 +423,9 @@ impl PythonArchBuilder {
         }
     }
 
-    fn extract_all_symbol_eval_values(&self, value: &Option<&EvaluationValue>) -> (Vec<String>, bool) {
+    fn extract_all_symbol_eval_values(&self, value: &Option<&EvaluationValue>) -> (Vec<Yarn>, bool) {
         let mut parse_error = false;
-        let vec: Vec<String> = match value {
+        let vec: Vec<Yarn> = match value {
             Some(eval) => {
                 match eval {
                     EvaluationValue::ANY() => {
@@ -434,7 +435,7 @@ impl PythonArchBuilder {
                     EvaluationValue::CONSTANT(c) => {
                         match c {
                             Expr::StringLiteral(s) => {
-                                vec![s.value.to_string()]
+                                vec![yarn!("{}", s.value)]
                             },
                             _ => {parse_error = true; vec![]}
                         }
@@ -447,7 +448,7 @@ impl PythonArchBuilder {
                         for v in l.iter() {
                             match v {
                                 Expr::StringLiteral(s) => {
-                                    res.push(s.value.to_string());
+                                    res.push(yarn!("{}", s.value));
                                 }
                                 _ => {parse_error = true; }
                             }
@@ -459,7 +460,7 @@ impl PythonArchBuilder {
                         for v in t.iter() {
                             match v {
                                 Expr::StringLiteral(s) => {
-                                    res.push(s.value.to_string());
+                                    res.push(yarn!("{}", s.value));
                                 }
                                 _ => {parse_error = true; }
                             }
@@ -482,7 +483,7 @@ impl PythonArchBuilder {
             if let Some(ref expr) = assign.value{
                 self.visit_expr(session, expr);
             }
-            self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, &assign.target.id.to_string(), &assign.target.range);
+            self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, yarn!("{}", assign.target.id), &assign.target.range);
         }
     }
 
@@ -492,7 +493,7 @@ impl PythonArchBuilder {
             if let Some(ref expr) = assign.value {
                 self.visit_expr(session, expr);
             }
-            let variable = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, &assign.target.id.to_string(), &assign.target.range);
+            let variable = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, yarn!("{}", assign.target.id), &assign.target.range);
             let mut variable = variable.borrow_mut();
             if self.file_mode && variable.name() == "__all__" && assign.value.is_some() && variable.parent().is_some() {
                 let parent = variable.parent().as_ref().unwrap().upgrade();
@@ -530,7 +531,7 @@ impl PythonArchBuilder {
 
     fn visit_named_expr(&mut self, session: &mut SessionInfo, named_expr: &ExprNamed) {
         self.visit_expr(session, &named_expr.value);
-        self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, &named_expr.target.as_name_expr().unwrap().id.to_string(), &named_expr.target.range());
+        self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, yarn!("{}", named_expr.target.as_name_expr().unwrap().id), &named_expr.target.range());
     }
 
     fn visit_func_def(&mut self, session: &mut SessionInfo, func_def: &StmtFunctionDef) -> Result<(), Error> {
@@ -563,7 +564,7 @@ impl PythonArchBuilder {
         drop(sym_bw);
         //add params
         for arg in func_def.parameters.posonlyargs.iter() {
-            let param = sym.borrow_mut().add_new_variable(session, &arg.parameter.name.id.to_string(), &arg.range);
+            let param = sym.borrow_mut().add_new_variable(session, yarn!("{}", arg.parameter.name.id), &arg.range);
             param.borrow_mut().as_variable_mut().is_parameter = true;
             sym.borrow_mut().as_func_mut().args.push(Argument {
                 symbol: Rc::downgrade(&param),
@@ -573,7 +574,7 @@ impl PythonArchBuilder {
             });
         }
         for arg in func_def.parameters.args.iter() {
-            let param = sym.borrow_mut().add_new_variable(session, &arg.parameter.name.id.to_string(), &arg.range);
+            let param = sym.borrow_mut().add_new_variable(session, yarn!("{}", arg.parameter.name.id), &arg.range);
             param.borrow_mut().as_variable_mut().is_parameter = true;
             let mut default = None;
             if arg.default.is_some() {
@@ -587,7 +588,7 @@ impl PythonArchBuilder {
             });
         }
         if let Some(arg) = &func_def.parameters.vararg {
-            let param = sym.borrow_mut().add_new_variable(session, &arg.name.id.to_string(), &arg.range);
+            let param = sym.borrow_mut().add_new_variable(session, yarn!("{}", arg.name.id), &arg.range);
             param.borrow_mut().as_variable_mut().is_parameter = true;
             sym.borrow_mut().as_func_mut().args.push(Argument {
                 symbol: Rc::downgrade(&param),
@@ -597,7 +598,7 @@ impl PythonArchBuilder {
             });
         }
         for arg in func_def.parameters.kwonlyargs.iter() {
-            let param = sym.borrow_mut().add_new_variable(session, &arg.parameter.name.id.to_string(), &arg.range);
+            let param = sym.borrow_mut().add_new_variable(session, yarn!("{}", arg.parameter.name.id), &arg.range);
             param.borrow_mut().as_variable_mut().is_parameter = true;
             sym.borrow_mut().as_func_mut().args.push(Argument {
                 symbol: Rc::downgrade(&param),
@@ -607,7 +608,7 @@ impl PythonArchBuilder {
             });
         }
         if let Some(arg) = &func_def.parameters.kwarg {
-            let param = sym.borrow_mut().add_new_variable(session, &arg.name.id.to_string(), &arg.range);
+            let param = sym.borrow_mut().add_new_variable(session, yarn!("{}", arg.name.id), &arg.range);
             param.borrow_mut().as_variable_mut().is_parameter = true;
             sym.borrow_mut().as_func_mut().args.push(Argument {
                 symbol: Rc::downgrade(&param),
@@ -652,7 +653,7 @@ impl PythonArchBuilder {
     fn _resolve_all_symbols(&mut self, session: &mut SessionInfo) {
         for (symbol_name, range) in self.__all_symbols_to_add.drain(..) {
             if self.sym_stack.last().unwrap().borrow().get_content_symbol(&symbol_name, u32::MAX).symbols.is_empty() {
-                let all_var = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, &symbol_name, &range);
+                let all_var = self.sym_stack.last().unwrap().borrow_mut().add_new_variable(session, yarn!("{}", symbol_name), &range);
             }
         }
     }
@@ -720,7 +721,7 @@ impl PythonArchBuilder {
             if let Some(ref expr) = assign.value {
                 self.visit_expr(session, expr);
             }
-            scope.borrow_mut().add_new_variable(session, &assign.target.id.to_string(), &assign.target.range);
+            scope.borrow_mut().add_new_variable(session, yarn!("{}", assign.target.id), &assign.target.range);
         }
         let previous_section = SectionIndex::INDEX(scope.borrow().as_symbol_mgr().get_last_index());
         scope.borrow_mut().as_mut_symbol_mgr().add_section(
@@ -804,7 +805,7 @@ impl PythonArchBuilder {
                 match &**var {
                     Expr::Name(expr_name) => {
                         self.sym_stack.last().unwrap().borrow_mut().add_new_variable(
-                            session, &expr_name.id.to_string(), &var.range());
+                            session, yarn!("{}", expr_name.id), &var.range());
                     },
                     Expr::Tuple(_) => {continue;},
                     Expr::List(_) => {continue;},
@@ -833,13 +834,13 @@ impl PythonArchBuilder {
                 Pattern::MatchStar(pattern_match_star) => {
                     if let Some(name) = &pattern_match_star.name { //if name is None, this is a wildcard pattern (*_)
                         scope.borrow_mut().add_new_variable(
-                            session, &name.to_string(), &pattern_match_star.range());
+                            session, yarn!("{}", name), &pattern_match_star.range());
                     }
                 },
                 Pattern::MatchAs(pattern_match_as) => {
                     if let Some(name) = &pattern_match_as.name { //if name is None, this is a wildcard pattern (_)
                         scope.borrow_mut().add_new_variable(
-                            session, &name.to_string(), &pattern_match_as.range());
+                            session, yarn!("{}", name), &pattern_match_as.range());
                     }
                 },
                 Pattern::MatchOr(match_or) => {

--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -2,9 +2,10 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::cell::RefCell;
 use tracing::warn;
+use byteyarn::Yarn;
 use crate::core::symbols::symbol::Symbol;
 use crate::threads::SessionInfo;
-use crate::S;
+use crate::{Sy, S};
 
 use super::odoo::SyncOdoo;
 
@@ -17,50 +18,49 @@ impl PythonArchBuilderHooks {
         let name = &sym.name();
         match name.as_str() {
             "BaseModel" => {
-                if sym.get_main_entry_tree(session) == (vec![S!("odoo"), S!("models")], vec![S!("BaseModel")]) {
+                if sym.get_main_entry_tree(session) == (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel")]) {
                     // ----------- env ------------
-                    let env = sym.get_symbol(&(vec![], vec![S!("env")]), u32::MAX);
+                    let env = sym.get_symbol(&(vec![], vec![Sy!("env")]), u32::MAX);
                     if env.is_empty() {
                         let mut range = sym.range().clone();
-                        let slots = sym.get_symbol(&(vec![], vec![S!("__slots__")]), u32::MAX);
+                        let slots = sym.get_symbol(&(vec![], vec![Sy!("__slots__")]), u32::MAX);
                         if slots.len() == 1 {
                             if slots.len() == 1 {
                                 range = slots[0].borrow().range().clone();
                             }
                         }
-                        sym.add_new_variable(session, &S!("env"), &range);
+                        sym.add_new_variable(session, Sy!("env"), &range);
                     }
-                    
                 }
             },
             "Environment" => {
-                if sym.get_main_entry_tree(session) == (vec![S!("odoo"), S!("api")], vec![S!("Environment")]) {
-                    let new_sym = sym.get_symbol(&(vec![], vec![S!("__new__")]), u32::MAX);
+                if sym.get_main_entry_tree(session) == (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("Environment")]) {
+                    let new_sym = sym.get_symbol(&(vec![], vec![Sy!("__new__")]), u32::MAX);
                     let mut range = sym.range().clone();
                     if new_sym.len() == 1 {
                         range = new_sym[0].borrow().range().clone();
                     }
                     // ----------- env.cr ------------
-                    sym.add_new_variable(session, &S!("cr"), &range);
+                    sym.add_new_variable(session, Sy!("cr"), &range);
                     // ----------- env.uid ------------
-                    let uid_sym = sym.add_new_variable(session, &S!("uid"), &range);
+                    let uid_sym = sym.add_new_variable(session, Sy!("uid"), &range);
                     uid_sym.borrow_mut().as_variable_mut().doc_string = Some(S!("The current user id (for access rights checks)"));
                     // ----------- env.context ------------
-                    let context_sym = sym.add_new_variable(session, &S!("context"), &range);
+                    let context_sym = sym.add_new_variable(session, Sy!("context"), &range);
                     context_sym.borrow_mut().as_variable_mut().doc_string = Some(S!("The current context"));
                     // ----------- env.su ------------
-                    let su_sym = sym.add_new_variable(session, &S!("su"), &range);
+                    let su_sym = sym.add_new_variable(session, Sy!("su"), &range);
                     su_sym.borrow_mut().as_variable_mut().doc_string = Some(S!("whether in superuser mode"));
                     // ----------- env.registry -----------
-                    let _ = sym.add_new_variable(session, &S!("registry"), &range);
+                    let _ = sym.add_new_variable(session, Sy!("registry"), &range);
                 }
             },
             "Boolean" | "Integer" | "Float" | "Monetary" | "Char" | "Text" | "Html" | "Date" | "Datetime" |
             "Binary" | "Image" | "Selection" | "Reference" | "Many2one" | "Many2oneReference" | "Json" |
             "Properties" | "PropertiesDefinition" | "One2many" | "Many2many" | "Id" => {
-                if sym.get_main_entry_tree(session).0 == vec![S!("odoo"), S!("fields")] {
+                if sym.get_main_entry_tree(session).0 == vec![Sy!("odoo"), Sy!("fields")] {
                     // ----------- __get__ ------------
-                    let get_sym = sym.get_symbol(&(vec![], vec![S!("__get__")]), u32::MAX);
+                    let get_sym = sym.get_symbol(&(vec![], vec![Sy!("__get__")]), u32::MAX);
                     if get_sym.is_empty() {
                         let range = sym.range().clone();
                         sym.add_new_function(session, &S!("__get__"), &range, &range.end());
@@ -78,7 +78,7 @@ impl PythonArchBuilderHooks {
     pub fn on_done(session: &mut SessionInfo, symbol: &Rc<RefCell<Symbol>>) {
         let name = symbol.borrow().name().clone();
         if name == "release" {
-            if symbol.borrow().get_main_entry_tree(session) == (vec![S!("odoo"), S!("release")], vec![]) {
+            if symbol.borrow().get_main_entry_tree(session) == (vec![Sy!("odoo"), Sy!("release")], vec![]) {
                 let (maj, min, mic) = SyncOdoo::read_version(session, PathBuf::from(symbol.borrow().paths()[0].clone()));
                 if maj != session.sync_odoo.version_major || min != session.sync_odoo.version_minor || mic != session.sync_odoo.version_micro {
                     session.sync_odoo.need_rebuild = true;

--- a/server/src/core/symbols/class_symbol.rs
+++ b/server/src/core/symbols/class_symbol.rs
@@ -1,3 +1,4 @@
+use byteyarn::Yarn;
 use ruff_text_size::{TextRange, TextSize};
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
@@ -7,7 +8,7 @@ use weak_table::PtrWeakHashSet;
 use crate::constants::SymType;
 use crate::core::model::ModelData;
 use crate::threads::SessionInfo;
-use crate::S;
+use crate::{Sy, S};
 
 use super::symbol::Symbol;
 use super::symbol_mgr::{SectionRange, SymbolMgr};
@@ -15,7 +16,7 @@ use super::symbol_mgr::{SectionRange, SymbolMgr};
 
 #[derive(Debug)]
 pub struct ClassSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub is_external: bool,
     pub doc_string: Option<String>,
     pub bases: Vec<Weak<RefCell<Symbol>>>,
@@ -29,16 +30,16 @@ pub struct ClassSymbol {
     //Trait SymbolMgr
     //--- Body symbols
     pub sections: Vec<SectionRange>,
-    pub symbols: HashMap<String, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
+    pub symbols: HashMap<Yarn, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
     //--- dynamics variables
-    pub ext_symbols: HashMap<String, Vec<Rc<RefCell<Symbol>>>>,
+    pub ext_symbols: HashMap<Yarn, Vec<Rc<RefCell<Symbol>>>>,
 }
 
 impl ClassSymbol {
 
     pub fn new(name: String, range: TextRange, body_start: TextSize, is_external: bool) -> Self {
         let mut res = Self {
-            name,
+            name: Yarn::from(name),
             is_external,
             weak_self: None,
             parent: None,
@@ -86,7 +87,7 @@ impl ClassSymbol {
     }
 
     pub fn is_descriptor(&self) -> bool {
-        for get_sym in self.get_content_symbol(S!("__get__"), u32::MAX).symbols.iter() {
+        for get_sym in self.get_content_symbol(Sy!("__get__"), u32::MAX).symbols.iter() {
             if get_sym.borrow().typ() == SymType::FUNCTION {
                 return true;
             }

--- a/server/src/core/symbols/compiled_symbol.rs
+++ b/server/src/core/symbols/compiled_symbol.rs
@@ -1,22 +1,24 @@
 use std::{cell::RefCell, collections::HashMap, rc::{Rc, Weak}};
 
+use byteyarn::{yarn, Yarn};
+
 use super::symbol::Symbol;
 
 #[derive(Debug)]
 pub struct CompiledSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub is_external: bool,
     pub path: String,
     pub weak_self: Option<Weak<RefCell<Symbol>>>,
     pub parent: Option<Weak<RefCell<Symbol>>>,
-    pub module_symbols: HashMap<String, Rc<RefCell<Symbol>>>,
+    pub module_symbols: HashMap<Yarn, Rc<RefCell<Symbol>>>,
 }
 
 impl CompiledSymbol {
 
     pub fn new(name: String, path: String, is_external: bool) -> Self {
         Self {
-            name,
+            name: Yarn::from_string(name),
             is_external,
             weak_self:None,
             path,

--- a/server/src/core/symbols/disk_dir_symbol.rs
+++ b/server/src/core/symbols/disk_dir_symbol.rs
@@ -1,3 +1,4 @@
+use byteyarn::{yarn, Yarn};
 use weak_table::PtrWeakHashSet;
 
 use std::{cell::RefCell, collections::HashMap, path::PathBuf, rc::{Rc, Weak}};
@@ -11,9 +12,9 @@ DiskDir symbol represent a directory on disk we didn't parse yet. So it can eith
 */
 #[derive(Debug)]
 pub struct DiskDirSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub path: String,
-    pub module_symbols: HashMap<String, Rc<RefCell<Symbol>>>,
+    pub module_symbols: HashMap<Yarn, Rc<RefCell<Symbol>>>,
     pub is_external: bool,
     pub weak_self: Option<Weak<RefCell<Symbol>>>,
     pub parent: Option<Weak<RefCell<Symbol>>>,
@@ -24,7 +25,7 @@ impl DiskDirSymbol {
 
     pub fn new(name: String, path: String, is_external: bool) -> Self {
         Self {
-            name,
+            name: yarn!("{}", name),
             path: PathBuf::from(path).sanitize(),
             is_external,
             weak_self: None,

--- a/server/src/core/symbols/file_symbol.rs
+++ b/server/src/core/symbols/file_symbol.rs
@@ -1,3 +1,4 @@
+use byteyarn::{yarn, Yarn};
 use weak_table::PtrWeakHashSet;
 
 use crate::{constants::{BuildStatus, BuildSteps}, core::model::Model};
@@ -7,7 +8,7 @@ use super::{symbol::Symbol, symbol_mgr::{SectionRange, SymbolMgr}};
 
 #[derive(Debug)]
 pub struct FileSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub path: String,
     pub is_external: bool,
     pub weak_self: Option<Weak<RefCell<Symbol>>>,
@@ -16,7 +17,7 @@ pub struct FileSymbol {
     pub arch_eval_status: BuildStatus,
     pub odoo_status: BuildStatus,
     pub validation_status: BuildStatus,
-    pub not_found_paths: Vec<(BuildSteps, Vec<String>)>,
+    pub not_found_paths: Vec<(BuildSteps, Vec<Yarn>)>,
     pub in_workspace: bool,
     pub self_import: bool,
     pub model_dependencies: PtrWeakHashSet<Weak<RefCell<Model>>>, //always on validation level, as odoo step is always required
@@ -26,16 +27,16 @@ pub struct FileSymbol {
 
     //Trait SymbolMgr
     pub sections: Vec<SectionRange>,
-    pub symbols: HashMap<String, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
+    pub symbols: HashMap<Yarn, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
     //--- dynamics variables
-    pub ext_symbols: HashMap<String, Vec<Rc<RefCell<Symbol>>>>,
+    pub ext_symbols: HashMap<Yarn, Vec<Rc<RefCell<Symbol>>>>,
 }
 
 impl FileSymbol {
 
     pub fn new(name: String, path: String, is_external: bool) -> Self {
         let mut res = Self {
-            name,
+            name: yarn!("{}", name),
             path,
             is_external,
             weak_self: None,

--- a/server/src/core/symbols/function_symbol.rs
+++ b/server/src/core/symbols/function_symbol.rs
@@ -1,5 +1,6 @@
 use std::{cell::RefCell, cmp::min, collections::HashMap, rc::{Rc, Weak}};
 
+use byteyarn::{yarn, Yarn};
 use lsp_types::Diagnostic;
 use ruff_python_ast::{Expr, ExprCall};
 use ruff_text_size::{TextRange, TextSize};
@@ -29,7 +30,7 @@ pub struct Argument {
 
 #[derive(Debug)]
 pub struct FunctionSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub is_external: bool,
     pub is_static: bool,
     pub is_property: bool,
@@ -53,9 +54,9 @@ pub struct FunctionSymbol {
     //Trait SymbolMgr
     //--- Body content
     pub sections: Vec<SectionRange>,
-    pub symbols: HashMap<String, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
+    pub symbols: HashMap<Yarn, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
     //--- dynamics variables
-    pub ext_symbols: HashMap<String, Vec<Rc<RefCell<Symbol>>>>,
+    pub ext_symbols: HashMap<Yarn, Vec<Rc<RefCell<Symbol>>>>,
 
 }
 
@@ -63,7 +64,7 @@ impl FunctionSymbol {
 
     pub fn new(name: String, range: TextRange, body_start: TextSize, is_external: bool) -> Self {
         let mut res = Self {
-            name,
+            name: yarn!("{}", name),
             is_external,
             weak_self: None,
             parent: None,
@@ -178,7 +179,7 @@ impl FunctionSymbol {
         }
         if let Some(keyword) = call_arg_keyword {
             for arg in self.args.iter() {
-                if arg.symbol.upgrade().unwrap().borrow().name() == keyword.arg.as_ref().unwrap().id {
+                if arg.symbol.upgrade().unwrap().borrow().name().to_string() == keyword.arg.as_ref().unwrap().id {
                     return Some(arg);
                 }
             }

--- a/server/src/core/symbols/namespace_symbol.rs
+++ b/server/src/core/symbols/namespace_symbol.rs
@@ -1,3 +1,4 @@
+use byteyarn::Yarn;
 use weak_table::PtrWeakHashSet;
 
 use std::{cell::RefCell, collections::HashMap, rc::{Rc, Weak}};
@@ -10,12 +11,12 @@ use super::symbol::Symbol;
 #[derive(Debug)]
 pub struct NamespaceDirectory {
     pub path: String,
-    pub module_symbols: HashMap<String, Rc<RefCell<Symbol>>>,
+    pub module_symbols: HashMap<Yarn, Rc<RefCell<Symbol>>>,
 }
 
 #[derive(Debug)]
 pub struct NamespaceSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub directories: Vec<NamespaceDirectory>,
     pub is_external: bool,
     pub weak_self: Option<Weak<RefCell<Symbol>>>,
@@ -36,7 +37,7 @@ impl NamespaceSymbol {
             })
         }
         Self {
-            name,
+            name: Yarn::from_string(name),
             directories: directories,
             is_external,
             weak_self: None,

--- a/server/src/core/symbols/package_symbol.rs
+++ b/server/src/core/symbols/package_symbol.rs
@@ -1,3 +1,4 @@
+use byteyarn::{yarn, Yarn};
 use weak_table::PtrWeakHashSet;
 
 use crate::{constants::{BuildStatus, BuildSteps}, core::model::Model, threads::SessionInfo, S};
@@ -22,7 +23,7 @@ impl PackageSymbol {
             None
         }
     }
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &Yarn {
         match self {
             PackageSymbol::PythonPackage(p) => &p.name,
             PackageSymbol::Module(m) => &m.name,
@@ -98,7 +99,7 @@ impl PackageSymbol {
 
 #[derive(Debug)]
 pub struct PythonPackageSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub path: String,
     pub i_ext: String,
     pub is_external: bool,
@@ -108,10 +109,10 @@ pub struct PythonPackageSymbol {
     pub arch_eval_status: BuildStatus,
     pub odoo_status: BuildStatus,
     pub validation_status: BuildStatus,
-    pub not_found_paths: Vec<(BuildSteps, Vec<String>)>,
+    pub not_found_paths: Vec<(BuildSteps, Vec<Yarn>)>,
     pub in_workspace: bool,
     pub self_import: bool,
-    pub module_symbols: HashMap<String, Rc<RefCell<Symbol>>>,
+    pub module_symbols: HashMap<Yarn, Rc<RefCell<Symbol>>>,
     pub model_dependencies: PtrWeakHashSet<Weak<RefCell<Model>>>, //always on validation level, as odoo step is always required
     pub dependencies: [Vec<PtrWeakHashSet<Weak<RefCell<Symbol>>>>; 4],
     pub dependents: [Vec<PtrWeakHashSet<Weak<RefCell<Symbol>>>>; 3],
@@ -119,16 +120,16 @@ pub struct PythonPackageSymbol {
 
     //Trait SymbolMgr
     pub sections: Vec<SectionRange>,
-    pub symbols: HashMap<String, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
+    pub symbols: HashMap<Yarn, HashMap<u32, Vec<Rc<RefCell<Symbol>>>>>,
     //--- dynamics variables
-    pub ext_symbols: HashMap<String, Vec<Rc<RefCell<Symbol>>>>,
+    pub ext_symbols: HashMap<Yarn, Vec<Rc<RefCell<Symbol>>>>,
 }
 
 impl PythonPackageSymbol {
 
     pub fn new(name: String, path: String, is_external: bool) -> Self {
         let mut res = Self {
-            name,
+            name: yarn!("{}", name),
             path,
             is_external,
             i_ext: S!(""),

--- a/server/src/core/symbols/root_symbol.rs
+++ b/server/src/core/symbols/root_symbol.rs
@@ -1,3 +1,5 @@
+use byteyarn::{yarn, Yarn};
+
 use crate::{constants::BuildSteps, core::entry_point::EntryPoint, threads::SessionInfo, S};
 use std::{cell::RefCell, collections::HashMap, rc::{Rc, Weak}};
 
@@ -5,19 +7,19 @@ use super::symbol::Symbol;
 
 #[derive(Debug)]
 pub struct RootSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub entry_point: Option<Rc<RefCell<EntryPoint>>>,
     pub paths: Vec<String>,
     pub weak_self: Option<Weak<RefCell<Symbol>>>,
     pub parent: Option<Weak<RefCell<Symbol>>>,
-    pub module_symbols: HashMap<String, Rc<RefCell<Symbol>>>,
+    pub module_symbols: HashMap<Yarn, Rc<RefCell<Symbol>>>,
 }
 
 impl RootSymbol {
 
     pub fn new() -> Self {
         Self {
-            name: S!("Root"),
+            name: yarn!("Root"),
             paths: vec![],
             weak_self: None,
             entry_point: None,

--- a/server/src/core/symbols/symbol_mgr.rs
+++ b/server/src/core/symbols/symbol_mgr.rs
@@ -1,4 +1,5 @@
 use std::{cell::RefCell, rc::Rc, collections::{HashMap, HashSet}};
+use byteyarn::Yarn;
 
 use ruff_text_size::TextSize;
 
@@ -30,8 +31,8 @@ pub trait SymbolMgr {
     fn get_last_index(&self) -> u32;
     fn add_section(&mut self, range_start: TextSize, maybe_previous_indexes: Option<SectionIndex>) -> SectionRange;
     fn change_parent(&mut self, new_parent: SectionIndex, section: &mut SectionRange);
-    fn get_content_symbol(&self, name: String, position: u32) -> ContentSymbols;
-    fn get_ext_symbol(&self, name: String) -> Option<&Vec<Rc<RefCell<Symbol>>>>;
+    fn get_content_symbol(&self, name: Yarn, position: u32) -> ContentSymbols;
+    fn get_ext_symbol(&self, name: Yarn) -> Option<&Vec<Rc<RefCell<Symbol>>>>;
     fn _init_symbol_mgr(&mut self);
     fn _get_loc_symbol(&self, map: &HashMap<u32, Vec<Rc<RefCell<Symbol>>>>, position: u32, index: &SectionIndex, acc: &mut HashSet<u32>) -> ContentSymbols;
 }
@@ -98,7 +99,7 @@ macro_rules! impl_section_mgr_for {
         }
 
         ///Return all the symbols that are valid as last declaration for the given position
-        fn get_content_symbol(&self, name: String, position: u32) -> ContentSymbols {
+        fn get_content_symbol(&self, name: Yarn, position: u32) -> ContentSymbols {
             let sections: Option<&HashMap<u32, Vec<Rc<RefCell<Symbol>>>>> = self.symbols.get(&name);
             if let Some(sections) = sections {
                 let section: SectionRange = self.get_section_for(position);
@@ -107,7 +108,7 @@ macro_rules! impl_section_mgr_for {
             ContentSymbols::default()
         }
 
-        fn get_ext_symbol(&self, name: String) -> Option<&Vec<Rc<RefCell<Symbol>>>> {
+        fn get_ext_symbol(&self, name: Yarn) -> Option<&Vec<Rc<RefCell<Symbol>>>> {
             self.ext_symbols.get(&name)
         }
 

--- a/server/src/core/symbols/variable_symbol.rs
+++ b/server/src/core/symbols/variable_symbol.rs
@@ -1,3 +1,4 @@
+use byteyarn::{yarn, Yarn};
 use ruff_text_size::TextRange;
 
 use crate::{constants::flatten_tree, core::evaluation::Evaluation, threads::SessionInfo};
@@ -7,7 +8,7 @@ use super::symbol::Symbol;
 
 #[derive(Debug)]
 pub struct VariableSymbol {
-    pub name: String,
+    pub name: Yarn,
     pub is_external: bool,
     pub doc_string: Option<String>,
     pub ast_indexes: Vec<u16>, //list of index to reach the corresponding ast node from file ast
@@ -21,7 +22,7 @@ pub struct VariableSymbol {
 
 impl VariableSymbol {
 
-    pub fn new(name: String, range: TextRange, is_external: bool) -> Self {
+    pub fn new(name: Yarn, range: TextRange, is_external: bool) -> Self {
         Self {
             name,
             is_external,
@@ -40,7 +41,7 @@ impl VariableSymbol {
         //TODO it does not use get_symbol call, and only evaluate "sym" from EvaluationSymbol
         return self.evaluations.len() >= 1 && self.evaluations.iter().all(|x| !x.symbol.is_instance().unwrap_or(true)) && !self.is_import_variable;
     }
-    
+
     /* If this variable has been evaluated to a relational field, return the main symbol of the comodel */
     pub fn get_relational_model(&self, session: &mut SessionInfo, from_module: Option<Rc<RefCell<Symbol>>>) -> Vec<Rc<RefCell<Symbol>>> {
         for eval in self.evaluations.iter() {
@@ -52,7 +53,7 @@ impl VariableSymbol {
                         let Some(comodel) = eval_weak.as_weak().context.get("comodel") else {
                             continue;
                         };
-                        let Some(model) = session.sync_odoo.models.get(&comodel.as_string()).cloned() else {
+                        let Some(model) = session.sync_odoo.models.get(&yarn!("{}", &comodel.as_string())).cloned() else {
                             continue;
                         };
                         return model.borrow().get_main_symbols(session, from_module);

--- a/server/src/core/symbols/variable_symbol.rs
+++ b/server/src/core/symbols/variable_symbol.rs
@@ -2,10 +2,11 @@ use byteyarn::{yarn, Yarn};
 use ruff_text_size::TextRange;
 
 use crate::{constants::flatten_tree, core::evaluation::Evaluation, threads::SessionInfo};
-use std::{cell::RefCell, rc::{Rc, Weak}};
+use core::fmt;
+use std::{cell::RefCell, f32::consts::E, rc::{Rc, Weak}};
 
 use super::symbol::Symbol;
-
+ 
 #[derive(Debug)]
 pub struct VariableSymbol {
     pub name: Yarn,
@@ -41,6 +42,23 @@ impl VariableSymbol {
         //TODO it does not use get_symbol call, and only evaluate "sym" from EvaluationSymbol
         return self.evaluations.len() >= 1 && self.evaluations.iter().all(|x| !x.symbol.is_instance().unwrap_or(true)) && !self.is_import_variable;
     }
+
+    // pub fn full_size_of(self) -> serde_json::Value {
+    //     let name_to_add = if self.name.len() > 15 {
+    //         self.name.len()
+    //     } else {
+    //         0
+    //     };
+    //     let mut evals = 0;
+    //     for eval in self.evaluations.iter() {
+    //         evals += eval.full_size_of();
+    //     }
+    //     size_of::<Self>() +
+    //     name_to_add +
+    //     self.doc_string.map(|x| x.capacity()).unwrap_or(0) +
+    //     self.ast_indexes.capacity() +
+    //     evals
+    // }
 
     /* If this variable has been evaluated to a relational field, return the main symbol of the comodel */
     pub fn get_relational_model(&self, session: &mut SessionInfo, from_module: Option<Rc<RefCell<Symbol>>>) -> Vec<Rc<RefCell<Symbol>>> {

--- a/server/src/features/definition.rs
+++ b/server/src/features/definition.rs
@@ -1,3 +1,4 @@
+use byteyarn::yarn;
 use lsp_types::{GotoDefinitionResponse, Location, Range};
 use ruff_python_ast::{Expr, ExprCall};
 use ruff_text_size::TextSize;
@@ -42,7 +43,7 @@ impl DefinitionFeature {
     fn check_for_model_string(session: &mut SessionInfo, eval: &Evaluation, file_symbol: &Rc<RefCell<Symbol>>, links: &mut Vec<Location>) -> bool {
         let value = if let Some(eval_value) = eval.value.as_ref() {
             if let EvaluationValue::CONSTANT(Expr::StringLiteral(expr)) = eval_value {
-                expr.value.to_string()
+                yarn!("{}", expr.value.to_string())
             } else {
                 return false;
             }

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -1,3 +1,4 @@
+use byteyarn::yarn;
 use itertools::Itertools;
 use ruff_python_ast::{Expr, ExprCall};
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -175,7 +176,7 @@ impl FeaturesUtils {
                             return FeaturesUtils::build_markdown_description(session, file_symbol, &string_domain_fields_evals, call_expr, Some(offset))
                         }
                     }
-                    if let Some(model) = session.sync_odoo.models.get(&str).cloned() {
+                    if let Some(model) = session.sync_odoo.models.get(&yarn!("{}", str)).cloned() {
                         let main_classes = model.borrow().get_main_symbols(session, from_module.clone());
                         for main_class_rc in main_classes.iter() {
                             let main_class = main_class_rc.borrow();
@@ -360,12 +361,12 @@ impl FeaturesUtils {
                 .and_then(|parent| Evaluation::eval_from_ast(session, &anno_expr, parent.clone(), &anno_expr.range().start()).0.first().cloned())
                 .and_then(|type_evaluation| type_evaluation.symbol.get_symbol_as_weak(session, &mut None, &mut vec![], None).weak.upgrade())
                  else {
-                    return arg_name
+                    return arg_name.to_string()
                 };
                 let type_name = type_symbol.borrow().name().clone();
                 format!("{}: {}", arg_name, type_name)
             },
-            None => arg_name
+            None => arg_name.to_string()
         }
     }
 
@@ -392,7 +393,7 @@ impl FeaturesUtils {
                                                     if typ.typ() == SymType::VARIABLE {
                                                         "Any".to_string()
                                                     } else {
-                                                        typ.name().clone()
+                                                        typ.name().to_string()
                                                     }
                                                 } else {
                                                     "Any".to_string()
@@ -414,7 +415,7 @@ impl FeaturesUtils {
                             SymType::FILE => S!("File"),
                             SymType::PACKAGE(_) => S!("Module"),
                             SymType::NAMESPACE => S!("Namespace"),
-                            SymType::CLASS => if eval_weak.is_super {format!("super[{}]", S!(inferred_type.name()))} else {S!(inferred_type.name())}, // TODO: Maybe do something special if it is a descriptor
+                            SymType::CLASS => if eval_weak.is_super {format!("super[{}]", inferred_type.name().to_string())} else {inferred_type.name().to_string()}, // TODO: Maybe do something special if it is a descriptor
                             _ => S!("Any")
                         }
                     }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,4 +1,5 @@
 use std::{fs, path::{Path, PathBuf}, str::FromStr};
+use byteyarn::yarn;
 use path_slash::{PathBufExt, PathExt};
 use ruff_text_size::TextSize;
 
@@ -8,6 +9,13 @@ use crate::constants::Tree;
 macro_rules! S {
     ($x: expr) => {
         String::from($x)
+    };
+}
+
+#[macro_export]
+macro_rules! Sy {
+    ($x: expr) => {
+        Yarn::from($x)
     };
 }
 
@@ -125,7 +133,7 @@ impl PathSanitizer for PathBuf {
     fn to_tree(&self) -> Tree {
         let mut tree = (vec![], vec![]);
         self.components().for_each(|c| {
-            tree.0.push(c.as_os_str().to_str().unwrap().replace(".py", "").replace(".pyi", "").to_string());
+            tree.0.push(yarn!("{}", c.as_os_str().to_str().unwrap().replace(".py", "").replace(".pyi", "")));
         });
         if matches!(tree.0.last().unwrap().as_str(), "__init__" | "__manifest__") {
             tree.0.pop();
@@ -154,7 +162,7 @@ impl PathSanitizer for Path {
     fn to_tree(&self) -> Tree {
         let mut tree = (vec![], vec![]);
         self.components().for_each(|c| {
-            tree.0.push(c.as_os_str().to_str().unwrap().replace(".py", "").replace(".pyi", "").to_string());
+            tree.0.push(yarn!("{}", c.as_os_str().to_str().unwrap().replace(".py", "").replace(".pyi", "")));
         });
         if matches!(tree.0.last().unwrap().as_str(), "__init__" | "__manifest__") {
             tree.0.pop();

--- a/server/tests/test_basics.rs
+++ b/server/tests/test_basics.rs
@@ -2,11 +2,12 @@
 
 use std::collections::HashSet;
 use std::env;
+use byteyarn::{yarn, Yarn};
 use odoo_ls_server::core::evaluation::EvaluationValue;
 use odoo_ls_server::utils::PathSanitizer;
 use ruff_python_ast::Expr;
 
-use odoo_ls_server::S;
+use odoo_ls_server::{Sy, S};
 
 mod setup;
 
@@ -35,7 +36,7 @@ fn test_assigns() {
     let path = env::current_dir().unwrap().join("tests/data/python/expressions/assign.py").sanitize();
     let session = setup::setup::prepare_custom_entry_point(&mut odoo, path.as_str());
     assert!(session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.len() == 1);
-    let a = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("a")]), u32::MAX);
+    let a = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("a")]), u32::MAX);
     assert!(a.len() == 1);
     assert!(a[0].borrow().name() == "a");
     assert!(a[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -45,7 +46,7 @@ fn test_assigns() {
     assert!(a[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.is_int());
     assert!(a[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 5);
 
-    let b = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("b")]), u32::MAX);
+    let b = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("b")]), u32::MAX);
     assert!(b.len() == 1);
     assert!(b[0].borrow().name() == "b");
     assert!(b[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -54,7 +55,7 @@ fn test_assigns() {
     assert!(b[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_string_literal_expr());
     assert!(b[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_string_literal_expr().unwrap().value.to_str() == "test");
 
-    let c = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("c")]), u32::MAX);
+    let c = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("c")]), u32::MAX);
     assert!(c.len() == 1);
     assert!(c[0].borrow().name() == "c");
     assert!(c[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -64,7 +65,7 @@ fn test_assigns() {
     assert!(c[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.is_float());
     assert!(c[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_float().unwrap() == &3.14);
 
-    let d = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("d")]), u32::MAX);
+    let d = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("d")]), u32::MAX);
     assert!(d.len() == 1);
     assert!(d[0].borrow().name() == "d");
     assert!(d[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -73,7 +74,7 @@ fn test_assigns() {
     assert!(d[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_boolean_literal_expr());
     assert!(d[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_boolean_literal_expr().unwrap().value == true);
 
-    let e = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("e")]), u32::MAX);
+    let e = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("e")]), u32::MAX);
     assert!(e.len() == 1);
     assert!(e[0].borrow().name() == "e");
     assert!(e[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -82,7 +83,7 @@ fn test_assigns() {
     assert!(e[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_boolean_literal_expr());
     assert!(e[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_boolean_literal_expr().unwrap().value == false);
 
-    let f = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("f")]), u32::MAX);
+    let f = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("f")]), u32::MAX);
     assert!(f.len() == 1);
     assert!(f[0].borrow().name() == "f");
     assert!(f[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -90,7 +91,7 @@ fn test_assigns() {
     assert!(matches!(f[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::NoneLiteral(_))));
     assert!(f[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_none_literal_expr());
 
-    let g = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("g")]), u32::MAX);
+    let g = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("g")]), u32::MAX);
     assert!(g.len() == 1);
     assert!(g[0].borrow().name() == "g");
     assert!(g[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -104,7 +105,7 @@ fn test_assigns() {
     assert!(g[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_list()[2].is_number_literal_expr());
     assert!(g[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_list()[2].as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 3);
 
-    let h = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("h")]), u32::MAX);
+    let h = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("h")]), u32::MAX);
     assert!(h.len() == 1);
     assert!(h[0].borrow().name() == "h");
     assert!(h[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -118,7 +119,7 @@ fn test_assigns() {
     assert!(h[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_tuple()[2].is_number_literal_expr());
     assert!(h[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_tuple()[2].as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 3);
 
-    let i = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("i")]), u32::MAX);
+    let i = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("i")]), u32::MAX);
     assert!(i.len() == 1);
     assert!(i[0].borrow().name() == "i");
     assert!(i[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -134,7 +135,7 @@ fn test_assigns() {
     assert!(i[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_dict()[1].1.is_number_literal_expr());
     assert!(i[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_dict()[1].1.as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 2);
 
-    let j = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!("j")]), u32::MAX);
+    let j = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("j")]), u32::MAX);
     assert!(j.len() == 1);
     assert!(j[0].borrow().name() == "j");
     assert!(j[0].borrow().evaluations().as_ref().unwrap().len() == 1);
@@ -150,7 +151,7 @@ fn test_sections() {
     assert!(session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.len() == 1);
 
     let assert_get_int_eval_values = |var_name: &str, values: HashSet<i32>|{
-        let syms = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![S!(var_name)]), u32::MAX);
+        let syms = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![yarn!("{}", var_name)]), u32::MAX);
         assert_eq!(syms.len(), values.len()); // Check Number of symbols
         assert_eq!(syms.iter()
         .map(|sym| {

--- a/server/tests/test_ls.rs
+++ b/server/tests/test_ls.rs
@@ -5,8 +5,10 @@ use std::{env, rc::Rc};
 use std::cell::RefCell;
 use std::fs::File;
 use std::io::BufReader;
+use byteyarn::Yarn;
 use odoo_ls_server::core::odoo::SyncOdoo;
 use odoo_ls_server::utils::PathSanitizer;
+use odoo_ls_server::Sy;
 use serde_json::Value;
 
 use odoo_ls_server::{S, core::symbols::symbol::Symbol, constants::SymType};
@@ -23,24 +25,24 @@ fn test_structure() {
     let odoo_path = env::var("COMMUNITY_PATH").unwrap();
     let odoo_path = PathBuf::from(odoo_path).sanitize();
     let odoo_path = odoo_path.as_str();
-    assert!(!odoo.get_symbol(odoo_path, &(vec![S!("odoo")], vec![]), u32::MAX).is_empty());
-    assert!(!odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons")], vec![]), u32::MAX).is_empty());
-    assert!(!odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1")], vec![]), u32::MAX).is_empty());
-    assert!(!odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_2")], vec![]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("not_a_module")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_2")], vec![]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("not_a_module")], vec![]), u32::MAX).is_empty());
 
-    assert!(odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("not_loaded")], vec![]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("not_loaded"), S!("not_loaded_file")], vec![]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("not_loaded"), S!("not_loaded_file")], vec![S!("NotLoadedClass")]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("not_loaded"), S!("not_loaded_file")], vec![S!("NotLoadedFunc")]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded")], vec![]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded"), Sy!("not_loaded_file")], vec![]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded"), Sy!("not_loaded_file")], vec![Sy!("NotLoadedClass")]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded"), Sy!("not_loaded_file")], vec![Sy!("NotLoadedFunc")]), u32::MAX).is_empty());
 
-    let models = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("models")], vec![]), u32::MAX);
+    let models = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("models")], vec![]), u32::MAX);
     assert!(models.len() == 1);
-    assert!(models[0].borrow().get_symbol(&(vec![S!("base_test_models")], vec![]), u32::MAX).len() == 1);
-    assert!(models[0].borrow().get_symbol(&(vec![], vec![S!("base_test_models")]), u32::MAX).len() == 1);
-    assert!(!Rc::ptr_eq(&models[0].borrow().get_symbol(&(vec![S!("base_test_models")], vec![]), u32::MAX)[0],
-            &models[0].borrow().get_symbol(&(vec![], vec![S!("base_test_models")]), u32::MAX)[0]));
-    let module_1 = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1")], vec![]), u32::MAX);
+    assert!(models[0].borrow().get_symbol(&(vec![Sy!("base_test_models")], vec![]), u32::MAX).len() == 1);
+    assert!(models[0].borrow().get_symbol(&(vec![], vec![Sy!("base_test_models")]), u32::MAX).len() == 1);
+    assert!(!Rc::ptr_eq(&models[0].borrow().get_symbol(&(vec![Sy!("base_test_models")], vec![]), u32::MAX)[0],
+            &models[0].borrow().get_symbol(&(vec![], vec![Sy!("base_test_models")]), u32::MAX)[0]));
+    let module_1 = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![]), u32::MAX);
     assert!(module_1.len() == 1);
     //assert!(compare_symbol_with_json(module_1, "tests/module_1_structure.json"))
     test_imports(&odoo);
@@ -51,54 +53,54 @@ fn test_imports(odoo: &SyncOdoo) {
     let odoo_path = env::var("COMMUNITY_PATH").unwrap();
     let odoo_path = PathBuf::from(odoo_path).sanitize();
     let odoo_path = odoo_path.as_str();
-    let model_var = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1")], vec![S!("models")]), u32::MAX);
-    let model_dir = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("models")], vec![]), u32::MAX);
+    let model_var = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![Sy!("models")]), u32::MAX);
+    let model_dir = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("models")], vec![]), u32::MAX);
     assert!(model_var.len() == 1);
     assert!(model_dir.len() == 1);
     assert!(!Rc::ptr_eq(&model_dir[0], &model_var[0]));
     assert!(model_var[0].borrow().evaluations().as_ref().unwrap().len() == 1);
     assert!(Rc::ptr_eq(&model_dir[0], &model_var[0].borrow().evaluations().as_ref().unwrap()[0].symbol.get_symbol_ptr().upgrade_weak().unwrap()));
-    let data_var = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1")], vec![S!("data")]), u32::MAX);
+    let data_var = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![Sy!("data")]), u32::MAX);
     assert!(data_var.len() == 1);
     assert!(data_var[0].borrow().evaluations().as_ref().unwrap().is_empty());
 
     //test * imports
-    let constants_dir = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("constants")], vec![]), u32::MAX);
+    let constants_dir = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("constants")], vec![]), u32::MAX);
     assert!(constants_dir.len() == 1);
     let constants_dir = constants_dir[0].clone();
     assert!(constants_dir.borrow().all_symbols().collect::<Vec<_>>().len() == 3);
-    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_1")]), u32::MAX).len() == 1);
-    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX).len() == 1);
-    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_3")]), u32::MAX).len() == 0);
-    assert!(constants_dir.borrow().get_symbol(&(vec![S!("data")], vec![]), u32::MAX).len() == 1);
-    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
-    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
-    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
-    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
-    let data_dir = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("constants"), S!("data")], vec![]), u32::MAX);
+    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX).len() == 1);
+    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX).len() == 1);
+    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_3")]), u32::MAX).len() == 0);
+    assert!(constants_dir.borrow().get_symbol(&(vec![Sy!("data")], vec![]), u32::MAX).len() == 1);
+    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
+    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
+    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
+    assert!(constants_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
+    let data_dir = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("constants"), Sy!("data")], vec![]), u32::MAX);
     assert!(data_dir.len() == 1);
     let data_dir = data_dir[0].clone();
     assert!(data_dir.borrow().all_symbols().collect::<Vec<_>>().len() == 4);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_1")]), u32::MAX).len() == 1);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX).len() == 1);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_3")]), u32::MAX).len() == 0);
-    assert!(data_dir.borrow().get_symbol(&(vec![S!("constants")], vec![]), u32::MAX).len() == 1);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_some());
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_number_literal_expr());
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 22);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), 26)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
-    assert!(data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), 26)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
-    assert!(!data_dir.borrow().get_symbol(&(vec![], vec![S!("CONSTANT_2")]), 26)[0].borrow().evaluations().as_ref().unwrap()[0].symbol.get_weak().weak.is_expired());
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX).len() == 1);
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX).len() == 1);
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_3")]), u32::MAX).len() == 0);
+    assert!(data_dir.borrow().get_symbol(&(vec![Sy!("constants")], vec![]), u32::MAX).len() == 1);
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_some());
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_number_literal_expr());
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0].borrow().evaluations().as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 22);
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), 26)[0].borrow().evaluations().as_ref().unwrap().len() == 1);
+    assert!(data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), 26)[0].borrow().evaluations().as_ref().unwrap()[0].value.is_none());
+    assert!(!data_dir.borrow().get_symbol(&(vec![], vec![Sy!("CONSTANT_2")]), 26)[0].borrow().evaluations().as_ref().unwrap()[0].symbol.get_weak().weak.is_expired());
 
     //Test odoo.addons import
-    let constant_1_var = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("models"), S!("base_test_models")], vec![S!("CONSTANT_1")]), u32::MAX);
+    let constant_1_var = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("models"), Sy!("base_test_models")], vec![Sy!("CONSTANT_1")]), u32::MAX);
     println!("test");
     assert!(constant_1_var.len() == 1);
     assert!(constant_1_var[0].borrow().evaluations().as_ref().unwrap().len() == 1);
-    let constant_1_var_data = odoo.get_symbol(odoo_path, &(vec![S!("odoo"), S!("addons"), S!("module_1"), S!("constants")], vec![S!("CONSTANT_1")]), u32::MAX);
+    let constant_1_var_data = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("constants")], vec![Sy!("CONSTANT_1")]), u32::MAX);
     assert!(constant_1_var_data.len() == 1);
     assert!(Rc::ptr_eq(&constant_1_var_data[0], &constant_1_var[0].borrow().evaluations().as_ref().unwrap()[0].symbol.get_symbol_ptr().upgrade_weak().unwrap()));
 

--- a/server/tests/test_setup.rs
+++ b/server/tests/test_setup.rs
@@ -1,7 +1,8 @@
 use std::env;
 use std::path::Path;
 
-use odoo_ls_server::S;
+use byteyarn::Yarn;
+use odoo_ls_server::{Sy, S};
 
 mod setup;
 
@@ -21,9 +22,9 @@ fn test_start_odoo_server() {
     let odoo = setup::setup::setup_server(true);
 
     /* Let's ensure that the architecture is loaded */
-    assert!(!odoo.get_symbol(env::var("COMMUNITY_PATH").unwrap().as_str(), &(vec![S!("odoo")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(env::var("COMMUNITY_PATH").unwrap().as_str(), &(vec![Sy!("odoo")], vec![]), u32::MAX).is_empty());
     /* Let's ensure that odoo/addons is loaded */
-    assert!(!odoo.get_symbol(env::var("COMMUNITY_PATH").unwrap().as_str(), &(vec![S!("odoo"), S!("addons")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(env::var("COMMUNITY_PATH").unwrap().as_str(), &(vec![Sy!("odoo"), Sy!("addons")], vec![]), u32::MAX).is_empty());
     /* And let's test that our test module has well been added and available in odoo/addons */
-    assert!(!odoo.get_symbol(env::var("COMMUNITY_PATH").unwrap().as_str(), &(vec![S!("odoo"), S!("addons"), S!("module_1")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(env::var("COMMUNITY_PATH").unwrap().as_str(), &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![]), u32::MAX).is_empty());
 }


### PR DESCRIPTION
By using Yarn instead of string for small names, memory in allocated on the stack instead of the heap.
It makes the code ~10% faster and 5% less memory consumming