### PR TITLE
[FIX] reload cache if invalidated

### DIFF
--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -513,7 +513,7 @@ impl FileMgr {
         let return_info = file_info.clone();
         //Do not modify the file if a version is not given but the file is opened
         let mut updated: bool = false;
-        if (version.is_some() && version.unwrap() != -100) || !file_info.borrow().opened {
+        if (version.is_some() && version.unwrap() != -100) || !file_info.borrow().opened || force {
             let mut file_info_mut = (*return_info).borrow_mut();
             updated = file_info_mut.update(session, uri, content, version, self.is_in_workspace(uri), force);
             drop(file_info_mut);


### PR DESCRIPTION
If a FileInfo has been dropped but is needed for a validation, we should not panic but reload it.

It can happen if a custom entrypoint is tagging a FileInfo as external but is part of another entrypoint. It wuld be possible to try to count how many references entrypoints are using to a FileInfo, but that's error prone, and a reload should not happen so often