### PR TITLE
[IMP] prevent import error diagnostic in ImportError catch clause of …

### DIFF
--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -857,8 +857,19 @@ impl PythonArchEval {
         self.visit_sub_stmts(session, &try_stmt.finalbody);
         for handler in try_stmt.handlers.iter() {
             handler.as_except_handler().map(|h| {
+                //Prevent import error in catch clause of ImportError too
+                let mut added_safe_import = false;
+                if let Some(type_) = &h.type_ {
+                    if type_.is_name_expr() && type_.as_name_expr().unwrap().id.to_string() == "ImportError" {
+                        added_safe_import = true;
+                        self.safe_import.push(true);
+                    }
+                }
                 h.type_.as_ref().map(|test_clause| self.visit_expr(session, test_clause));
-                self.visit_sub_stmts(session, &h.body)
+                self.visit_sub_stmts(session, &h.body);
+                if added_safe_import {
+                    self.safe_import.pop();
+                }
             });
         }
     }


### PR DESCRIPTION
…try..catch

If a missing impotr is in a catch clause like
```python
try:
    pass
except ImportError:
    import something_wrong
```
we should not raise a diagnostic as the content of the try will probably contain the right import