### PR TITLE
[FIX] missing SELF evaluation to search method

### DIFF
--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -512,8 +512,9 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("search")]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        let mut search: std::cell::RefMut<Symbol> = symbol.borrow_mut();
-        let func = search.as_func_mut();
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+        let search = symbol.borrow();
+        let func = search.as_func();
         if func.args.len() > 1 {
             if let Some(arg_symbol) = func.args.get(1).unwrap().symbol.upgrade() {
                 if arg_symbol.borrow().name().eq(&Sy!("domain")) {

--- a/server/tests/test_hooks.rs
+++ b/server/tests/test_hooks.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::path::PathBuf;
+
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::utils::PathSanitizer;
+
+mod setup;
+mod test_utils;
+
+#[test]
+fn test_search_eval_hook() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let test_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/addons/module_1/models/base_test_models.py")
+        .sanitize();
+
+    let Some(file_symbol) =
+        SyncOdoo::get_symbol_of_opened_file(&mut session, &PathBuf::from(&test_file))
+    else {
+        panic!("Failed to get file symbol for {}", test_file);
+    };
+
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&test_file).unwrap();
+
+    // Hover over closing parenthesis in call to `search` to verify its return type
+    let hover_text = test_utils::get_hover_markdown(&mut session, &file_symbol, &file_info, 33, 60)
+        .expect("Should get hover text for return type of search");
+
+    assert!(
+        hover_text.contains("BaseTestModel"),
+        "Hover over 'search' return type should show 'BaseTestModel' class. Got: {}",
+        hover_text
+    );
+}


### PR DESCRIPTION
The base model's search method should have an evaluation of EvaluationSymbolPtr::SELF.

This used to be the case, but it got lost in a refactor ([1]).

[1]: https://github.com/odoo/odoo-ls/commit/ca26c3e9f60da0ea13da1a3da97fa7123ad0e679