### PR TITLE
[IMP] mark implicit class methods as such

### DIFF
--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -686,6 +686,11 @@ impl PythonArchBuilder {
                 }
             }
         }
+        // __init_subclass__ and __class_getitem__ are always classmethods
+        // see https://docs.python.org/3/reference/datamodel.html
+        if ["__init_subclass__", "__class_getitem__"].contains(&func_sym.name.as_str()) {
+            func_sym.is_class_method = true;
+        }
         if func_def.body[0].is_expr_stmt() {
             let expr: &ruff_python_ast::StmtExpr = func_def.body[0].as_expr_stmt().unwrap();
             if let Some(s) = expr.value.as_string_literal_expr() {

--- a/server/tests/data/python/lack_of_diagnostics/implicit_class_method_no_ols_01007.py
+++ b/server/tests/data/python/lack_of_diagnostics/implicit_class_method_no_ols_01007.py
@@ -1,0 +1,4 @@
+class SomeClass(object):
+    @classmethod
+    def __init_subclass__(cls):
+        super().__init_subclass__()

--- a/server/tests/diagnostics/implicit_class_method_no_ols_01007.rs
+++ b/server/tests/diagnostics/implicit_class_method_no_ols_01007.rs
@@ -1,0 +1,25 @@
+use odoo_ls_server::utils::PathSanitizer;
+use std::env;
+
+use crate::{setup::setup::*, test_utils::diag_on_line};
+
+#[test]
+fn implicit_class_method_no_ols_01007() {
+    // Setup server and session with test addons
+    let (mut odoo, config) = setup_server(false);
+    let mut session = create_init_session(&mut odoo, config);
+    let path = env::current_dir()
+        .unwrap()
+        .join("tests/data/python/lack_of_diagnostics/implicit_class_method_no_ols_01007.py")
+        .sanitize();
+    prepare_custom_entry_point(&mut session, &path);
+    let diagnostics = get_diagnostics_for_path(&mut session, &path);
+    // Verify that there are no OLS01007 on line 4 due to implicit classmethod of `__init_subclass__`
+    let line_diagnostics = diag_on_line(&diagnostics, 3);
+    assert_eq!(
+        line_diagnostics.len(),
+        0,
+        "Expected no diagnostics on line 4, but found some: {:?}",
+        line_diagnostics
+    );
+}

--- a/server/tests/diagnostics/mod.rs
+++ b/server/tests/diagnostics/mod.rs
@@ -17,3 +17,4 @@ pub mod ols03301;
 pub mod ols03302;
 pub mod ols04000_1_to_12;
 pub mod ols05000s;
+pub mod implicit_class_method_no_ols_01007;


### PR DESCRIPTION
`__init_subclass__` and `__class_getitem__` have a special behavior where they are implicitly classmethods without the decorator This is added here to avoid, for example, wrong diagnostics

It is IMP and FIX at the same time, but it should target 1.1.3 to fix the wrong diagnostic