### PR TITLE
[IMP] propagate SELF evaluations

### DIFF
--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -250,7 +250,8 @@ impl EvaluationSymbolWeak {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub enum EvaluationSymbolPtr {
     WEAK(EvaluationSymbolWeak),
-    SELF,
+    SELF(EvaluationSymbolWeak),
+    // Weak symbol is the current symbol pointed to self. Under subclasses this would get overridden on evaluation
     ARG(u32),
     DOMAIN,
     NONE,
@@ -411,12 +412,9 @@ impl Evaluation {
         }
     }
 
-    pub fn new_self() -> Self {
+    pub fn new_self(base: Weak<RefCell<Symbol>>, instance: Option<bool>) -> Self {
         Self {
-            symbol: EvaluationSymbol {
-                sym: EvaluationSymbolPtr::SELF,
-                get_symbol_hook: None,
-            },
+            symbol: EvaluationSymbol::new_self(None, base, instance),
             value: None,
             range: None
         }
@@ -848,7 +846,7 @@ impl Evaluation {
                     return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                 }
                 let base_eval_ptrs: Vec<EvaluationSymbolPtr> = base_evals.iter().map(|base_eval| {
-                    let base_sym_weak_eval_base = base_eval.symbol.get_symbol_weak_transformed(session, context, &mut diagnostics, None);
+                    let base_sym_weak_eval_base = base_eval.symbol.get_symbol(session, context, &mut diagnostics, None);
                     Symbol::follow_ref(&base_sym_weak_eval_base, session, context, true, false, None, None)
                 }).flatten().collect();
 
@@ -877,7 +875,7 @@ impl Evaluation {
                                         if class_sym_weak_eval.upgrade_weak().unwrap().borrow().typ() != SymType::CLASS{
                                             return None;
                                         }
-                                        let class_sym_weak_eval = class_sym_weak_eval.as_weak();
+                                        let class_sym_weak_eval = class_sym_weak_eval.get_weak();
                                         if class_sym_weak_eval.instance.unwrap_or(false) {
                                             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS01005, &[]){
                                                 diagnostics.push(Diagnostic {
@@ -903,8 +901,8 @@ impl Evaluation {
                                                     &object_or_type_eval[0].symbol.get_symbol(
                                                         session, context, &mut diagnostics, Some(parent.clone())),
                                                         session, &mut None, false, false, None, None)[0];
-                                                if object_or_type_weak_eval.is_weak() {
-                                                    is_instance = Some(object_or_type_weak_eval.as_weak().instance.unwrap_or(default_instance));
+                                                if object_or_type_weak_eval.has_weak() {
+                                                    is_instance = Some(object_or_type_weak_eval.get_weak().instance.unwrap_or(default_instance));
                                                 } else {
                                                     is_instance = Some(default_instance);
                                                 }
@@ -943,7 +941,7 @@ impl Evaluation {
                                 if let Some((super_class, instance)) = super_class{
                                     evals.push(Evaluation{
                                         symbol: EvaluationSymbol {
-                                            sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
+                                            sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{
                                                 weak: super_class,
                                                 context: HashMap::new(),
                                                 instance,
@@ -1040,9 +1038,16 @@ impl Evaluation {
                             }
                         }
                         if base_sym.borrow().evaluations().is_some() {
-                            let call_parent = match base_sym_weak_eval.context.get(&S!("base_attr")){
-                                Some(ContextValue::SYMBOL(s)) => s.clone(),
-                                _ => Weak::new()
+                            let (call_parent, base_is_self) = match (
+                                base_sym_weak_eval.context.get(&S!("base_attr")),
+                                base_sym_weak_eval.context.get(&S!("base_is_self")),
+                            )
+                            {
+                                (
+                                    Some(ContextValue::SYMBOL(s)),
+                                    Some(ContextValue::BOOLEAN(base_is_self)),
+                                ) => (s.clone(), base_is_self.clone()),
+                                _ => (Weak::new(), false)
                             };
                             if session.sync_odoo.evaluation_search.is_some() {
                                 Evaluation::search_reference_in_arg(session, expr, &parent);
@@ -1057,7 +1062,8 @@ impl Evaluation {
                                     on_instance,
                                     ));
                             }
-                            context.as_mut().unwrap().insert(S!("base_call"), ContextValue::SYMBOL(call_parent));
+                            context.as_mut().unwrap().insert(S!("base_call"), ContextValue::SYMBOL(call_parent.clone()));
+                            context.as_mut().unwrap().insert(S!("base_is_self"), ContextValue::BOOLEAN(base_is_self));
                             context.as_mut().unwrap().insert(S!("parameters"), ContextValue::ARGUMENTS(expr.arguments.clone()));
                             context.as_mut().unwrap().insert(S!("is_in_validation"), ContextValue::BOOLEAN(is_in_validation));
                             for eval in base_sym.borrow().evaluations().unwrap().iter() {
@@ -1072,6 +1078,7 @@ impl Evaluation {
                                 });
                             }
                             context.as_mut().unwrap().remove(&S!("base_call"));
+                            context.as_mut().unwrap().remove(&S!("base_is_self"));
                             context.as_mut().unwrap().remove(&S!("parameters"));
                             context.as_mut().unwrap().remove(&S!("is_in_validation"));
                         }
@@ -1092,6 +1099,7 @@ impl Evaluation {
                     }
                     let bases = Symbol::follow_ref(&base_ref, session, context, false, false, None, None);
                     for ibase in bases.iter() {
+                        let base_is_self = matches!(ibase, EvaluationSymbolPtr::SELF(_));
                         let base_loc = ibase.upgrade_weak();
                         if let Some(base_loc) = base_loc {
                             let file = base_loc.borrow().get_file().clone();
@@ -1106,14 +1114,14 @@ impl Evaluation {
                                     }
                                 }
                             }
-                            let is_super = ibase.is_weak() && ibase.as_weak().is_super;
+                            let is_super = ibase.has_weak() && ibase.get_weak().is_super;
                             let (attributes, mut attributes_diagnostics) = base_loc.borrow().get_member_symbol(session, &expr.attr.to_string(), module.clone(), false, false, false, true, is_super);
                             for diagnostic in attributes_diagnostics.iter_mut(){
                                 diagnostic.range = FileMgr::textRange_to_temporary_Range(&expr.range())
                             }
                             diagnostics.extend(attributes_diagnostics);
                             if !attributes.is_empty() {
-                                let is_instance = ibase.as_weak().instance.unwrap_or(false);
+                                let is_instance = ibase.get_weak().instance.unwrap_or(false);
                                 attributes.iter().for_each(|attribute|{
                                     let instance = match attribute.borrow().typ() {
                                         SymType::CLASS => match for_annotation{
@@ -1132,6 +1140,7 @@ impl Evaluation {
                                     match eval.symbol.sym {
                                         EvaluationSymbolPtr::WEAK(ref mut weak) => {
                                             weak.context.insert(S!("base_attr"), ContextValue::SYMBOL(Rc::downgrade(&base_loc)));
+                                            weak.context.insert(S!("base_is_self"), ContextValue::BOOLEAN(base_is_self));
                                             weak.context.insert(S!("is_attr_of_instance"), ContextValue::BOOLEAN(is_instance));
                                         },
                                         _ => {}
@@ -1223,7 +1232,7 @@ impl Evaluation {
                                 // TODO: handle generic types
                                 let mut new_base = base.clone();
                                 if for_annotation {
-                                    new_base.as_mut_weak().instance = Some(true);
+                                    new_base.get_mut_weak().instance = Some(true);
                                 }
                                 evals.push(Evaluation {
                                     symbol: EvaluationSymbol {
@@ -1238,7 +1247,7 @@ impl Evaluation {
                         }
                         _ => {}
                     }
-                    if !base.is_weak() {
+                    if !base.has_weak() {
                         continue;
                     }
                     let base = base.upgrade_weak().unwrap();
@@ -1282,7 +1291,7 @@ impl Evaluation {
                                 context.as_mut().unwrap().remove(&S!("is_in_validation"));
                                 context.as_mut().unwrap().insert(S!("range"), old_range.unwrap());
                             }
-                            if let EvaluationSymbolPtr::SELF = get_item_eval.symbol.get_symbol_ptr(){
+                            if let EvaluationSymbolPtr::SELF(_) = get_item_eval.symbol.get_symbol_ptr(){
                                 // Evaluate to the base itself
                                 // For example for models, since you get the same type of recordset when subscripted
                                 evals.push(Evaluation{
@@ -1548,7 +1557,7 @@ impl Evaluation {
                     //if we have multiple matches, it means that that ast can reference it multiple times, but we only want to know if that ast matches or not
                     break;
                 }
-                if eval.symbol.sym.is_weak() && let Some(weak) = eval.symbol.sym.as_weak().weak.upgrade() {
+                if eval.symbol.sym.has_weak() && let Some(weak) = eval.symbol.sym.get_weak().weak.upgrade() {
                     if let Some(evaluation_search_sym) = evaluation_search.as_symbol() {
                         if Rc::ptr_eq(&weak, &evaluation_search_sym) {
                             let file = parent.borrow().get_file().unwrap().upgrade().unwrap();
@@ -2027,9 +2036,9 @@ impl EvaluationSymbol {
         Self { sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: symbol, context, instance: instance, is_super: false}), get_symbol_hook }
     }
 
-    pub fn new_self(get_symbol_hook: Option<GetSymbolHook>) -> EvaluationSymbol {
+    pub fn new_self(get_symbol_hook: Option<GetSymbolHook>, base: Weak<RefCell<Symbol>>, instance: Option<bool>) -> EvaluationSymbol {
         Self {
-            sym: EvaluationSymbolPtr::SELF,
+            sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{weak: base, context: HashMap::new(), instance, is_super: false}),
             get_symbol_hook,
         }
     }
@@ -2040,9 +2049,8 @@ impl EvaluationSymbol {
             EvaluationSymbolPtr::ARG(_) => None,
             EvaluationSymbolPtr::NONE => None,
             EvaluationSymbolPtr::UNBOUND(_) => None,
-            EvaluationSymbolPtr::SELF => Some(true),
             EvaluationSymbolPtr::DOMAIN => Some(false), //domain is always used for types
-            EvaluationSymbolPtr::WEAK(w) => w.instance
+            EvaluationSymbolPtr::SELF(w) | EvaluationSymbolPtr::WEAK(w) => w.instance,
         }
     }
 
@@ -2062,7 +2070,7 @@ impl EvaluationSymbol {
 
     /* Execute the hook, then use context to return an EvaluationSymbolWeak if possible, else return an empty one */
     pub fn get_symbol_as_weak(&self, session: &mut SessionInfo, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<Rc<RefCell<Symbol>>>) -> EvaluationSymbolWeak {
-        let eval = EvaluationSymbol::get_symbol(&self, session, context, diagnostics, scope);
+        let eval = self.get_symbol(session, context, diagnostics, scope);
         match eval {
             EvaluationSymbolPtr::WEAK(w) => {
                 w
@@ -2072,7 +2080,7 @@ impl EvaluationSymbol {
             EvaluationSymbolPtr::NONE => EvaluationSymbolWeak{weak: Weak::new(), context: HashMap::new(), instance: Some(false), is_super: false},
             EvaluationSymbolPtr::UNBOUND(_) => EvaluationSymbolWeak{weak: Weak::new(), context: HashMap::new(), instance: Some(false), is_super: false},
             EvaluationSymbolPtr::DOMAIN => EvaluationSymbolWeak{weak: Weak::new(), context: HashMap::new(), instance: Some(false), is_super: false},
-            EvaluationSymbolPtr::SELF => {
+            EvaluationSymbolPtr::SELF(_) => {
                 let class = context.as_ref().
                 and_then(|context| context.get(&S!("parent_for")).or(context.get(&S!("base_attr"))))
                 .unwrap_or(&ContextValue::BOOLEAN(false));
@@ -2086,7 +2094,7 @@ impl EvaluationSymbol {
 
     /* Execute Hook, then return the effective EvaluationSymbolPtr, but transformed as EvaluationSmbolWeak if possible */
     pub fn get_symbol_weak_transformed(&self, session: &mut SessionInfo, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<Rc<RefCell<Symbol>>>) -> EvaluationSymbolPtr {
-        let eval = EvaluationSymbol::get_symbol(&self, session, context, diagnostics, scope);
+        let eval = self.get_symbol(session, context, diagnostics, scope);
         match eval {
             EvaluationSymbolPtr::WEAK(_) => {
                 eval
@@ -2096,11 +2104,26 @@ impl EvaluationSymbol {
             EvaluationSymbolPtr::NONE => eval,
             EvaluationSymbolPtr::UNBOUND(_) => eval,
             EvaluationSymbolPtr::DOMAIN => eval,
-            EvaluationSymbolPtr::SELF => {
+            EvaluationSymbolPtr::SELF(_) => {
+                let default = EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Weak::new(), context: HashMap::new(), instance: Some(false), is_super: false});
                 let class = context.as_ref().and_then(|context| context.get(&S!("base_call"))).unwrap_or(&ContextValue::BOOLEAN(false));
-                match class {
-                    ContextValue::SYMBOL(s) => EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: s.clone(), context: HashMap::new(), instance: Some(true), is_super: false}),
-                    _ => EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Weak::new(), context: HashMap::new(), instance: Some(false), is_super: false})
+                let class_sym = match class {
+                    ContextValue::SYMBOL(s) => match s.upgrade() {
+                        Some(sym) => sym,
+                        None => {return default;}
+                    },
+                    _ => {return default;}
+                };
+                let eval_symbol_weak = EvaluationSymbolWeak{weak: Rc::downgrade(&class_sym), context: HashMap::new(), instance: Some(true), is_super: false};
+                let base_is_self = context
+                    .as_ref()
+                    .and_then(|context| context.get(&S!("base_is_self")))
+                    .unwrap_or(&ContextValue::BOOLEAN(false))
+                    .as_bool();
+                if base_is_self {
+                    EvaluationSymbolPtr::SELF(eval_symbol_weak)
+                } else {
+                    EvaluationSymbolPtr::WEAK(eval_symbol_weak)
                 }
             }
         }
@@ -2129,35 +2152,35 @@ impl EvaluationSymbolPtr {
 
     pub fn is_expired_if_weak(&self) -> bool {
         match self {
-            EvaluationSymbolPtr::WEAK(w) => w.weak.is_expired(),
+            EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) => w.weak.is_expired(),
             _ => false
         }
     }
 
     pub fn upgrade_weak(&self) -> Option<Rc<RefCell<Symbol>>> {
         match self {
-            EvaluationSymbolPtr::WEAK(w) => w.weak.upgrade(),
+            EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) => w.weak.upgrade(),
             _ => None
         }
     }
 
-    pub(crate) fn is_weak(&self) -> bool {
+    pub(crate) fn has_weak(&self) -> bool {
         match self {
-            EvaluationSymbolPtr::WEAK(_) => true,
+            EvaluationSymbolPtr::WEAK(_) | EvaluationSymbolPtr::SELF(_) => true,
             _ => false
         }
     }
 
-    pub(crate) fn as_weak(&self) -> &EvaluationSymbolWeak {
+    pub(crate) fn get_weak(&self) -> &EvaluationSymbolWeak {
         match self {
-            EvaluationSymbolPtr::WEAK(w) => &w,
+            EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) => &w,
             _ => panic!("Not an EvaluationSymbolWeak")
         }
     }
 
-    pub(crate) fn as_mut_weak(&mut self) -> &mut EvaluationSymbolWeak {
+    pub(crate) fn get_mut_weak(&mut self) -> &mut EvaluationSymbolWeak {
         match self {
-            EvaluationSymbolPtr::WEAK(w) => w,
+            EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) => w,
             _ => panic!("Not an EvaluationSymbolWeak")
         }
     }

--- a/server/src/core/model.rs
+++ b/server/src/core/model.rs
@@ -305,4 +305,29 @@ impl Model {
             }
         }
     }
+
+    pub fn inherits_from(&self, session: &mut SessionInfo, base: &Rc<RefCell<Model>>) -> bool {
+        fn inner(this: &Model, session: &mut SessionInfo, base: &Rc<RefCell<Model>>, checked: &mut HashSet<OYarn>) -> bool {
+            if checked.contains(&this.name) {
+                return false;
+            }
+            checked.insert(this.name.clone());
+            for symbol in this.symbols.iter() {
+                let sym_ref = symbol.borrow();
+                let Some(model_data) = &sym_ref.as_class_sym()._model else {continue};
+                for inherit in model_data.inherit.iter() {
+                    if inherit == &base.borrow().name {
+                        return true;
+                    }
+                    if let Some(model) = session.sync_odoo.models.get(inherit).cloned() {
+                        if inner(&model.borrow(), session, base, checked) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        }
+        inner(self, session, base, &mut HashSet::new())
+    }
 }

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -756,7 +756,7 @@ impl PythonArchEval {
                         let mut var_bw = function_sym.borrow_mut();
                         let is_class_method = var_bw.as_func().is_class_method;
                         let symbol = var_bw.as_func_mut().symbols.get(&OYarn::from(arg.parameter.name.id.to_string())).unwrap().get(&0).unwrap().get(0).unwrap(); //get first declaration
-                        symbol.borrow_mut().evaluations_mut().unwrap().push(Evaluation::eval_from_symbol(&Rc::downgrade(self.sym_stack.last().unwrap()), Some(!is_class_method)));
+                        symbol.borrow_mut().evaluations_mut().unwrap().push(Evaluation::new_self(Rc::downgrade(self.sym_stack.last().unwrap()), Some(!is_class_method)));
                         is_first = false;
                         continue;
                     }
@@ -1022,7 +1022,11 @@ impl PythonArchEval {
                     None
                 ).len() > 0
             ){
-                func_sym.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                let mut func_ref_mut = func_sym.borrow_mut();
+                if let Some(base) = func_ref_mut.get_in_parents(&vec![SymType::CLASS], true){
+                    let is_class_method = func_ref_mut.as_func().is_class_method.clone();
+                    func_ref_mut.set_evaluations(vec![Evaluation::new_self(base, Some(!is_class_method))]);
+                }
                 return;
             }
             for eval in evaluations.iter_mut() { //as this is an evaluation, we need to set the instance to true

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -31,6 +31,19 @@ use super::python_arch_eval::PythonArchEval;
 
 type PythonArchEvalHookFile = fn (odoo: &mut SessionInfo, entry: &Rc<RefCell<EntryPoint>>, file_symbol: Rc<RefCell<Symbol>>, symbol: Rc<RefCell<Symbol>>);
 
+fn get_base_model_symbol(odoo: &mut SyncOdoo) -> Option<Rc<RefCell<Symbol>>> {
+    let base_model_tree = if compare_semver(odoo.full_version.as_str(), "18.1") >= Ordering::Equal {
+        (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel")])
+    } else {
+        (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel")])
+    };
+    let base_model_symbol = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &base_model_tree, u32::MAX);
+    if !base_model_symbol.is_empty() {
+        base_model_symbol.first().cloned()
+    } else {
+        None
+    }
+}
 pub struct PythonArchEvalFileHook {
     pub odoo_entry: bool,
     pub trees: Vec<(OYarn, OYarn, (Vec<OYarn>, Vec<OYarn>))>, //if tree content is set, will provide symbol in file content instead of the file symbol to func
@@ -353,7 +366,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
         }
         if let Some(boolean) = boolean_field.first() {
             let mut eval = Evaluation::eval_from_symbol(&Rc::downgrade(&boolean), Some(true));
-            let weak = eval.symbol.get_mut_symbol_ptr().as_mut_weak();
+            let weak = eval.symbol.get_mut_symbol_ptr().get_mut_weak();
             weak.context.insert(S!("compute"), ContextValue::STRING(S!("_compute_global")));
             symbol.borrow_mut().set_evaluations(vec![eval]);
         }
@@ -521,57 +534,65 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__iter__")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__iter__")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__getitem__")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__getitem__")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_env")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_env")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("sudo")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("sudo")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("create")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("create")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered_domain")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered_domain")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("search")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("search")]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
         let search = symbol.borrow();
         let func = search.as_func();
         if func.args.len() > 1 {
@@ -588,43 +609,49 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("browse")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("browse")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_company")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_company")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_context")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_context")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_prefetch")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_prefetch")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_user")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_user")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("exists")])),
                         (Sy!("18.1"), Sy!("999.0"), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("exists")]))],
                         if_exist_only: true,
-                        func: |_odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
-        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+                        func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: Rc<RefCell<Symbol>>| {
+        let base_model = get_base_model_symbol(odoo);
+        symbol.borrow_mut().set_evaluations(vec![Evaluation::new_self(Rc::downgrade(&base_model.unwrap()), Some(true))]);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![(Sy!("0.0"), Sy!("18.1"), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Id"), Sy!("__get__")])),
@@ -1197,7 +1224,10 @@ impl PythonArchEvalHooks {
         let Some(Expr::StringLiteral(expr)) = arguments.args.first() else {return diagnostics};
         let returns_str = expr.value.to_string();
         if returns_str == S!("self"){
-            func_sym.borrow_mut().set_evaluations(vec![Evaluation::new_self()]);
+            if let Some(base) = func_sym.borrow().get_in_parents(&vec![SymType::CLASS], true){
+                let is_class_method = func_sym.borrow().as_func().is_class_method.clone();
+                func_sym.borrow_mut().set_evaluations(vec![Evaluation::new_self(base, Some(!is_class_method))]);
+            }
             return diagnostics;
         }
         let Some(model) = session.sync_odoo.models.get(&oyarn!("{}", returns_str)).cloned() else {

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -369,7 +369,7 @@ impl PythonOdooBuilder {
             // base_model_syms empty so sym cannot be a model, otherwise we would have found it earlier
             return false;
         }
-        if !symbol.borrow().as_class_sym().inherits(&base_model_syms[0], &mut None) {
+        if !symbol.borrow().as_class_sym().inherits(session, &base_model_syms[0], &mut None) {
             return false;
         }
         // Check if we have a _register = False

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -417,8 +417,8 @@ impl PythonValidator {
                         continue;
                     }
                     'related_check: {
-                        if let Some(related_field_name) = eval_weak.as_weak().context.get(&S!("related")).filter(|val| matches!(val, ContextValue::STRING(_))).map(|ctx_val| ctx_val.as_string()) {
-                            let Some(special_arg_range) = eval_weak.as_weak().context.get(&S!("related_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
+                        if let Some(related_field_name) = eval_weak.get_weak().context.get(&S!("related")).filter(|val| matches!(val, ContextValue::STRING(_))).map(|ctx_val| ctx_val.as_string()) {
+                            let Some(special_arg_range) = eval_weak.get_weak().context.get(&S!("related_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                 break 'related_check;
                             };
                             let syms = PythonArchEval::get_nested_sub_field(session, &related_field_name, class.clone(), maybe_from_module.clone());
@@ -478,8 +478,8 @@ impl PythonValidator {
                         }
                     }
                     'comodel_check: {
-                        if let Some(comodel_field_name) = eval_weak.as_weak().context.get(&S!("comodel_name")).map(|ctx_val| ctx_val.as_string()) {
-                            let Some(special_arg_range) = eval_weak.as_weak().context.get(&S!("comodel_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
+                        if let Some(comodel_field_name) = eval_weak.get_weak().context.get(&S!("comodel_name")).map(|ctx_val| ctx_val.as_string()) {
+                            let Some(special_arg_range) = eval_weak.get_weak().context.get(&S!("comodel_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                 break 'comodel_check;
                             };
                             let Some(file_symbol) = class_ref.get_file().and_then(|file| file.upgrade()) else {
@@ -513,7 +513,7 @@ impl PythonValidator {
                         }
                     }
                     for special_fn_field_name in ["compute", "inverse", "search"]{
-                        let Some(method_name) = eval_weak.as_weak().context.get(&S!(special_fn_field_name)).map(|ctx_val| ctx_val.as_string()) else {
+                        let Some(method_name) = eval_weak.get_weak().context.get(&S!(special_fn_field_name)).map(|ctx_val| ctx_val.as_string()) else {
                             continue;
                         };
                         let Some(module) = class_ref.find_module() else {
@@ -530,7 +530,7 @@ impl PythonValidator {
                         );
                         let method_found = !symbols.is_empty();
                         if !method_found{
-                            let Some(arg_range) = eval_weak.as_weak().context.get(&format!("{special_fn_field_name}_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
+                            let Some(arg_range) = eval_weak.get_weak().context.get(&format!("{special_fn_field_name}_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };
                             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03018, &[&method_name]) {
@@ -542,8 +542,8 @@ impl PythonValidator {
 
                         }
                     }
-                    if let Some(inverse_name) = eval_weak.as_weak().context.get(&S!("inverse_name")).map(|ctx_val| ctx_val.as_string()) {
-                        let Some(model_name) = eval_weak.as_weak().context.get(&S!("comodel_name")).map(|ctx_val| ctx_val.as_string()) else {
+                    if let Some(inverse_name) = eval_weak.get_weak().context.get(&S!("inverse_name")).map(|ctx_val| ctx_val.as_string()) {
+                        let Some(model_name) = eval_weak.get_weak().context.get(&S!("comodel_name")).map(|ctx_val| ctx_val.as_string()) else {
                             continue;
                         };
                         let Some(model) = session.sync_odoo.models.get(&oyarn!("{}", model_name)).cloned() else {
@@ -557,7 +557,7 @@ impl PythonValidator {
                             main_sym.clone().borrow().get_member_symbol(session, &inverse_name, Some(module.clone()), false, true, false, true, false).0
                         ).collect();
                         if symbols.is_empty() {
-                            let Some(arg_range) = eval_weak.as_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
+                            let Some(arg_range) = eval_weak.get_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };
                             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03021, &[&inverse_name, &model_name]) {
@@ -568,7 +568,7 @@ impl PythonValidator {
                             }
                         }
                         if symbols.iter().any(|sym| !sym.borrow().is_specific_field(session, &["Many2one", "Many2oneReference"])) {
-                            let Some(arg_range) = eval_weak.as_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
+                            let Some(arg_range) = eval_weak.get_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };
                             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03022, &[]) {
@@ -597,13 +597,13 @@ impl PythonValidator {
                                 }
                             }
                             for comodel_eval_weak in comodel_eval_weaks {
-                                let Some(model_name) = comodel_eval_weak.as_weak().context.get(&S!("comodel_name")).map(|ctx_val| ctx_val.as_string()) else {
+                                let Some(model_name) = comodel_eval_weak.get_weak().context.get(&S!("comodel_name")).map(|ctx_val| ctx_val.as_string()) else {
                                     continue;
                                 };
                                 if model_name == model_data.name.to_string() { // valid
                                     continue;
                                 }
-                                let Some(arg_range) = eval_weak.as_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
+                                let Some(arg_range) = eval_weak.get_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                     continue;
                                 };
                                 if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03023, &[&inverse_name, &model_data.name, &model_name]) {

--- a/server/src/core/symbols/class_symbol.rs
+++ b/server/src/core/symbols/class_symbol.rs
@@ -8,6 +8,7 @@ use crate::constants::{OYarn, SymType};
 use crate::core::file_mgr::NoqaInfo;
 use crate::core::model::ModelData;
 use crate::Sy;
+use crate::threads::SessionInfo;
 use crate::utils::NoHashBuilder;
 
 use super::symbol::Symbol;
@@ -61,9 +62,12 @@ impl ClassSymbol {
         res
     }
 
-    pub fn inherits(&self, base: &Rc<RefCell<Symbol>>, checked: &mut Option<PtrWeakHashSet<Weak<RefCell<Symbol>>>>) -> bool {
+    pub fn inherits(&self, session: &mut SessionInfo, base: &Rc<RefCell<Symbol>>, checked: &mut Option<PtrWeakHashSet<Weak<RefCell<Symbol>>>>) -> bool {
         if checked.is_none() {
             *checked = Some(PtrWeakHashSet::new());
+        }
+        if base.borrow().typ() != SymType::CLASS {
+            return false;
         }
         for base_weak in self.bases.iter() {
             let b = match base_weak.upgrade(){
@@ -74,10 +78,21 @@ impl ClassSymbol {
                 return true;
             }
             if checked.as_ref().unwrap().contains(&b) {
-                return false;
+                continue;
             }
             checked.as_mut().unwrap().insert(b.clone());
-            if b.borrow().as_class_sym().inherits(base, checked) {
+            if b.borrow().as_class_sym().inherits(session, base, checked) {
+                return true;
+            }
+        }
+        if let (Some(self_model), Some(base_model)) = (
+            self._model.as_ref().and_then(|model_data|
+                session.sync_odoo.models.get(&model_data.name).cloned()
+            ),
+            base.borrow().as_class_sym()._model.as_ref().and_then(|model_data|
+                session.sync_odoo.models.get(&model_data.name).cloned()
+            )){
+            if self_model.borrow().inherits_from(session, &base_model) {
                 return true;
             }
         }

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -2156,7 +2156,7 @@ impl Symbol {
                                     if !get_result.weak.is_expired() {
                                         let mut eval = Evaluation::eval_from_symbol(&get_result.weak, get_result.instance);
                                         match eval.symbol.get_mut_symbol_ptr() {
-                                            EvaluationSymbolPtr::WEAK(weak) => {
+                                            EvaluationSymbolPtr::WEAK(weak) | EvaluationSymbolPtr::SELF(weak)=> {
                                                 if let Some(eval_sym_rc) = weak.weak.upgrade(){
                                                     if Rc::ptr_eq(&eval_sym_rc, &symbol_rc){
                                                         continue;
@@ -2182,8 +2182,8 @@ impl Symbol {
             for eval in v.evaluations.iter() {
                 let ctx = &mut Some(symbol_context.clone().into_iter().chain(context.clone().unwrap_or(HashMap::new()).into_iter()).collect::<HashMap<_, _>>());
                 let mut sym = eval.symbol.get_symbol(session, ctx, diagnostics, None);
-                match sym {
-                    EvaluationSymbolPtr::WEAK(ref mut w) => {
+                match &mut sym {
+                    EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w)=> {
                         if let Some(base_attr) = symbol_context.get(&S!("base_attr")) {
                             if !w.context.get(&S!("is_attr_of_instance")).map(|x| x.as_bool()).unwrap_or(false) {
                                 w.context.insert(S!("base_attr"), base_attr.clone());
@@ -2220,11 +2220,12 @@ impl Symbol {
             // can't find the tree symbol, stop here
             return default_result;
         }
-        let EvaluationSymbolPtr::WEAK(w) = evaluation else {
-            // Non-weak evaluations are final
-            return default_result
+        let eval_with_weak = match evaluation {
+            EvaluationSymbolPtr::WEAK(weak)
+            | EvaluationSymbolPtr::SELF(weak) => weak,
+            _ => return default_result // Non-weak evaluations are final
         };
-        let Some(symbol) = w.weak.upgrade() else {
+        let Some(symbol) = eval_with_weak.weak.upgrade() else {
             return default_result;
         };
         if stop_on_value {
@@ -2237,15 +2238,19 @@ impl Symbol {
             }
         }
         //return a list of all possible evaluation: a weak ptr to the final symbol, and a bool indicating if this is an instance or not
-        let mut work_queue = Symbol::next_refs(session, symbol.clone(), context, &w.context, stop_on_type, &mut vec![]);
+        let mut work_queue = Symbol::next_refs(session, symbol.clone(), context, &eval_with_weak.context, stop_on_type, &mut vec![]);
         if work_queue.is_empty() {
             return default_result;
         }
-        if w.instance.is_some_and(|v| v) {
+        if eval_with_weak.instance.is_some_and(|v| v) {
             //if the previous evaluation was set to True, we want to keep it
             work_queue = work_queue.into_iter().map(|mut r| {
-                if let EvaluationSymbolPtr::WEAK(ref mut weak) = r {
+                match r {
+                    EvaluationSymbolPtr::WEAK(ref mut weak)
+                    | EvaluationSymbolPtr::SELF(ref mut weak) =>  {
                     weak.instance = Some(true);
+                    },
+                    _ => {}
                 }
                 r
             }).collect();
@@ -2254,10 +2259,14 @@ impl Symbol {
         let mut visited: PtrWeakHashSet<Weak<RefCell<Symbol>>> = PtrWeakHashSet::new();
         let can_eval_external = !symbol.borrow().is_external();
         while let Some(current_eval) = work_queue.pop_front() {
-            let EvaluationSymbolPtr::WEAK(next_ref_weak) = &current_eval else  {
+            let next_ref_weak = match &current_eval {
+                EvaluationSymbolPtr::WEAK(weak)
+                | EvaluationSymbolPtr::SELF(weak) => weak,
+                _ => {
                 // Non-weak references are final
                 results.push(current_eval);
                 continue;
+                }
             };
             let Some(sym_rc) = next_ref_weak.weak.upgrade() else {
                 // Discard evaluation to expired reference
@@ -2307,8 +2316,12 @@ impl Symbol {
                     // /!\ we want to keep instance = True if previous evaluation was set to True!
                     if next_ref_weak_instance.is_some_and(|v| v) {
                         next_sym_refs = next_sym_refs.into_iter().map(|mut next_results| {
-                            if let EvaluationSymbolPtr::WEAK(weak) = &mut next_results {
-                                weak.instance = Some(true);
+                            match next_results {
+                                EvaluationSymbolPtr::WEAK(ref mut weak)
+                                | EvaluationSymbolPtr::SELF(ref mut weak) =>  {
+                                    weak.instance = Some(true);
+                                },
+                                _ => {}
                             }
                             next_results
                         }).collect();
@@ -2335,7 +2348,7 @@ impl Symbol {
         if let Some(stop_on_tree_syms) = stop_on_tree_syms.as_ref() {
             results.retain(|r| {
                 match r {
-                    EvaluationSymbolPtr::WEAK(weak) => {
+                    EvaluationSymbolPtr::WEAK(weak) | EvaluationSymbolPtr::SELF(weak) => {
                         if let Some(sym_rc) = weak.weak.upgrade() {
                             stop_on_tree_syms.iter().any(|s| Rc::ptr_eq(s, &sym_rc))
                         } else {

--- a/server/src/core/symbols/variable_symbol.rs
+++ b/server/src/core/symbols/variable_symbol.rs
@@ -71,7 +71,7 @@ impl VariableSymbol {
             for eval_weak in eval_weaks.iter() {
                 if let Some(symbol) = eval_weak.upgrade_weak() {
                     if ["Many2one", "One2many", "Many2many"].contains(&symbol.borrow().name().as_str()) {
-                        let Some(comodel) = eval_weak.as_weak().context.get("comodel_name") else {
+                        let Some(comodel) = eval_weak.get_weak().context.get("comodel_name") else {
                             continue;
                         };
                         let Some(model) = session.sync_odoo.models.get(&oyarn!("{}", &comodel.as_string())).cloned() else {

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -866,7 +866,7 @@ fn complete_attribut(session: &mut SessionInfo, file: &Rc<RefCell<Symbol>>, attr
                 let parent_sym_types = Symbol::follow_ref(&parent_sym_eval, session, &mut None, false, false, None, None);
                 for parent_sym_type in parent_sym_types.iter() {
                     let Some(parent_sym) = parent_sym_type.upgrade_weak() else {continue};
-                    add_model_attributes(session, &mut items, from_module.clone(), parent_sym, parent_sym_eval.as_weak().is_super, false, false, attr.attr.id.as_str(), &None)
+                    add_model_attributes(session, &mut items, from_module.clone(), parent_sym, parent_sym_eval.get_weak().is_super, false, false, attr.attr.id.as_str(), &None)
                 }
             }
         }

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -89,7 +89,7 @@ impl FeaturesUtils {
             );
         }
         if !followed_evals.iter().any(|eval|
-            eval.is_weak() && eval.as_weak().weak.upgrade().map(|sym| sym.borrow().is_field_class(session)).unwrap_or(false)
+            eval.has_weak() && eval.get_weak().weak.upgrade().map(|sym| sym.borrow().is_field_class(session)).unwrap_or(false)
         ) {
             return vec![];
         }
@@ -553,7 +553,7 @@ impl FeaturesUtils {
                 }
                 continue;
             };
-            let mut context = Some(eval_symbol.as_weak().context.clone());
+            let mut context = Some(eval_symbol.get_weak().context.clone());
             let evaluation_ptrs = Symbol::follow_ref(&eval_symbol, session, &mut context, false, false, None, None);
 
             let symbol_type = symbol.borrow().typ();
@@ -627,12 +627,13 @@ impl FeaturesUtils {
             return TypeInfo::VALUE(S!(""));
         }
         match eval {
-            EvaluationSymbolPtr::WEAK(eval_weak) => {
+            EvaluationSymbolPtr::WEAK(eval_weak) | EvaluationSymbolPtr::SELF(eval_weak)  => {
                 if let Some(inferred_type) = eval.upgrade_weak() {
                     let inferred_type = inferred_type.borrow();
                     match inferred_type.typ() {
                         SymType::FUNCTION if !inferred_type.as_func().is_property => {
-                            let call_parent = match eval.as_weak().context.get(&S!("base_attr")){
+                            let base_attr_ctx_ref = eval.get_weak().context.get(&S!("base_attr")).or(context.as_mut().and_then(|ctx| ctx.get(&S!("base_attr"))));
+                            let call_parent = match base_attr_ctx_ref {
                                 Some(ContextValue::SYMBOL(s)) => s.clone(),
                                 _ => {
                                     let parent = inferred_type.parent().and_then(|parent_weak| parent_weak.upgrade());
@@ -692,7 +693,7 @@ impl FeaturesUtils {
         let mut single_func_eval = false;
         //variable name
         if inferred_types.len() == 1
-        && inferred_types[0].eval_ptr.is_weak()
+        && inferred_types[0].eval_ptr.has_weak()
         && inferred_types[0].eval_ptr.upgrade_weak().unwrap().borrow().typ() == SymType::FUNCTION
         && !inferred_types[0].eval_ptr.upgrade_weak().unwrap().borrow().as_func().is_property {
             //display 'def' only if there is only a single evaluation to a function
@@ -702,7 +703,7 @@ impl FeaturesUtils {
             };
             value += &format!("def {}({}) -> ", symbol_name, arguments);
         } else {
-            if symbol_type == SymType::CLASS && inferred_types.len() == 1 && inferred_types[0].eval_ptr.is_weak() && inferred_types[0].eval_ptr.as_weak().is_super {
+            if symbol_type == SymType::CLASS && inferred_types.len() == 1 && inferred_types[0].eval_ptr.has_weak() && inferred_types[0].eval_ptr.get_weak().is_super {
                 value += &format!("(super[{}]) ", symbol_name);
             } else {
                 value += symbol_name;

--- a/server/tests/data/addons/self_propagation_module/__init__.py
+++ b/server/tests/data/addons/self_propagation_module/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/server/tests/data/addons/self_propagation_module/__manifest__.py
+++ b/server/tests/data/addons/self_propagation_module/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name' : 'Module fro testing',
+    'version' : '1.0',
+    'summary': 'Test Module 1',
+    'sequence': 10,
+    'description': """
+Module 1
+====================
+This is the description of the module 1
+    """,
+    'category': 'Accounting/Accounting',
+    'depends' : ["mail"], # we want to overriding of `with_user`
+    'installable': True,
+    'application': True,
+    'license': 'LGPL-3',
+}

--- a/server/tests/data/addons/self_propagation_module/models/__init__.py
+++ b/server/tests/data/addons/self_propagation_module/models/__init__.py
@@ -1,0 +1,1 @@
+from . import all_models

--- a/server/tests/data/addons/self_propagation_module/models/all_models.py
+++ b/server/tests/data/addons/self_propagation_module/models/all_models.py
@@ -1,0 +1,42 @@
+from odoo import api, fields, models
+
+class ModelA(models.Model):
+
+    _name = "self_propagation_module.modela"
+
+    ch_field = fields.Char()
+
+    def create_new(self): # -> Self@ModelA
+        return super().create([])
+
+    def create_from_self_env(self): # -> ModelA
+        return self.env['self_propagation_module.modela'].create([])
+
+    def search_in_a(self): # -> Self@ModelA
+        # Check that env to with_user is properly propagated to be Self.
+        return self.env['self_propagation_module.modela'].with_user(self.internal_user).search(
+        [('ch_field', '=', "dummy_str")], # no diagnostic
+        limit=1)
+
+class ModelB(models.Model):
+
+    _name = "self_propagation_module.modelb"
+    _inherit = "self_propagation_module.modela"
+
+    def method(self):
+        # Test self propagation in the presence of inheritance and multiple calls to self methods
+        self.create_new() # create_new is from ModelA, returns an instance of ModelB
+        self.create_from_self_env() # create_from_self_env is from ModelA, returns an instance of ModelA, because it uses self.env['self_propagation_module.modela']
+
+class A:
+    def method_self(self):
+        return self
+    def method_hard_a(self):
+        return A()
+
+class B(A):
+    def method_b_self(self): # -> Self@B
+        return self.method_self() # method_self is from A, returns an instance of B since it's called on B
+
+    def method_b_hard_a(self): # -> A
+        return self.method_hard_a() # method_hard_a is from A, returns an instance of A

--- a/server/tests/mod.rs
+++ b/server/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod test_utils;
 pub mod diagnostics;
+pub mod self_propagation_tests;
 pub mod setup;

--- a/server/tests/self_propagation_tests/mod.rs
+++ b/server/tests/self_propagation_tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod self_propagation_tests;

--- a/server/tests/self_propagation_tests/self_propagation_tests.rs
+++ b/server/tests/self_propagation_tests/self_propagation_tests.rs
@@ -1,0 +1,134 @@
+use std::{cell::RefCell, path::PathBuf, rc::Rc};
+
+use odoo_ls_server::{constants::OYarn, core::{odoo::SyncOdoo, symbols::symbol::Symbol}, Sy, utils::PathSanitizer};
+
+use crate::{setup::setup, test_utils};
+
+#[test]
+fn test_model_subscription() {
+    // Setup: Get the symbol for BaseTestModel and verify its existence
+    let (mut odoo, config) = setup::setup_server(true);
+    let mut session = setup::create_init_session(&mut odoo, config);
+    let test_addons_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("data").join("addons");
+    let test_file = test_addons_path.join("self_propagation_module").join("models").join("all_models.py").sanitize();
+    let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(
+        &mut session,
+        &PathBuf::from(&test_file)
+    ) else {
+        panic!("Failed to get file symbol");
+    };
+    let follow_evaluation_refs = |syms: Vec<Rc<RefCell<Symbol>>>, session: &mut odoo_ls_server::threads::SessionInfo<'_>| syms.iter().flat_map(|sym| {
+        match sym.borrow().evaluations() {
+            Some(evals) => evals.iter().flat_map(|eval|
+                Symbol::follow_ref(
+                    &eval.symbol.get_symbol(session, &mut None, &mut vec![], None),
+                    session,
+                    &mut None,
+                    false,
+                    false,
+                    None,
+                    None
+                )
+            )
+            .flat_map(|sym_ptr|
+                sym_ptr.upgrade_weak()
+            )
+            .collect::<Vec<_>>(),
+            None => vec![]
+        }
+    }).collect::<Vec<_>>();;
+
+    let diagnostics = setup::get_diagnostics_for_path(&mut session, &test_file);
+    // Verify that there are no OLS03011 on line 18 due to wrong self propagation due to with_user in search_in_a method of ModelA
+    let line_diagnostics = test_utils::diag_on_line(&diagnostics, 17);
+    assert_eq!(
+        line_diagnostics.len(),
+        0,
+        "Expected no diagnostics on line 18, but found some: {:?}",
+        line_diagnostics
+    );
+
+
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&test_file).unwrap();
+    let model_a_sym = file_symbol.borrow().get_symbol(&(vec![], vec![Sy!("ModelA")]), u32::MAX);
+    assert_eq!(model_a_sym.len(), 1, "Expected 1 symbol for ModelA");
+    let model_b_sym = file_symbol.borrow().get_symbol(&(vec![], vec![Sy!("ModelB")]), u32::MAX);
+    assert_eq!(model_b_sym.len(), 1, "Expected 1 symbol for ModelB");
+
+    let create_new_in_model_a = follow_evaluation_refs(
+        test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 8, 14),
+        &mut session,
+    );
+    assert!(
+        create_new_in_model_a.iter().any(|sym| Rc::ptr_eq(sym, &model_a_sym[0])),
+        "Expected to find ModelA symbol"
+    );
+
+    let create_from_self_env_in_model_a = follow_evaluation_refs(
+        test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 11, 14),
+        &mut session,
+    );
+    assert!(
+        create_from_self_env_in_model_a.iter().any(|sym| Rc::ptr_eq(sym, &model_a_sym[0])),
+        "Expected to find ModelA symbol"
+    );
+
+    let search_in_a_in_model_a = follow_evaluation_refs(
+        test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 14, 14),
+        &mut session,
+    );
+    assert!(
+        search_in_a_in_model_a.iter().any(|sym| Rc::ptr_eq(sym, &model_a_sym[0])),
+        "Expected to find ModelA symbol"
+    );
+
+    let create_new_in_model_b = test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 27, 24);
+    assert!(
+        create_new_in_model_b.iter().any(|sym| Rc::ptr_eq(sym, &model_b_sym[0])),
+        "Expected to find ModelB symbol"
+    );
+
+    let create_from_self_env_in_model_b = test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 28, 34);
+    assert!(
+        create_from_self_env_in_model_b.iter().any(|sym| Rc::ptr_eq(sym, &model_a_sym[0])),
+        "Expected to find ModelA symbol"
+    );
+
+    // Test on normal classes
+
+    let a_sym = file_symbol.borrow().get_symbol(&(vec![], vec![Sy!("A")]), u32::MAX);
+    assert_eq!(a_sym.len(), 1, "Expected 1 symbol for A");
+    let b_sym = file_symbol.borrow().get_symbol(&(vec![], vec![Sy!("B")]), u32::MAX);
+    assert_eq!(b_sym.len(), 1, "Expected 1 symbol for B");
+
+    let method_self_in_a = follow_evaluation_refs(
+        test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 31, 14),
+        &mut session,
+    );
+    assert!(
+        method_self_in_a.iter().any(|sym| Rc::ptr_eq(sym, &a_sym[0])),
+        "Expected to find A symbol"
+    );
+
+    let method_hard_a_in_a = follow_evaluation_refs(
+        test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 33, 14),
+        &mut session,
+    );
+    assert!(
+        method_hard_a_in_a.iter().any(|sym| Rc::ptr_eq(sym, &a_sym[0])),
+        "Expected to find A symbol"
+    );
+
+    let method_b_self_in_b = test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 38, 32);
+    assert!(
+        method_b_self_in_b.iter().any(|sym| Rc::ptr_eq(sym, &b_sym[0])),
+        "Expected to find B symbol"
+    );
+
+    let method_b_hard_a_in_b = test_utils::get_resolved_symbols_at_position(&mut session, &file_symbol, &file_info, 41, 34);
+    assert!(
+        method_b_hard_a_in_b.iter().any(|sym| Rc::ptr_eq(sym, &a_sym[0])),
+        "Expected to find A symbol"
+    );
+}


### PR DESCRIPTION
Works by adding a weak pointer to the SELF EvaluationSymbolPtr variant,
which is used to propagate the SELF evaluation through method calls.
When a method with a SELF return type is called, under a subclass,
the weak pointer is updated to point to the new symbol,
allowing the evaluation to be correctly propagated.

Also SELF evaluations are now treated as weak evaluations when it is
final, like in features, or in any situation where it will not be
propagated any further