### PR TITLE
[FIX] Check all rel fields during domain validation

### DIFF
--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -1633,7 +1633,7 @@ impl Evaluation {
                                 false,
                                 true,
                                 false,
-                                false,
+                                true,
                                 false);
                             if symbols.is_empty() {
                                 if let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS03011, &[&name, &object.borrow().name()]) {


### PR DESCRIPTION
Fix for OLS03013. 

If we had an overwritten Relational field, that does not have `comodel_name` set, then we will fail to follow it during validation.

That is why we set all to `true`, to get all of them and search them all. 

Example failure caused by this bug https://runbot.odoo.com/runbot/build/95131106