### PR TITLE
[FIX] Rebuild __iter__ evaluation if not ready

### DIFF
--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -833,8 +833,11 @@ impl PythonArchEval {
                     if symbol_type.typ() == SymType::CLASS {
                         let (iter, _) = symbol_type.get_member_symbol(session, &S!("__iter__"), None, true, false, false, false, false);
                         if iter.len() == 1 {
-                            SyncOdoo::build_now(session, &iter[0], BuildSteps::ARCH_EVAL);
-                            SyncOdoo::build_now(session, &iter[0], BuildSteps::VALIDATION);
+                            if !iter[0].borrow().is_external() { //we can't rebuild functions of external files
+                                SyncOdoo::build_now(session, &iter[0], BuildSteps::ARCH);
+                                SyncOdoo::build_now(session, &iter[0], BuildSteps::ARCH_EVAL);
+                                SyncOdoo::build_now(session, &iter[0], BuildSteps::VALIDATION);
+                            }
                             if iter[0].borrow().evaluations().is_some() && iter[0].borrow().evaluations().unwrap().len() == 1 {
                                 let iter = iter[0].borrow();
                                 let eval_iter = &iter.evaluations().unwrap()[0];


### PR DESCRIPTION
When rebuilding __iter__ function, arch has to be done too, as it is a function. If arch_eval has not been done yet, arch has not either. However, we can't do it for external files as file_info has been discarded