### PR TITLE
[IMP] controllers

### DIFF
--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -38,12 +38,26 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
                 let mut range = symbol.borrow().range().clone();
                 let slots = symbol.borrow().get_symbol(&(vec![], vec![Sy!("__slots__")]), u32::MAX);
                 if slots.len() == 1 {
-                    if slots.len() == 1 {
-                        range = slots[0].borrow().range().clone();
-                    }
+                    range = slots[0].borrow().range().clone();
                 }
                 symbol.borrow_mut().add_new_variable(session, Sy!("env"), &range);
             }
+        }
+    },
+    PythonArchClassHook {
+        odoo_entry: true,
+        trees: vec![
+            (Sy!("15.3"), Sy!("19.2"), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("Request")])),
+            (Sy!("19.2"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("http"), Sy!("requestlib")], vec![Sy!("Request")]))
+        ],
+        func: |session: &mut SessionInfo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+            // ----------- Request.env ------------
+            let has_env = !symbol.borrow().get_content_symbol(&Sy!("env"), u32::MAX).symbols.is_empty();
+            if has_env {
+                return;
+            }
+            let range = symbol.borrow().range().clone();
+            symbol.borrow_mut().add_new_variable(session, Sy!("env"), &range);
         }
     },
     PythonArchClassHook {

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -66,6 +66,58 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
         }
     }},
     PythonArchEvalFileHook {odoo_entry: true,
+                        trees: vec![(Sy!("0.0"), Sy!("15.3"), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("request")]))],
+                        if_exist_only: true,
+                        func: |_odoo: &mut SessionInfo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
+        // --------- request: WebRequest (before 15.3) ---------
+        let web_request_class_syms = file_symbol.borrow().get_symbol(&(vec![], vec![Sy!("WebRequest")]), u32::MAX);
+        let Some(web_request_class) = web_request_class_syms.last() else {
+            return;
+        };
+        let mut request = symbol.borrow_mut();
+        request.set_evaluations(vec![Evaluation::eval_from_symbol(&Rc::downgrade(web_request_class), Some(true))]);
+    }},
+    PythonArchEvalFileHook {odoo_entry: true,
+                        trees: vec![
+                            (Sy!("15.3"), Sy!("19.2"), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("request")])),
+                            (Sy!("19.2"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("http"), Sy!("requestlib")], vec![Sy!("request")]))
+                        ],
+                        if_exist_only: true,
+                        func: |_odoo: &mut SessionInfo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
+        // --------- request: Request (15.3+) ---------
+        let request_class_syms = file_symbol.borrow().get_symbol(&(vec![], vec![Sy!("Request")]), u32::MAX);
+        let Some(request_class) = request_class_syms.last() else {
+            return;
+        };
+        let mut request = symbol.borrow_mut();
+        request.set_evaluations(vec![Evaluation::eval_from_symbol(&Rc::downgrade(request_class), Some(true))]);
+    }},
+    PythonArchEvalFileHook {odoo_entry: true,
+                        trees: vec![
+                            (Sy!("0.0"), Sy!("15.3"), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("WebRequest"), Sy!("env")])),
+                            (Sy!("15.3"), Sy!("19.2"), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("Request"), Sy!("env")])),
+                            (Sy!("19.2"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("http"), Sy!("requestlib")], vec![Sy!("Request"), Sy!("env")]))
+                        ],
+                        if_exist_only: true,
+                        func: |odoo: &mut SessionInfo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>| {
+        // --------- (Web)Request.env: Environment | None ---------
+        let env_file_syms = odoo.sync_odoo.get_symbol(odoo.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("api")], vec![]), u32::MAX);
+        let Some(env_file) = env_file_syms.last() else {
+            return;
+        };
+        let env_class_syms = env_file.borrow().get_symbol(&(vec![], vec![Sy!("Environment")]), u32::MAX);
+        let Some(env_class) = env_class_syms.last() else {
+            return;
+        };
+        // env is a property (function) before 15.3, and an instance variable in 15.3+.
+        // In both cases the evaluation is Environment | None.
+        symbol.borrow_mut().set_evaluations(vec![
+            Evaluation::eval_from_symbol(&Rc::downgrade(env_class), Some(true)),
+            Evaluation::new_none()
+        ]);
+        file_symbol.borrow_mut().add_dependency(&mut env_file.borrow_mut(), BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
+    }},
+    PythonArchEvalFileHook {odoo_entry: true,
                         trees: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("ids")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("ids")]))],
                         if_exist_only: true,

--- a/server/tests/data/addons/module_1/__init__.py
+++ b/server/tests/data/addons/module_1/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import data
+from . import controllers

--- a/server/tests/data/addons/module_1/controllers/__init__.py
+++ b/server/tests/data/addons/module_1/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/server/tests/data/addons/module_1/controllers/main.py
+++ b/server/tests/data/addons/module_1/controllers/main.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+
+class TestController(http.Controller):
+    
+    @http.route('/test/request', type='http', auth='public')
+    def test_request_type(self):
+        """Test that request has correct type."""
+        # Hovering over 'request' should show Request class
+        req = request
+        
+        # Hovering over 'request.env' should show Environment | None
+        env = request.env
+        
+        # Accessing models via request.env
+        partner = request.env['res.partner']
+        partners = request.env['res.partner'].search([])

--- a/server/tests/test_controller.rs
+++ b/server/tests/test_controller.rs
@@ -1,0 +1,134 @@
+use std::env;
+use std::path::PathBuf;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::core::symbols::symbol::Symbol;
+use odoo_ls_server::core::file_mgr::FileInfo;
+use odoo_ls_server::utils::PathSanitizer;
+use odoo_ls_server::threads::SessionInfo;
+
+mod setup;
+mod test_utils;
+
+/// Test that odoo.http.request and request.env hooks work correctly.
+/// Tests hover and definition.
+#[test]
+fn test_controller() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let test_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/addons/module_1/controllers/main.py")
+        .sanitize();
+    
+    let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(&mut session, &PathBuf::from(&test_file)) else {
+        panic!("Failed to get file symbol for {}", test_file);
+    };
+    
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&test_file).unwrap();
+    
+    test_request_type_hover(&mut session, &file_symbol, &file_info);
+    test_request_env_definition(&mut session, &file_symbol, &file_info);
+    test_request_env_subscript(&mut session, &file_symbol, &file_info);
+}
+
+/// Test that hovering over 'request' shows Request class
+/// and that hovering over 'request.env' shows Environment type
+fn test_request_type_hover(
+    session: &mut SessionInfo,
+    file_symbol: &Rc<RefCell<Symbol>>,
+    file_info: &Rc<RefCell<FileInfo>>
+) {
+    // Test 1: Hover over 'request' variable (line 11: req = request)
+    // Should show Request class
+    let hover_text = test_utils::get_hover_markdown(session, file_symbol, file_info, 11, 14)
+        .expect("Should get hover text for request");
+    
+    assert!(
+        hover_text.contains("Request"),
+        "Hover over 'request' should show Request class. Got: {}",
+        hover_text
+    );
+    
+    // Test 2: Hover over 'request.env' (line 14: env = request.env)
+    // Should show Environment | None
+    let hover_text = test_utils::get_hover_markdown(session, file_symbol, file_info, 14, 21)
+        .expect("Should get hover text for request.env");
+    
+    assert!(
+        hover_text.contains("Environment"),
+        "Hover over 'request.env' should show Environment type. Got: {}",
+        hover_text
+    );
+    assert!(
+        hover_text.contains("None"),
+        "Hover over 'request.env' should show None. Got: {}",
+        hover_text
+    );
+}
+
+/// Test that request.env provides correct definitions
+fn test_request_env_definition(
+    session: &mut SessionInfo,
+    file_symbol: &Rc<RefCell<Symbol>>,
+    file_info: &Rc<RefCell<FileInfo>>
+) {
+    // Test 1: Go-to-definition on 'request' import (line 3: from odoo.http import request)
+    // Should navigate to request variable in odoo.http
+    let definitions = test_utils::get_definition_locs(session, file_symbol, file_info, 2, 22);
+    
+    assert!(
+        !definitions.is_empty(),
+        "Should find definition for 'request' import"
+    );
+    
+    // Verify it points to the correct file
+    let target_uri = &definitions[0].target_uri.to_string();
+    assert!(
+        target_uri.contains("odoo/http"),
+        "Definition should point to http or requestlib. Got: {:?}",
+        target_uri
+    );
+    
+    // Test 2: Go-to-definition on 'request.env' (line 15: env = request.env)
+    let definitions = test_utils::get_definition_locs(session, file_symbol, file_info, 14, 22);
+    assert!(
+        !definitions.is_empty(),
+        "Should find definition for 'request.env'"
+    );
+}
+
+/// Test that request.env["model_name"] resolves to Model instance
+fn test_request_env_subscript(
+    session: &mut SessionInfo,
+    file_symbol: &Rc<RefCell<Symbol>>,
+    file_info: &Rc<RefCell<FileInfo>>
+) {
+    let partner_class = test_utils::PARTNER_CLASS_NAME(&session.sync_odoo.full_version);
+
+    // Test 1: Hover over 'partner' variable (line 18: partner = request.env['res.partner'])
+    // Should show Partner/ResPartner class
+    let hover_text = test_utils::get_hover_markdown(session, file_symbol, file_info, 17, 8)
+        .expect("Should get hover text for 'partner' variable");
+    
+    assert!(
+        hover_text.contains(partner_class),
+        "Hover over 'partner' should show {} class. Got: {}",
+        partner_class,
+        hover_text
+    );
+
+    // Test 2: Hover over .search on request.env['res.partner'].search (line 19)
+    // Should display markdown content for the search method
+    let hover_text = test_utils::get_hover_markdown(session, file_symbol, file_info, 18, 46)
+        .expect("Should get hover text for .search method");
+    
+    assert!(
+        hover_text.contains("def search"),
+        "Hover over .search should show its definition. Got: {}",
+        hover_text
+    );
+}


### PR DESCRIPTION
This PR adds some missing features related to controllers.
- `request` now evaluates to `Request` class
- `request.env` now evaluates to `Environment | None`
- subscript on request's env is now supported. E.g. `request.env["res.partner"]` evaluates to the model 

Next steps:
In a Controller, `self.env` still does not work, as `env` is a property (which simply returns `request.env`), and properties are not resolved to their return types.
Support for resolving property types is introduced by https://github.com/odoo/odoo-ls/pull/511, which should then:
- enable `self.env` in a `Controller` class
- enable `request.env` before 15.3, in which `request` is an instance of `WebRequest`, which in turn has `env` as a property.