### PR TITLE
[FIX] server: no build_now on arch_eval for __all__

### DIFF
--- a/.github/workflows/warn_supsect_pr.yml
+++ b/.github/workflows/warn_supsect_pr.yml
@@ -41,7 +41,7 @@ jobs:
           script: |
             let body = "";
             if (process.env.file_changed === 'true') {
-              body += "⚠️ The file 'Cargo.toml or caonstant.rs' has been modified in this PR. Please review the changes carefully.\n";
+              body += "⚠️ The file 'Cargo.toml or constant.rs' has been modified in this PR. Please review the changes carefully.\n";
             }
             if (process.env.println_found === 'true') {
               body += "⚠️ A 'println!(' statement was found in the commit. Please ensure debug statements are removed before merging.\n";

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -170,9 +170,9 @@ impl PythonArchBuilder {
                 }
                 let mut all_name_allowed = true;
                 let mut name_filter: Vec<OYarn> = vec![];
-                if let Some(all) = import_result.symbol.borrow().get_content_symbol("__all__", u32::MAX).symbols.first() {
+                if let Some(all) = import_result.symbol.borrow().get_content_symbol("__all__", u32::MAX).symbols.first().cloned() {
                     let all_value = Symbol::follow_ref(&EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(
-                        Rc::downgrade(all), None, false
+                        Rc::downgrade(&all), None, false
                     )), session, &mut None, false, true, None, &mut self.diagnostics);
                     if let Some(all_value_first) = all_value.get(0) {
                         if !all_value_first.is_expired_if_weak() {

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -1885,7 +1885,7 @@ impl Symbol {
                                             continue;
                                         }
                                     }
-                                    if sym_rc.borrow().as_variable().evaluations.is_empty() && can_eval_external {
+                                    if sym_rc.borrow().as_variable().evaluations.is_empty() && sym_rc.borrow().name() != "__all__" && can_eval_external {
                                         //no evaluation? let's check that the file has been evaluated
                                         let file_symbol = sym_rc.borrow().get_file();
                                         if let Some(file_symbol) = file_symbol {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -72,6 +72,9 @@ fn main() {
     info!("Server version: {}", EXTENSION_VERSION);
     info!("Compiled setting: DEBUG_ODOO_BUILDER: {}", DEBUG_ODOO_BUILDER);
     info!("Compiled setting: DEBUG_MEMORY: {}", DEBUG_MEMORY);
+    info!("Compiled setting: DEBUG_THREADS: {}", DEBUG_THREADS);
+    info!("Compiled setting: DEBUG_STEPS: {}", DEBUG_STEPS);
+    info!("Compiled setting: DEBUG_REBUILD_NOW: {}", DEBUG_REBUILD_NOW);
     info!("Operating system: {}", std::env::consts::OS);
     info!("");
 


### PR DESCRIPTION
as __all__ is evaluated at arch step, a follow_ref on it should not try to build arch_eval. It can lead to a borrow error