### PR TITLE
[IMP] handle windows wsl paths

### DIFF
--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -137,7 +137,8 @@ pub trait ToFilePath {
 impl ToFilePath for lsp_types::Uri {
 
     fn to_file_path(&self) -> Result<PathBuf, ()> {
-        let url = url::Url::from_str(self.as_str()).map_err(|_| ())?;
+        let str_repr = self.as_str().replace("file:////", "file://");
+        let url = url::Url::from_str(&str_repr).map_err(|_| ())?;
         url.to_file_path()
     }
 


### PR DESCRIPTION
#429 

The libraries in rust, do not handle well URIs with `file:////` i.e. 4 slashes, so we need to make sure we have only two (not three) slashes that that it is treated correctly. 

Because we want `wsl.localhost` or similar hosts to be treated as the `hostname`. While with the legacy URI of file:////, it is not perceived as such. 

In addition it seems that some clients like PyCharm expects and communicates the path using the legacy way, i.e. `file:////wsl.localhost/...` . While others like VSCode, it uses the "correct" form with two slashes `file://wsl.localhost/...` 

So we gotta catch and handle that 