### PR TITLE
[FIX] allow M2OReference on inverse_name

### DIFF
--- a/server/src/core/diagnostic_codes_list.rs
+++ b/server/src/core/diagnostic_codes_list.rs
@@ -164,9 +164,9 @@ OLS03020, DiagnosticSetting::Warning, "Model {0} is shadowing an existing model 
  */
 OLS03021, DiagnosticSetting::Error, "Inverse field {0} does not exist on comodel {1}",
 /**
- * On a One2many field, the inverse_name should be a field on the comodel that is a Many2one to the current model.
+ * On a One2many field, the inverse_name should be a field on the comodel that is a Many2one or a Many2oneReference to the current model.
  */
-OLS03022, DiagnosticSetting::Error, "Inverse field is not a Many2one field",
+OLS03022, DiagnosticSetting::Error, "Inverse field is neither a Many2one nor a Many2oneReference field",
 /**
  * On a One2many field, the inverse_name should be a field on the comodel that is a Many2one to the current model
  * -> current_model is not right

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -563,7 +563,7 @@ impl PythonValidator {
                                 });
                             }
                         }
-                        if symbols.iter().any(|sym| !sym.borrow().is_specific_field(session, &["Many2one"])) {
+                        if symbols.iter().any(|sym| !sym.borrow().is_specific_field(session, &["Many2one", "Many2oneReference"])) {
                             let Some(arg_range) = eval_weak.as_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };

--- a/server/tests/data/addons/module_1/models/diagnostics.py
+++ b/server/tests/data/addons/module_1/models/diagnostics.py
@@ -117,3 +117,11 @@ class SameNameModel(models.Model):
 class SameNameModel2(models.Model):
     _name = "module_1.same_name_model" # OLS03020
     _description = "Another model with same name"
+    attachment_ids = fields.One2many('module_1.m2o_reference_model', 'res_id', string='Attachments')
+
+class ModelWithM2OReference(models.Model):
+    _name = "module_1.m2o_reference_model"
+    _description = "Model to test Many2oneReference field"
+
+    model = fields.Char('Related Document Model')
+    res_id = fields.Many2oneReference('Related Document ID', model_field='model')

--- a/server/tests/diagnostics/ols03000_1_to_23.rs
+++ b/server/tests/diagnostics/ols03000_1_to_23.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use odoo_ls_server::utils::PathSanitizer;
 
-use crate::{setup::setup::*, test_utils::{verify_diagnostics_against_doc}};
+use crate::{setup::setup::*, test_utils::{diag_on_line, verify_diagnostics_against_doc}};
 
 #[test]
 fn test_ols03001_23() {
@@ -12,5 +12,10 @@ fn test_ols03001_23() {
     let path = env::current_dir().unwrap().join("tests/data/addons/module_1/models/diagnostics.py").sanitize();
     let diagnostics = get_diagnostics_for_path(&mut session, &path);
     let doc_diags = get_diagnostics_test_comments(&mut session, &path);
+
+    // Verify that there are no OLS03022 diagnostics on line 120 (index 119) for a O2M field with inverse name to a Many2oneReference field
+    let line_diagnostics = diag_on_line(&diagnostics, 119);
+    assert_eq!(line_diagnostics.len(), 0, "Expected no diagnostics on line 120, but found some: {:?}", line_diagnostics);
+    // Verify all diagnostics against those specified in the document
     verify_diagnostics_against_doc(diagnostics, doc_diags);
 }


### PR DESCRIPTION
Before we were checking if inverse_name arg
points to a M2O field, but it can also be a
Many2oneReference

Fixed false positives for OLS03022