### PR TITLE
[IMP] Add method to ensure function evaluations

### DIFF
--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -912,17 +912,7 @@ impl Evaluation {
                                 let init = base_sym.borrow().get_member_symbol(session, &S!("__init__"), module.clone(), true, false, false, false, false);
                                 let mut found_hook = false;
                                 if let Some(init) = init.0.first() {
-                                    let init_sym_file = init.borrow().get_file().as_ref().unwrap().upgrade().unwrap().clone();
-                                    if init.borrow().evaluations().is_some()
-                                    && init.borrow().evaluations().unwrap().len() == 0
-                                    && !init_sym_file.borrow().is_external()
-                                    && init_sym_file.borrow().build_status(BuildSteps::ARCH_EVAL) == BuildStatus::DONE
-                                    && init.borrow().build_status(BuildSteps::ARCH) != BuildStatus::IN_PROGRESS
-                                    && init.borrow().build_status(BuildSteps::ARCH_EVAL) != BuildStatus::IN_PROGRESS
-                                    && init.borrow().build_status(BuildSteps::VALIDATION) == BuildStatus::PENDING {
-                                        let mut v = PythonValidator::new(init.borrow().get_entry().unwrap(), init.clone());
-                                        v.validate(session);
-                                    }
+                                    SyncOdoo::ensure_func_evaluations(session, init);
                                     if let Some(init_eval) = init.borrow().evaluations() {
                                         //init will always return an instance of the class, so we are not searching the method to check its return type, but rather to check if there is 
                                         //an hook on it. Hooks, can be used to use parameters for context (see relational fields for example).
@@ -974,29 +964,15 @@ impl Evaluation {
                         }
                     } else if base_sym.borrow().typ() == SymType::FUNCTION {
                         let base_sym_file = base_sym.borrow().get_file().as_ref().unwrap().upgrade().unwrap().clone();
-                        SyncOdoo::build_now(session, &base_sym_file, BuildSteps::ARCH_EVAL);
                         let in_class = base_sym.borrow().get_in_parents(&vec![SymType::CLASS], true).is_some();
                         if required_dependencies.len() >= 2 {
                             if !in_class {
                                 required_dependencies[1].push(base_sym_file.clone());
                             }
                         }
-                        //function return evaluation can come from:
-                        //  - type annotation parsing (ARCH_EVAL step)
-                        //  - documentation parsing (Arch_eval and VALIDATION step)
-                        //  - function body inference (VALIDATION step)
-                        // Therefore, the actual version of the algorithm will trigger build from the different steps if this one has already been reached.
-                        // We don't want to launch validation step while Arch evaluating the code.
-                        if base_sym.borrow().evaluations().is_some()
-                        && base_sym.borrow().evaluations().unwrap().len() == 0
-                        && !base_sym_file.borrow().is_external()
-                        && base_sym_file.borrow().build_status(BuildSteps::ARCH_EVAL) == BuildStatus::DONE
-                        && base_sym.borrow().build_status(BuildSteps::ARCH) != BuildStatus::IN_PROGRESS
-                        && base_sym.borrow().build_status(BuildSteps::ARCH_EVAL) != BuildStatus::IN_PROGRESS
-                        && base_sym.borrow().build_status(BuildSteps::VALIDATION) == BuildStatus::PENDING {
-                            let mut v = PythonValidator::new(base_sym.borrow().get_entry().unwrap(), base_sym.clone());
-                            v.validate(session);
-                        }
+                        // Ensure return-type evaluations are available: resolves type annotations
+                        // (ARCH_EVAL) and, if still empty, infers from body (VALIDATION).
+                        SyncOdoo::ensure_func_evaluations(session, &base_sym);
                         if required_dependencies.len() >= 3 {
                             if in_class {
                                 required_dependencies[2].push(base_sym_file.clone());

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -901,6 +901,25 @@ impl SyncOdoo {
         false
     }
 
+    /// Ensure that a function symbol's evaluations are as fully populated
+    pub fn ensure_func_evaluations(session: &mut SessionInfo, func: &Rc<RefCell<Symbol>>) {
+        if func.borrow().typ() != SymType::FUNCTION {
+            return; // TODO: Arena, func should accept function symbols only
+        }
+        let Some(func_file) = func.borrow().get_file().and_then(|f| f.upgrade()) else {
+            return;
+        };
+        if func.borrow().evaluations().expect("Function symbols must have evaluations").is_empty()
+        && !func_file.borrow().is_external()
+        {
+            // Run Arch eval on file, if possible, then run everything on the fn
+            // until arch_eval
+            SyncOdoo::build_now(session, &func_file, BuildSteps::ARCH_EVAL);
+            SyncOdoo::build_now(session, &func, BuildSteps::ARCH);
+            SyncOdoo::build_now(session, &func, BuildSteps::ARCH_EVAL);
+        }
+    }
+
     pub fn build_now_dependencies(session: &mut SessionInfo, symbol: &Rc<RefCell<Symbol>>, step: BuildSteps) {
         let symbol = symbol.borrow();
         match symbol.typ() {

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -839,15 +839,11 @@ impl PythonArchEval {
                     let symbol_type_rc = symbol_eval[0].upgrade_weak().unwrap();
                     let symbol_type = symbol_type_rc.borrow();
                     if symbol_type.typ() == SymType::CLASS {
-                        let (iter, _) = symbol_type.get_member_symbol(session, &S!("__iter__"), None, true, false, false, false, false);
-                        if iter.len() == 1 {
-                            if !iter[0].borrow().is_external() { //we can't rebuild functions of external files
-                                SyncOdoo::build_now(session, &iter[0], BuildSteps::ARCH);
-                                SyncOdoo::build_now(session, &iter[0], BuildSteps::ARCH_EVAL);
-                                SyncOdoo::build_now(session, &iter[0], BuildSteps::VALIDATION);
-                            }
-                            if iter[0].borrow().evaluations().is_some() && iter[0].borrow().evaluations().unwrap().len() == 1 {
-                                let iter = iter[0].borrow();
+                        let (iters, _) = symbol_type.get_member_symbol(session, &S!("__iter__"), None, true, false, false, false, false);
+                        if let Some(iter) = iters.first() && iters.len() == 1 {
+                            SyncOdoo::ensure_func_evaluations(session, iter);
+                            if iter.borrow().evaluations().is_some() && iter.borrow().evaluations().unwrap().len() == 1 {
+                                let iter = iter.borrow();
                                 let eval_iter = &iter.evaluations().unwrap()[0];
                                 if for_stmt.target.is_name_expr() { //only handle simple variable for now
                                     let variable = self.sym_stack.last().unwrap().borrow().get_positioned_symbol(&OYarn::from(for_stmt.target.as_name_expr().unwrap().id.to_string()), &for_stmt.target.range());
@@ -948,6 +944,7 @@ impl PythonArchEval {
                                 if let Some(symbol) = symbol.weak.upgrade() {
                                     let _enter_ = symbol.borrow().get_symbol(&(vec![], vec![Sy!("__enter__")]), u32::MAX);
                                     if let Some(_enter_) = _enter_.last() {
+                                        SyncOdoo::ensure_func_evaluations(session, _enter_);
                                         match *_enter_.borrow() {
                                             Symbol::Function(ref func) => {
                                                 enter_evals.extend(func.evaluations.clone());

--- a/server/src/core/symbols/symbol.rs
+++ b/server/src/core/symbols/symbol.rs
@@ -2136,17 +2136,7 @@ impl Symbol {
                     let get_method = attribute_type_sym.get_member_symbol(session, &S!("__get__"), None, true, false, false, true, false).0.first().cloned();
                     match get_method {
                         Some(get_method) if (base_attr.borrow().typ() == SymType::CLASS) => {
-                            let get_sym_file = get_method.borrow().get_file().as_ref().unwrap().upgrade().unwrap().clone();
-                            if get_method.borrow().evaluations().is_some()
-                            && get_method.borrow().evaluations().unwrap().len() == 0
-                            && !get_sym_file.borrow().is_external()
-                            && get_sym_file.borrow().build_status(BuildSteps::ARCH_EVAL) == BuildStatus::DONE
-                            && get_method.borrow().build_status(BuildSteps::ARCH) != BuildStatus::IN_PROGRESS
-                            && get_method.borrow().build_status(BuildSteps::ARCH_EVAL) != BuildStatus::IN_PROGRESS
-                            && get_method.borrow().build_status(BuildSteps::VALIDATION) == BuildStatus::PENDING {
-                                let mut v = PythonValidator::new(get_method.borrow().get_entry().unwrap(), get_method.clone());
-                                v.validate(session);
-                            }
+                            SyncOdoo::ensure_func_evaluations(session, &get_method);
                             let get_method = get_method.borrow();
                             if get_method.evaluations().is_some() {
                                 let mut res = VecDeque::new();

--- a/server/tests/data/python/expressions/type_hints.py
+++ b/server/tests/data/python/expressions/type_hints.py
@@ -1,0 +1,18 @@
+class MyClass:
+    pass
+
+class MyContextManager:
+    def __enter__(self) -> MyClass:
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+def get_my_class() -> MyClass:
+    pass
+
+result = get_my_class()
+result
+
+with MyContextManager() as ctx:
+    ctx

--- a/server/tests/test_type_hints.rs
+++ b/server/tests/test_type_hints.rs
@@ -1,0 +1,74 @@
+mod setup;
+mod test_utils;
+
+use odoo_ls_server::constants::OYarn;
+use odoo_ls_server::core::file_mgr::FileInfo;
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::core::symbols::symbol::Symbol;
+use odoo_ls_server::threads::SessionInfo;
+use odoo_ls_server::utils::PathSanitizer;
+use odoo_ls_server::Sy;
+use std::cell::RefCell;
+use std::env;
+use std::path::PathBuf;
+use std::rc::Rc;
+use test_utils::get_resolved_symbols_at_position;
+
+/// Sets up a session with `type_hints.py` loaded and resolves `MyClass`, then calls `f` with
+/// the session, file info, file symbol, and `MyClass` symbol.
+fn with_type_hints_fixture<F>(f: F)
+where
+    F: FnOnce(&mut SessionInfo, &Rc<RefCell<FileInfo>>, &Rc<RefCell<Symbol>>, &Rc<RefCell<Symbol>>),
+{
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let path = env::current_dir()
+        .unwrap()
+        .join("tests/data/python/expressions/type_hints.py")
+        .sanitize();
+    setup::setup::prepare_custom_entry_point(&mut session, path.as_str());
+
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&path).unwrap();
+    let file_symbol = SyncOdoo::get_symbol_of_opened_file(&mut session, &PathBuf::from(&path))
+        .expect("Failed to get file symbol");
+
+    let my_class = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("MyClass")]), u32::MAX);
+    assert!(!my_class.is_empty(), "MyClass should be found in the test file");
+    let my_class = my_class[0].clone();
+
+    f(&mut session, &file_info, &file_symbol, &my_class);
+}
+
+/// Test that a function with a return type hint and `pass` body is recognized as returning
+/// the hinted type. The body provides no inferrable return value, so the hint must be used.
+#[test]
+fn test_function_return_type_hint() {
+    with_type_hints_fixture(|session, file_info, file_symbol, my_class| {
+        // Line 14: `result` — the standalone reference to the variable assigned from get_my_class().
+        // get_my_class() has `-> MyClass` and body `pass`, so the return type must come from
+        // the type hint rather than any inferred return statement.
+        let resolved = get_resolved_symbols_at_position(session, file_symbol, file_info, 14, 0);
+        assert!(
+            resolved.len() == 1 && Rc::ptr_eq(&resolved[0], my_class),
+            "result of get_my_class() should resolve to MyClass via return type hint, got: {:?}",
+            resolved.iter().map(|s| s.borrow().name().to_string()).collect::<Vec<_>>()
+        );
+    });
+}
+
+/// Test that the variable bound in a `with ... as <name>` statement has the type returned
+/// by the context manager's `__enter__` method.
+#[test]
+fn test_with_statement_type_from_enter() {
+    with_type_hints_fixture(|session, file_info, file_symbol, my_class| {
+        // Line 17: `    ctx` — the bound variable from `with MyContextManager() as ctx:`.
+        // MyContextManager.__enter__ has `-> MyClass`, so ctx should resolve to MyClass.
+        let resolved = get_resolved_symbols_at_position(session, file_symbol, file_info, 17, 4);
+        assert!(
+            resolved.len() == 1 && Rc::ptr_eq(&resolved[0], my_class),
+            "ctx in with statement should resolve to MyClass via __enter__ return type, got: {:?}",
+            resolved.iter().map(|s| s.borrow().name().to_string()).collect::<Vec<_>>()
+        );
+    });
+}


### PR DESCRIPTION
This basically ensure that a function has been built up to arch_eval. This has been done multiple times before in different parts of the code. This also is doing it with less checks, and essentially does arch and arch eval, no validation for the function, because it is not needed at this point