### PR TITLE
[FIX] Safe range in get_local_tree

### DIFF
--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -1401,10 +1401,13 @@ impl Symbol {
 
     /**
      * Return the tree without the entrypoint tree.
+     * As long as the tree starts with the entrypoint tree,
+     * otherwise return the full tree, even if it is related to an entrypoint.
+     * Which is possible due to relative imports e.g. `from ..module import X`.
      */
     pub fn get_local_tree(&self) -> Tree {
         let (mut tree, entry) = self.get_tree_and_entry();
-        if let Some(entry) = entry {
+        if let Some(entry) = entry && tree.0.starts_with(&entry.borrow().tree) {
             tree.0.drain(0..entry.borrow().tree.len());
         }
         tree


### PR DESCRIPTION
A panic was happening on `werkzeug/middleware/proxy_fix.py` from site packages which had an import to `werkzeug/urls`, which has an arch builder hook calling get_local_tree on it So the resulting path is shorter than the EP path, causing an out of bounds panic.

This PR assures we cannot get an invalid range