### PR TITLE
[FIX] Fix first argument on static methods

### DIFF
--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -736,10 +736,14 @@ impl PythonArchEval {
             return; // can be not found if AST is incomplete
         };
         {
+            let is_static = function_sym.borrow().as_func().is_static.clone();
             if function_sym.borrow_mut().as_func_mut().can_be_in_class() || !(self.sym_stack.last().unwrap().borrow().typ() == SymType::CLASS){
                 let mut is_first = true;
                 for arg in func_stmt.parameters.posonlyargs.iter().chain(&func_stmt.parameters.args) {
-                    if is_first && self.sym_stack.last().unwrap().borrow().typ() == SymType::CLASS {
+                    if is_first
+                        && !is_static
+                        && self.sym_stack.last().unwrap().borrow().typ() == SymType::CLASS
+                    {
                         let mut var_bw = function_sym.borrow_mut();
                         let is_class_method = var_bw.as_func().is_class_method;
                         let symbol = var_bw.as_func_mut().symbols.get(&OYarn::from(arg.parameter.name.id.to_string())).unwrap().get(&0).unwrap().get(0).unwrap(); //get first declaration
@@ -782,10 +786,10 @@ impl PythonArchEval {
                         self.diagnostics.extend(diags);
                     }
                 }
-            } else if !function_sym.borrow_mut().as_func_mut().is_static && !function_sym.borrow().as_func().is_class_method {
+            } else if !is_static {
                 if let Some(diagnostic) = create_diagnostic(&session, DiagnosticCode::OLS01004, &[]) {
                     self.diagnostics.push(Diagnostic {
-                        range: FileMgr::textRange_to_temporary_Range(&func_stmt.range),
+                        range: FileMgr::textRange_to_temporary_Range(&func_stmt.name.range()),
                         ..diagnostic
                     });
                 }

--- a/server/tests/data/python/diagnostics/ols01004.py
+++ b/server/tests/data/python/diagnostics/ols01004.py
@@ -28,8 +28,8 @@ class Test():
         pass
 
     @classmethod
-    def e(): #Should trigger another diagnostic, not OLS01004
+    def e(): # OLS01004
         pass
 
-    def oups(): #should trigger OLS01004
+    def oups(): # OLS01004
         pass

--- a/server/tests/diagnostics/ols01004.rs
+++ b/server/tests/diagnostics/ols01004.rs
@@ -1,9 +1,8 @@
 use std::env;
 
-use lsp_types::{DiagnosticSeverity, NumberOrString};
-use odoo_ls_server::{S, utils::PathSanitizer};
+use odoo_ls_server::utils::PathSanitizer;
 
-use crate::{setup::setup::*, test_utils::diag_on_line};
+use crate::{setup::setup::*, test_utils::verify_diagnostics_against_doc};
 
 #[test]
 fn test_ols01004() {
@@ -12,16 +11,6 @@ fn test_ols01004() {
     let path = env::current_dir().unwrap().join("tests/data/python/diagnostics/ols01004.py").sanitize();
     prepare_custom_entry_point(&mut session, &path);
     let diagnostics = get_diagnostics_for_path(&mut session, &path);
-    assert_eq!(diagnostics.len(), 1);
-    let diagnostics = diag_on_line(&diagnostics, 33);
-    assert_eq!(diagnostics.len(), 1);
-    let diag = &diagnostics[0];
-    assert!(diag.code.is_some());
-    let code = match &diag.code {
-        Some(NumberOrString::String(code)) => code,
-        Some(NumberOrString::Number(num)) => panic!("Unexpected numeric code: {}", num),
-        None => panic!("Diagnostic code is None"),
-    };
-    assert!(code == &S!("OLS01004"));
-    assert!(diag.severity.is_some_and(|s| s == DiagnosticSeverity::ERROR));
+    let doc_diags = get_diagnostics_test_comments(&mut session, &path);
+    verify_diagnostics_against_doc(diagnostics, doc_diags);
 }


### PR DESCRIPTION
Before first arg was always linked the parent class. But this is not true for static methods. Make sure we check for those here