### PR TITLE
[FIX] remove OLS05038

### DIFF
--- a/server/src/core/diagnostic_codes_list.rs
+++ b/server/src/core/diagnostic_codes_list.rs
@@ -380,10 +380,6 @@ OLS05036, DiagnosticSetting::Error, "Empty Value data, text data or file attribu
 */
 OLS05037, DiagnosticSetting::Error, "Empty Value data, one of text data, `file`, `eval`, or `search` has to be provided",
 /**
-* Empty Function data, either of `eval` attribute , or one or more `value`, or `function` children have to be provided.
-*/
-OLS05038, DiagnosticSetting::Error, "Empty Function data, either of `eval` attribute , or one or more `value`, or `function` children have to be provided",
-/**
 * You provided an empty XML ID. Please provide a valid XML ID.
 */
 OLS05039, DiagnosticSetting::Error, "Empty XML ID. Please provide a valid XML ID.",

--- a/server/src/core/xml_arch_builder_rng_validation.rs
+++ b/server/src/core/xml_arch_builder_rng_validation.rs
@@ -562,10 +562,8 @@ impl XmlArchBuilder {
                 }
             }
         }
-        let mut has_value_or_function_child = false;
         for child in node.children().filter(|n| n.is_element()) {
             if self.load_value(session, &child, diagnostics) {
-                has_value_or_function_child = true;
                 if has_eval {
                     if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05045, &[]) {
                         diagnostics.push(Diagnostic {
@@ -575,7 +573,6 @@ impl XmlArchBuilder {
                     }
                 }
             } else if self.load_function(session, &child, diagnostics) {
-                has_value_or_function_child = true;
                 if has_eval {
                     if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05047, &[]) {
                         diagnostics.push(Diagnostic {
@@ -591,14 +588,6 @@ impl XmlArchBuilder {
                         ..diagnostic.clone()
                     });
                 }
-            }
-        }
-        if !has_eval && !has_value_or_function_child {
-            if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05038, &[]) {
-                diagnostics.push(Diagnostic {
-                    range: Range { start: Position::new(node.range().start as u32, 0), end: Position::new(node.range().end as u32, 0) },
-                    ..diagnostic.clone()
-                });
             }
         }
         true

--- a/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
+++ b/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
@@ -80,7 +80,7 @@
     <function name="name" model="model" eval="eval"><value>children values not allowed</value></function> <!-- OLS05045 -->
     <function name="name" model="model" invalid_attr="error" eval="some_data"/> <!-- OLS05046 -->
     <function name="name" model="model" eval="eval"><function name="name" model="model" eval="some_data"/></function> <!-- OLS05047 -->
-    <function name="name" model="model"/> <!-- OLS05038 -->
+    <function name="name" model="model"/>
     <function name="name" model="model" eval="eval"><invalid_node /></function> <!-- OLS05048 -->
     <record id="bike_5" model="bikes.bike"><field name="wheel_id" ref=""/></record> <!-- OLS05039 -->
     <record id="bike_6" model="bikes.bike"><field name="wheel_id" ref="module_for_diagnostics.bike_wheel_6.too.many.dots"/></record> <!-- OLS05051 -->

--- a/server/tests/diagnostics/ols05000s.rs
+++ b/server/tests/diagnostics/ols05000s.rs
@@ -80,7 +80,6 @@ fn test_ols05000s_xml_file() {
     check_xml_diag("OLS05045", 79);
     check_xml_diag("OLS05046", 80);
     check_xml_diag("OLS05047", 81);
-    check_xml_diag("OLS05038", 82);
     check_xml_diag("OLS05048", 83);
     check_xml_diag("OLS05039", 84);
     check_xml_diag("OLS05051", 85);


### PR DESCRIPTION
OLS05038 was incorrect, the `import_xml.rng` marks eval and subnodes of type functions or evals to be optional.