### PR TITLE
[IMP] add debug configurations for rust-gdb

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,46 @@
             "console": "externalTerminal"
         },
         {
+            "name": "Launch Server (gdb)",
+            "type": "cppdbg",
+            "request": "launch",
+            "preLaunchTask": "cargo build",
+            "program": "${workspaceFolder}/server/target/debug/odoo_ls_server",
+            "args": ["--use-tcp"],
+            "cwd": "${workspaceFolder}/server",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "rust-gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+            ]
+        },
+        {
+            "name": "Debug Test (gdb)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/server/target/debug/deps/test_setup-22eac7e5dc85cac2",
+            "args": [],
+            "cwd": "${workspaceFolder}/server",
+            "environment": [
+                { "name": "COMMUNITY_PATH", "value": "/path/to/odoo" }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "rust-gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "Launch Server (cppvsdbg)",
             "type": "cppvsdbg",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,11 @@
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
                 },
+                {
+                    "description": "Set print depth limit to prevent infinite recursion",
+                    "text": "set print max-depth 3",
+                    "ignoreFailures": false
+                },
             ]
         },
         {
@@ -65,7 +70,12 @@
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
-                }
+                },
+                {
+                    "description": "Set print depth limit to prevent infinite recursion",
+                    "text": "set print max-depth 3",
+                    "ignoreFailures": false
+                },
             ]
         },
         {


### PR DESCRIPTION
While still not par with window's cppvsdbg, rust-gdb has some advantages over lldb, specially when inspecting an enum type.

Make sure you have the `ms-vscode.cpptools` extension installed in order to test it.