### PR TITLE
[FIX] Assign type hint evaluations to function

### DIFF
--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -179,7 +179,7 @@ impl PythonArchEval {
                 self._visit_for(session, for_stmt);
             },
             Stmt::With(with_stmt) => {
-                self._visit_with(session, with_stmt);
+                self.visit_with(session, with_stmt);
             },
             Stmt::Return(return_stmt) => {
                 self._visit_return(session, return_stmt);
@@ -926,11 +926,11 @@ impl PythonArchEval {
         }
     }
 
-    fn _visit_with(&mut self, session: &mut SessionInfo, with_stmt: &StmtWith) {
+    fn visit_with(&mut self, session: &mut SessionInfo, with_stmt: &StmtWith) {
         for item in with_stmt.items.iter() {
             self.visit_expr(session, &item.context_expr);
             if let Some(var) = item.optional_vars.as_ref() {
-                match &**var {
+                match var.as_ref() {
                     Expr::Name(expr_name) => {
                         let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&OYarn::from(expr_name.id.to_string()), &expr_name.range());
                         if let Some(variable_rc) = variable {
@@ -939,24 +939,25 @@ impl PythonArchEval {
                             if !self.file_mode {
                                 deps.push(vec![]);
                             }
-                            let (eval, diags) = Evaluation::eval_from_ast(session, &item.context_expr, parent, &with_stmt.range.start(), false, &mut deps);
+                            let (context_mgr_evals, diags) = Evaluation::eval_from_ast(session, &item.context_expr, parent, &with_stmt.range.start(), false, &mut deps);
                             Symbol::insert_dependencies(&self.file, &mut deps, self.current_step);
-                            let mut evals = vec![];
-                            for eval in eval.iter() {
-                                let symbol = eval.symbol.get_symbol_as_weak(session, &mut None, &mut self.diagnostics, Some(variable_rc.borrow().parent_file_or_function().unwrap().upgrade().unwrap().clone()));
+                            // The expression name in with <> [as <name>], is the result of __enter__.
+                            let mut enter_evals = vec![];
+                            for context_mgr_eval in context_mgr_evals.iter() {
+                                let symbol = context_mgr_eval.symbol.get_symbol_as_weak(session, &mut None, &mut self.diagnostics, Some(variable_rc.borrow().parent_file_or_function().unwrap().upgrade().unwrap().clone()));
                                 if let Some(symbol) = symbol.weak.upgrade() {
                                     let _enter_ = symbol.borrow().get_symbol(&(vec![], vec![Sy!("__enter__")]), u32::MAX);
                                     if let Some(_enter_) = _enter_.last() {
                                         match *_enter_.borrow() {
                                             Symbol::Function(ref func) => {
-                                                evals.extend(func.evaluations.clone());
+                                                enter_evals.extend(func.evaluations.clone());
                                             },
                                             _ => {}
                                         }
                                     }
                                 }
                             }
-                            variable_rc.borrow_mut().set_evaluations(eval);
+                            variable_rc.borrow_mut().set_evaluations(enter_evals);
                             self.diagnostics.extend(diags);
                         }
                     },

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -1030,6 +1030,7 @@ impl PythonArchEval {
                 Symbol::insert_dependencies(file_sym, &mut deps, BuildSteps::ARCH_EVAL);
             }
             diagnostics.extend(diags);
+            func_sym.borrow_mut().set_evaluations(evaluations);
         }
     }
 


### PR DESCRIPTION
This was mistakenly removed in #536