### PR TITLE
[FIX] features: fix gotodef location crash

### DIFF
--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -222,9 +222,9 @@ impl PythonArchBuilderHooks {
                 let full_path_monkeypatches = S!("odoo._monkeypatches");
                 let mut main_odoo_symbol = None;
                 if let Some(main_ep) = session.sync_odoo.entry_point_mgr.borrow().main_entry_point.as_ref() {
-                    //To import from main entry point, we have to import 'from' a symbol coming from main entry point. 
+                    //To import from main entry point, we have to import 'from' a symbol coming from main entry point.
                     //We then use the main symbol of the main entry point to achieve that, instead of the werkzeug symbol
-                    main_odoo_symbol = Some(main_ep.borrow().get_symbol().unwrap());
+                    main_odoo_symbol = main_ep.borrow().get_symbol();
                 }
                 if let Some(main_odoo_symbol) = main_odoo_symbol {
                     let werkzeug_patch = manual_import(session, &main_odoo_symbol, Some(full_path_monkeypatches), "werkzeug", None, None, &mut None);

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -2064,7 +2064,7 @@ impl Symbol {
     }
 
     pub fn get_file(&self) -> Option<Weak<RefCell<Symbol>>> {
-        if self.typ() == SymType::FILE || matches!(self.typ(), SymType::PACKAGE(_)) {
+        if self.typ() == SymType::FILE || matches!(self.typ(), SymType::PACKAGE(_)) || self.typ() == SymType::XML_FILE || self.typ() == SymType::CSV_FILE {
             return self.weak_self().clone();
         }
         if self.parent().is_some() {

--- a/server/src/features/definition.rs
+++ b/server/src/features/definition.rs
@@ -265,7 +265,7 @@ impl DefinitionFeature {
                                         _ => session.sync_odoo.get_file_mgr().borrow().std_range_to_range(session, &full_path, &range),
                                     };
                                     let link_range = if link_range.is_some() {
-                                        Some(session.sync_odoo.get_file_mgr().borrow().std_range_to_range(session, &full_path, link_range.as_ref().unwrap()))
+                                        Some(session.sync_odoo.get_file_mgr().borrow().std_range_to_range(session, file_symbol.borrow().paths().first().as_ref().unwrap(), link_range.as_ref().unwrap()))
                                     } else {
                                         None
                                     };


### PR DESCRIPTION
gotodef from XML files where redirected to wrong files, sometimes leading to a crash as rope is not long enough on the other file