### PR TITLE
[FIX] remove wrong stop_on_type in features

### DIFF
--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -611,7 +611,7 @@ impl FeaturesUtils {
                                 Some(func_eval) => {
                                     let type_names: Vec<_> = func_eval.iter().flat_map(|eval|{
                                         let eval_symbol = eval.symbol.get_symbol_weak_transformed(session, context, &mut vec![], None);
-                                        let weak_eval_symbols = Symbol::follow_ref(&eval_symbol, session, context, true, false, None, None);
+                                        let weak_eval_symbols = Symbol::follow_ref(&eval_symbol, session, context, false, false, None, None);
                                         weak_eval_symbols.iter().map(|weak_eval_symbol| match weak_eval_symbol.upgrade_weak(){
                                             //if fct is a variable, it means that evaluation is None.
                                             Some(s_type) if s_type.borrow().typ() != SymType::VARIABLE => s_type.borrow().name().to_string(),

--- a/server/tests/data/addons/module_1/models/base_test_models.py
+++ b/server/tests/data/addons/module_1/models/base_test_models.py
@@ -33,6 +33,10 @@ class BaseTestModel(models.Model):
         self.env["pygls.tests.base_test_model"]
         self.search([("partner_id.country_id.code", ">", 0)])
 
+    def _get_partner_id(self):
+        partner = self.partner_id
+        return partner
+
 BaseOtherName = BaseTestModel
 baseInstance1 = BaseTestModel()
 baseInstance2 = BaseOtherName()

--- a/server/tests/test_get_symbol.rs
+++ b/server/tests/test_get_symbol.rs
@@ -143,11 +143,20 @@ fn test_hover_on_model_field_and_method() {
     );
 
     // Hover on a variable assignment (baseInstance1)
-    let hover_var = test_utils::get_hover_markdown(&mut session, &file_symbol, &file_info, 35, 0).unwrap_or_default();
+    let hover_var = test_utils::get_hover_markdown(&mut session, &file_symbol, &file_info, 39, 0).unwrap_or_default();
     assert!(
         hover_var.contains("BaseTestModel"),
         "Hover on variable should show type info"
     );
+
+    // Hover on a method returning a variable that is assigned to a relational field
+    // To check that the descriptor is correctly resolved
+    let hover_var = test_utils::get_hover_markdown(&mut session, &file_symbol, &file_info, 35, 10).unwrap_or_default();
+    assert!(
+        hover_var.contains("ResPartner"),
+        "Hover on variable should show type info"
+    );
+
 }
 
 #[test]


### PR DESCRIPTION
This is done because functions that have a
return value that refers to a field with a descriptor were not correctly transferred
and were showing Many2One instead of
ModelName

Related to https://github.com/odoo/odoo-ls/pull/520