### PR TITLE
[IMP] server: refactor ast_indexes into new node_index support from Ruff

### DIFF
--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1172,13 +1172,13 @@ impl Odoo {
             if let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(session, &PathBuf::from(path.clone())) {
                 let file_info = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&path);
                 if let Some(file_info) = file_info {
-                    if file_info.borrow().file_info_ast.borrow().ast.is_none() {
+                    if file_info.borrow().file_info_ast.borrow().indexed_module.is_none() {
                         file_info.borrow_mut().prepare_ast(session);
                     }
                     let ast_type = file_info.borrow().file_info_ast.borrow().ast_type.clone();
                     match ast_type {
                         AstType::Python => {
-                            if file_info.borrow_mut().file_info_ast.borrow().ast.is_some() {
+                            if file_info.borrow_mut().file_info_ast.borrow().indexed_module.is_some() {
                                 return Ok(HoverFeature::hover_python(session, &file_symbol, &file_info, params.text_document_position_params.position.line, params.text_document_position_params.position.character));
                             }
                         },
@@ -1209,13 +1209,13 @@ impl Odoo {
             if let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(session, &PathBuf::from(path.clone())) {
                 let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path);
                 if let Some(file_info) = file_info {
-                    if file_info.borrow().file_info_ast.borrow().ast.is_none() {
+                    if file_info.borrow().file_info_ast.borrow().indexed_module.is_none() {
                         file_info.borrow_mut().prepare_ast(session);
                     }
                     let ast_type = file_info.borrow().file_info_ast.borrow().ast_type.clone();
                     match ast_type {
                         AstType::Python => {
-                            if file_info.borrow().file_info_ast.borrow().ast.is_some() {
+                            if file_info.borrow().file_info_ast.borrow().indexed_module.is_some() {
                                 return Ok(DefinitionFeature::get_location(session, &file_symbol, &file_info, params.text_document_position_params.position.line, params.text_document_position_params.position.character));
                             }
                         },
@@ -1246,13 +1246,13 @@ impl Odoo {
             if let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(session, &PathBuf::from(path.clone())) {
                 let file_info = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&path);
                 if let Some(file_info) = file_info {
-                    if file_info.borrow().file_info_ast.borrow().ast.is_none() {
+                    if file_info.borrow().file_info_ast.borrow().indexed_module.is_none() {
                         file_info.borrow_mut().prepare_ast(session);
                     }
                     let ast_type = file_info.borrow().file_info_ast.borrow().ast_type.clone();
                     match ast_type {
                         AstType::Python => {
-                            if file_info.borrow_mut().file_info_ast.borrow().ast.is_some() {
+                            if file_info.borrow_mut().file_info_ast.borrow().indexed_module.is_some() {
                                 return Ok(ReferenceFeature::get_references(session, &file_symbol, &file_info, params.text_document_position.position.line, params.text_document_position.position.character));
                             }
                         },
@@ -1284,10 +1284,10 @@ impl Odoo {
             if let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(session, &PathBuf::from(path.clone())) {
                 let file_info = session.sync_odoo.get_file_mgr().borrow_mut().get_file_info(&path);
                 if let Some(file_info) = file_info {
-                    if file_info.borrow().file_info_ast.borrow().ast.is_none() {
+                    if file_info.borrow().file_info_ast.borrow().indexed_module.is_none() {
                         file_info.borrow_mut().prepare_ast(session);
                     }
-                    if file_info.borrow_mut().file_info_ast.borrow().ast.is_some() {
+                    if file_info.borrow_mut().file_info_ast.borrow().indexed_module.is_some() {
                         return Ok(CompletionFeature::autocomplete(session, &file_symbol, &file_info, params.text_document_position.position.line, params.text_document_position.position.character));
                     }
                 }
@@ -1598,7 +1598,7 @@ impl Odoo {
         if uri.ends_with(".py") || uri.ends_with(".pyi") || uri.ends_with(".xml") || uri.ends_with(".csv") {
             let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path);
             if let Some(file_info) = file_info {
-                if file_info.borrow().file_info_ast.borrow().ast.is_none() {
+                if file_info.borrow().file_info_ast.borrow().indexed_module.is_none() {
                     file_info.borrow_mut().prepare_ast(session);
                 }
                 return Ok(DocumentSymbolFeature::get_symbols(session, &file_info));

--- a/server/src/core/symbols/class_symbol.rs
+++ b/server/src/core/symbols/class_symbol.rs
@@ -1,4 +1,5 @@
 use byteyarn::Yarn;
+use ruff_python_ast::AtomicNodeIndex;
 use ruff_text_size::{TextRange, TextSize};
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
@@ -21,7 +22,6 @@ pub struct ClassSymbol {
     pub is_external: bool,
     pub doc_string: Option<String>,
     pub bases: Vec<Weak<RefCell<Symbol>>>,
-    pub ast_indexes: Vec<u16>, //list of index to reach the corresponding ast node from file ast
     pub weak_self: Option<Weak<RefCell<Symbol>>>,
     pub parent: Option<Weak<RefCell<Symbol>>>,
     pub range: TextRange,
@@ -49,7 +49,6 @@ impl ClassSymbol {
             parent: None,
             range,
             body_range: TextRange::new(body_start, range.end()),
-            ast_indexes: vec![],
             doc_string: None,
             sections: vec![],
             symbols: HashMap::new(),

--- a/server/src/core/symbols/function_symbol.rs
+++ b/server/src/core/symbols/function_symbol.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, cmp::min, collections::HashMap, rc::{Rc, Weak}};
 
 use lsp_types::Diagnostic;
-use ruff_python_ast::{Expr, ExprCall};
+use ruff_python_ast::{AtomicNodeIndex, Expr, ExprCall};
 use ruff_text_size::{TextRange, TextSize};
 use weak_table::{PtrWeakHashSet, PtrWeakKeyHashMap};
 
@@ -34,7 +34,7 @@ pub struct FunctionSymbol {
     pub is_static: bool,
     pub is_property: bool,
     pub doc_string: Option<String>,
-    pub ast_indexes: Vec<u16>, //list of index to reach the corresponding ast node from file ast
+    pub node_index: AtomicNodeIndex,
     pub diagnostics: HashMap<BuildSteps, Vec<Diagnostic>>, //only temporary used for CLASS and FUNCTION to be collected like others are stored on FileInfo
     pub evaluations: Vec<Evaluation>, //Vec, because sometimes a single allocation can be ambiguous, like ''' a = "5" if X else 5 '''
     pub model_dependencies: PtrWeakHashSet<Weak<RefCell<Model>>>,
@@ -73,7 +73,7 @@ impl FunctionSymbol {
             is_static: false,
             is_property: false,
             diagnostics: HashMap::new(),
-            ast_indexes: vec![],
+            node_index: AtomicNodeIndex::dummy(),
             doc_string: None,
             evaluations: vec![],
             arch_status: BuildStatus::PENDING,

--- a/server/src/core/symbols/module_symbol.rs
+++ b/server/src/core/symbols/module_symbol.rs
@@ -117,10 +117,10 @@ impl ModuleSymbol {
         }
         let (updated, manifest_file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, manifest_path.sanitize().as_str(), None, None, false);
         let mut manifest_file_info = (*manifest_file_info).borrow_mut();
-        if manifest_file_info.file_info_ast.borrow().ast.is_none() {
+        if manifest_file_info.file_info_ast.borrow().indexed_module.is_none() {
             manifest_file_info.prepare_ast(session);
         }
-        if manifest_file_info.file_info_ast.borrow().ast.is_none() {
+        if manifest_file_info.file_info_ast.borrow().indexed_module.is_none() {
             return None;
         }
         let diags = module._load_manifest(session, &manifest_file_info);
@@ -161,7 +161,7 @@ impl ModuleSymbol {
     fn _load_manifest(&mut self, session: &mut SessionInfo, file_info: &FileInfo) -> Vec<Diagnostic> {
         let mut res = vec![];
         let file_info_ast = file_info.file_info_ast.borrow();
-        let ast = file_info_ast.ast.as_ref().unwrap();
+        let ast = file_info_ast.get_stmts().unwrap();
         if ast.len() != 1 || !matches!(ast.first(), Some(Stmt::Expr(expr)) if expr.value.is_dict_expr()) {
             if let Some(diagnostic) = create_diagnostic(&session, DiagnosticCode::OLS04001, &[]) {
                 res.push(Diagnostic {

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -1,4 +1,5 @@
 use byteyarn::{yarn, Yarn};
+use ruff_python_ast::AtomicNodeIndex;
 use ruff_text_size::{TextSize, TextRange};
 use tracing::{info, trace};
 use weak_table::traits::WeakElement;
@@ -729,10 +730,10 @@ impl Symbol {
         }
     }
 
-    pub fn has_ast_indexes(&self) -> bool {
+    pub fn has_node_index(&self) -> bool {
         match self {
-            Symbol::Variable(_) => true,
-            Symbol::Class(_) => true,
+            Symbol::Variable(_) => false,
+            Symbol::Class(_) => false,
             Symbol::Function(_) => true,
             Symbol::DiskDir(_) => false,
             Symbol::File(_) => false,
@@ -745,11 +746,11 @@ impl Symbol {
         }
     }
 
-    pub fn ast_indexes(&self) -> Option<&Vec<u16>> {
+    pub fn node_index(&self) -> Option<&AtomicNodeIndex> {
         match self {
-            Symbol::Variable(v) => Some(&v.ast_indexes),
-            Symbol::Class(c) => Some(&c.ast_indexes),
-            Symbol::Function(f) => Some(&f.ast_indexes),
+            Symbol::Variable(v) => None,
+            Symbol::Class(c) => None,
+            Symbol::Function(f) => Some(&f.node_index),
             Symbol::DiskDir(_) => None,
             Symbol::File(_) => None,
             Symbol::Compiled(_) => None,
@@ -761,11 +762,11 @@ impl Symbol {
         }
     }
 
-    pub fn ast_indexes_mut(&mut self) -> &mut Vec<u16> {
+    pub fn node_index_mut(&mut self) -> &mut AtomicNodeIndex {
         match self {
-            Symbol::Variable(v) => &mut v.ast_indexes,
-            Symbol::Class(c) => &mut c.ast_indexes,
-            Symbol::Function(f) => &mut f.ast_indexes,
+            Symbol::Variable(v) => panic!(),
+            Symbol::Class(c) => panic!(),
+            Symbol::Function(f) => &mut f.node_index,
             Symbol::DiskDir(_) => panic!(),
             Symbol::File(_) => panic!(),
             Symbol::Compiled(_) => panic!(),

--- a/server/src/core/symbols/variable_symbol.rs
+++ b/server/src/core/symbols/variable_symbol.rs
@@ -1,3 +1,4 @@
+use ruff_python_ast::AtomicNodeIndex;
 use ruff_text_size::TextRange;
 
 use crate::{constants::{OYarn, SymType}, core::evaluation::{ContextValue, Evaluation}, oyarn, threads::SessionInfo, Sy, S};
@@ -10,7 +11,6 @@ pub struct VariableSymbol {
     pub name: OYarn,
     pub is_external: bool,
     pub doc_string: Option<String>,
-    pub ast_indexes: Vec<u16>, //list of index to reach the corresponding ast node from file ast
     pub weak_self: Option<Weak<RefCell<Symbol>>>,
     pub parent: Option<Weak<RefCell<Symbol>>>,
     pub is_import_variable: bool,
@@ -26,7 +26,6 @@ impl VariableSymbol {
             name,
             is_external,
             doc_string: None,
-            ast_indexes: vec![],
             weak_self: None,
             parent: None,
             range,

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -51,7 +51,7 @@ impl CompletionFeature {
         let offset = file_info.borrow().position_to_offset(line, character);
         let file_info_ast = file_info.borrow().file_info_ast.clone();
         let file_info_ast = file_info_ast.borrow();
-        let ast = file_info_ast.ast.as_ref().unwrap();
+        let ast = file_info_ast.get_stmts().unwrap();
         complete_vec_stmt(ast, session, file_symbol, offset).or_else(|| complete_name(session, file_symbol, offset, false, &S!("")))
     }
 }

--- a/server/src/features/document_symbols.rs
+++ b/server/src/features/document_symbols.rs
@@ -15,7 +15,7 @@ impl DocumentSymbolFeature {
         let mut results = vec![];
         let file_info_bw = file_info.borrow();
         let file_info_ast = file_info_bw.file_info_ast.borrow();
-        if let Some(ast) = &file_info_ast.ast {
+        if let Some(ast) = &file_info_ast.get_stmts() {
             for stmt in ast.iter() {
                 DocumentSymbolFeature::visit_stmt(session, stmt, &mut results, file_info);
             }

--- a/server/src/features/mod.rs
+++ b/server/src/features/mod.rs
@@ -4,5 +4,6 @@ pub mod definition;
 pub mod document_symbols;
 pub mod features_utils;
 pub mod hover;
+pub mod node_index_ast;
 pub mod references;
 pub mod xml_ast_utils;

--- a/server/src/features/node_index_ast.rs
+++ b/server/src/features/node_index_ast.rs
@@ -1,0 +1,240 @@
+/// From https://github.com/astral-sh/ruff/blob/c433865801e2ee06902199d6b0a223cfca52269b/crates/ruff_db/src/parsed.rs#L160
+/// License MIT: https://github.com/astral-sh/ruff?tab=MIT-1-ov-file#readme
+
+use std::sync::Arc;
+
+use ruff_python_ast::visitor::source_order::*;
+use ruff_python_ast::*;
+use ruff_python_parser::Parsed;
+
+/// A visitor that collects nodes in source order.
+pub struct Visitor<'a> {
+    pub index: u32,
+    pub nodes: Vec<AnyRootNodeRef<'a>>,
+}
+
+impl<'a> Visitor<'a> {
+    fn visit_node<T>(&mut self, node: &'a T)
+    where
+        T: HasNodeIndex + std::fmt::Debug,
+        AnyRootNodeRef<'a>: From<&'a T>,
+    {
+        node.node_index().set(self.index);
+        self.nodes.push(AnyRootNodeRef::from(node));
+        self.index += 1;
+    }
+}
+
+impl<'a> SourceOrderVisitor<'a> for Visitor<'a> {
+    #[inline]
+    fn visit_mod(&mut self, module: &'a Mod) {
+        self.visit_node(module);
+        walk_module(self, module);
+    }
+
+    #[inline]
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        self.visit_node(stmt);
+        walk_stmt(self, stmt);
+    }
+
+    #[inline]
+    fn visit_annotation(&mut self, expr: &'a Expr) {
+        self.visit_node(expr);
+        walk_annotation(self, expr);
+    }
+
+    #[inline]
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        self.visit_node(expr);
+        walk_expr(self, expr);
+    }
+
+    #[inline]
+    fn visit_decorator(&mut self, decorator: &'a Decorator) {
+        self.visit_node(decorator);
+        walk_decorator(self, decorator);
+    }
+
+    #[inline]
+    fn visit_comprehension(&mut self, comprehension: &'a Comprehension) {
+        self.visit_node(comprehension);
+        walk_comprehension(self, comprehension);
+    }
+
+    #[inline]
+    fn visit_except_handler(&mut self, except_handler: &'a ExceptHandler) {
+        self.visit_node(except_handler);
+        walk_except_handler(self, except_handler);
+    }
+
+    #[inline]
+    fn visit_arguments(&mut self, arguments: &'a Arguments) {
+        self.visit_node(arguments);
+        walk_arguments(self, arguments);
+    }
+
+    #[inline]
+    fn visit_parameters(&mut self, parameters: &'a Parameters) {
+        self.visit_node(parameters);
+        walk_parameters(self, parameters);
+    }
+
+    #[inline]
+    fn visit_parameter(&mut self, arg: &'a Parameter) {
+        self.visit_node(arg);
+        walk_parameter(self, arg);
+    }
+
+    fn visit_parameter_with_default(
+        &mut self,
+        parameter_with_default: &'a ParameterWithDefault,
+    ) {
+        self.visit_node(parameter_with_default);
+        walk_parameter_with_default(self, parameter_with_default);
+    }
+
+    #[inline]
+    fn visit_keyword(&mut self, keyword: &'a Keyword) {
+        self.visit_node(keyword);
+        walk_keyword(self, keyword);
+    }
+
+    #[inline]
+    fn visit_alias(&mut self, alias: &'a Alias) {
+        self.visit_node(alias);
+        walk_alias(self, alias);
+    }
+
+    #[inline]
+    fn visit_with_item(&mut self, with_item: &'a WithItem) {
+        self.visit_node(with_item);
+        walk_with_item(self, with_item);
+    }
+
+    #[inline]
+    fn visit_type_params(&mut self, type_params: &'a TypeParams) {
+        self.visit_node(type_params);
+        walk_type_params(self, type_params);
+    }
+
+    #[inline]
+    fn visit_type_param(&mut self, type_param: &'a TypeParam) {
+        self.visit_node(type_param);
+        walk_type_param(self, type_param);
+    }
+
+    #[inline]
+    fn visit_match_case(&mut self, match_case: &'a MatchCase) {
+        self.visit_node(match_case);
+        walk_match_case(self, match_case);
+    }
+
+    #[inline]
+    fn visit_pattern(&mut self, pattern: &'a Pattern) {
+        self.visit_node(pattern);
+        walk_pattern(self, pattern);
+    }
+
+    #[inline]
+    fn visit_pattern_arguments(&mut self, pattern_arguments: &'a PatternArguments) {
+        self.visit_node(pattern_arguments);
+        walk_pattern_arguments(self, pattern_arguments);
+    }
+
+    #[inline]
+    fn visit_pattern_keyword(&mut self, pattern_keyword: &'a PatternKeyword) {
+        self.visit_node(pattern_keyword);
+        walk_pattern_keyword(self, pattern_keyword);
+    }
+
+    #[inline]
+    fn visit_elif_else_clause(&mut self, elif_else_clause: &'a ElifElseClause) {
+        self.visit_node(elif_else_clause);
+        walk_elif_else_clause(self, elif_else_clause);
+    }
+
+    #[inline]
+    fn visit_f_string(&mut self, f_string: &'a FString) {
+        self.visit_node(f_string);
+        walk_f_string(self, f_string);
+    }
+
+    #[inline]
+    fn visit_interpolated_string_element(
+        &mut self,
+        interpolated_string_element: &'a InterpolatedStringElement,
+    ) {
+        self.visit_node(interpolated_string_element);
+        walk_interpolated_string_element(self, interpolated_string_element);
+    }
+
+    #[inline]
+    fn visit_t_string(&mut self, t_string: &'a TString) {
+        self.visit_node(t_string);
+        walk_t_string(self, t_string);
+    }
+
+    #[inline]
+    fn visit_string_literal(&mut self, string_literal: &'a StringLiteral) {
+        self.visit_node(string_literal);
+        walk_string_literal(self, string_literal);
+    }
+
+    #[inline]
+    fn visit_bytes_literal(&mut self, bytes_literal: &'a BytesLiteral) {
+        self.visit_node(bytes_literal);
+        walk_bytes_literal(self, bytes_literal);
+    }
+
+    #[inline]
+    fn visit_identifier(&mut self, identifier: &'a Identifier) {
+        self.visit_node(identifier);
+        walk_identifier(self, identifier);
+    }
+}
+
+/// A wrapper around the AST that allows access to AST nodes by index.
+#[derive(Debug)]
+pub struct IndexedModule {
+    index: Box<[AnyRootNodeRef<'static>]>,
+    pub parsed: Parsed<ModModule>,
+}
+
+impl IndexedModule {
+    /// Create a new [`IndexedModule`] from the given AST.
+    #[allow(clippy::unnecessary_cast)]
+    pub fn new(parsed: Parsed<ModModule>) -> Arc<Self> {
+        let mut visitor = Visitor {
+            nodes: Vec::new(),
+            index: 0,
+        };
+
+        let mut inner = Arc::new(IndexedModule {
+            parsed,
+            index: Box::new([]),
+        });
+
+        AnyNodeRef::from(inner.parsed.syntax()).visit_source_order(&mut visitor);
+
+        let index: Box<[AnyRootNodeRef<'_>]> = visitor.nodes.into_boxed_slice();
+
+        // SAFETY: We cast from `Box<[AnyRootNodeRef<'_>]>` to `Box<[AnyRootNodeRef<'static>]>`,
+        // faking the 'static lifetime to create the self-referential struct. The node references
+        // are into the `Arc<Parsed<ModModule>>`, so are valid for as long as the `IndexedModule`
+        // is alive. We make sure to restore the correct lifetime in `get_by_index`.
+        //
+        // Note that we can never move the data within the `Arc` after this point.
+        Arc::get_mut(&mut inner).unwrap().index =
+            unsafe { Box::from_raw(Box::into_raw(index) as *mut [AnyRootNodeRef<'static>]) };
+
+        inner
+    }
+
+    /// Returns the node at the given index.
+    pub fn get_by_index<'ast>(&'ast self, index: NodeIndex) -> AnyRootNodeRef<'ast> {
+        // Note that this method restores the correct lifetime: the nodes are valid for as
+        // long as the reference to `IndexedModule` is alive.
+        self.index[index.as_usize()]
+    }
+}


### PR DESCRIPTION
Drop our home-made ast_indexes that help us indexing statements and use built-in node_indexes that are now directly on Nodes in last version of Ruff_python_ast.