### PR TITLE
[FIX] no panic when reading kwarg on env ref

### DIFF
--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -1242,10 +1242,10 @@ impl PythonArchEvalHooks {
         if !parameters.args[0].is_string_literal_expr() {
             return None;
         }
-        if parameters.keywords.len() == 1 {
-            if parameters.keywords[0].value.as_boolean_literal_expr().unwrap().value == false {
-                return None; // No need to process if the second argument (raise_if_not_found) is false
-            }
+        if parameters.keywords.len() == 1
+        // read raise_if_not_found keyword argument
+        && !parameters.keywords[0].value.as_boolean_literal_expr().map(|b| b.value).unwrap_or(true) {
+            return None; // No need to process if the second argument (raise_if_not_found) is false
         }
         let xml_id_expr = parameters.args[0].as_string_literal_expr().unwrap();
         let xml_id_str = xml_id_expr.value.to_str();


### PR DESCRIPTION
When reading `raise_if_not_found`, instead of unwrapping, this PR uses unwrap or true, so that if the user inputs a wrong type, or was still typing it, we do not panic.