### PR TITLE
XML Missing field check

### DIFF
--- a/server/src/core/diagnostic_codes_list.rs
+++ b/server/src/core/diagnostic_codes_list.rs
@@ -529,4 +529,8 @@ OLS05067, DiagnosticSetting::Error, "Path node in asset cannot be empty",
  * Unknown language code
  */
 OLS05068, DiagnosticSetting::Warning, "Unknown language code: '{0}'. Additional languages can be set in the configuration file.",
+/**
+ * Mandatory field is not provided in the record
+ */
+OLS05069, DiagnosticSetting::Warning, "Mandatory field '{0}' is not provided in record",
 }

--- a/server/src/core/xml_validation.rs
+++ b/server/src/core/xml_validation.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, cmp::Ordering, collections::{HashMap, HashSet}, rc::Rc}
 use lsp_types::{Diagnostic, Position, Range};
 use tracing::{info, trace};
 
-use crate::{Sy, constants::{BuildSteps, DEBUG_STEPS, OYarn}, core::{diagnostics::{DiagnosticCode, create_diagnostic}, entry_point::{EntryPoint, EntryPointType}, file_mgr::FileInfo, odoo::SyncOdoo, symbols::symbol::Symbol, xml_data::{OdooData, OdooDataRecord, XmlDataAsset, XmlDataDelete, XmlDataMenuItem, XmlDataTemplate}}, oyarn, threads::SessionInfo, utils::compare_semver};
+use crate::{Sy, S, constants::{BuildSteps, DEBUG_STEPS, OYarn}, core::{diagnostics::{DiagnosticCode, create_diagnostic}, entry_point::{EntryPoint, EntryPointType}, evaluation::ContextValue, file_mgr::FileInfo, odoo::SyncOdoo, symbols::symbol::Symbol, xml_data::{OdooData, OdooDataRecord, XmlDataAsset, XmlDataDelete, XmlDataMenuItem, XmlDataTemplate}}, oyarn, threads::SessionInfo, utils::compare_semver};
 
 
 
@@ -118,28 +118,30 @@ impl XmlValidator {
     }
 
     fn validate_fields(&self, session: &mut SessionInfo, xml_data_record: &OdooDataRecord, all_fields: &HashMap<OYarn, Vec<(Rc<RefCell<Symbol>>, Option<OYarn>)>>, diagnostics: &mut Vec<Diagnostic>, missing_model_dependencies: &mut HashSet<OYarn>) {
-        //Compute mandatory fields
-        // let mut mandatory_fields: Vec<String> = vec![];
-        // for (field_name, field_sym) in all_fields.iter() {
-        //     for (fs, deps) in field_sym.iter() {
-        //         if deps.is_none() {
-        //             let has_required = fs.borrow().evaluations().unwrap_or(&vec![]).iter()
-        //             .any(|eval|
-        //                 eval.symbol.get_symbol_as_weak(session, &mut None, diagnostics, None)
-        //                 .context.get("required").unwrap_or(&ContextValue::BOOLEAN(false)).as_bool()
-        //             );
-        //             let has_default = fs.borrow().evaluations().unwrap_or(&vec![]).iter()
-        //             .any(|eval|
-        //                 eval.symbol.get_symbol_as_weak(session, &mut None, diagnostics, None)
-        //                 .context.contains_key("default")
-        //             );
-        //             if has_required && !has_default {
-        //                 mandatory_fields.push(field_name.to_string());
-        //             }
-        //         }
-        //     }
-        // }
-        //check each field in the record
+        let mut mandatory_fields = HashSet::new();
+        for (field_name, field_symbols) in all_fields.iter() {
+            if xml_data_record.model.0.as_str() == "ir.ui.view" && field_name.as_str() == "name" {
+                continue; // "Name" gets calculated in create if missing
+            }
+            for (field_sym, deps) in field_symbols.iter() {
+                if deps.is_none() {
+                    let has_required = field_sym.borrow().evaluations().unwrap_or(&vec![]).iter()
+                        .any(|eval| {
+                            eval.symbol.get_symbol_as_weak(session, &mut None, diagnostics, None)
+                                .context.get(&S!("required")).unwrap_or(&ContextValue::BOOLEAN(false)).as_bool()
+                        });
+                    let has_default = field_sym.borrow().evaluations().unwrap_or(&vec![]).iter()
+                        .any(|eval| {
+                            eval.symbol.get_symbol_as_weak(session, &mut None, diagnostics, None)
+                                .context.contains_key(&S!("default"))
+                        });
+                    if has_required && !has_default {
+                        mandatory_fields.insert(field_name.clone());
+                    }
+                }
+            }
+        }
+
         for field in &xml_data_record.fields {
             let mut field_name = Sy!(field.name.clone());
             let mut has_translation = false;
@@ -198,9 +200,10 @@ impl XmlValidator {
                     }
                 }
             }
-            //Check that the field belong to the model
+            // Check that the field belongs to the model
             if all_fields.contains_key(&field_name) {
-                // mandatory_fields.retain(|f| f != &field_name.to_string());
+                // Remove from mandatory fields since it's provided in the record
+                mandatory_fields.remove(&field_name);
                 //Check specific attributes
                 let (Some(field_text), Some(field_text_range)) = (field.text.as_ref(), field.text_range.as_ref()) else {
                     continue;
@@ -248,19 +251,15 @@ impl XmlValidator {
                 }
             }
         }
-        //Diagnostic if some mandatory fields are not detected
-        // if !mandatory_fields.is_empty() {
-        // We have to check  that remaining fields are not declared in an inherited record or is automatically field (delegate=True)
-        //     diagnostics.push(Diagnostic::new(
-        //         Range::new(Position::new(xml_data_record.range.start.try_into().unwrap(), 0), Position::new(xml_data_record.range.end.try_into().unwrap(), 0)),
-        //         Some(lsp_types::DiagnosticSeverity::ERROR),
-        //         Some(lsp_types::NumberOrString::String(S!("OLS30452"))),
-        //         Some(EXTENSION_NAME.to_string()),
-        //         format!("Some mandatory fields are not declared in the record: {:?}", mandatory_fields),
-        //         None,
-        //         None
-        //     ));
-        // }
+        // Diagnostic if some mandatory fields are not provided
+        for field_name in mandatory_fields.iter() {
+            if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05069, &[field_name]) {
+                diagnostics.push(Diagnostic {
+                    range: Range { start: Position::new(xml_data_record.range.start.try_into().unwrap(), 0), end: Position::new(xml_data_record.range.end.try_into().unwrap(), 0) },
+                    ..diagnostic
+                });
+            }
+        }
     }
 
     fn validate_menu_item(&self, _session: &mut SessionInfo, _xml_data_menu_item: &XmlDataMenuItem, _diagnostics: &mut Vec<Diagnostic>, _dependencies: &mut Vec<Rc<RefCell<Symbol>>>, _missing_model_dependencies: &mut HashSet<OYarn>) {

--- a/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
+++ b/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
@@ -82,16 +82,16 @@
     <function name="name" model="model" eval="eval"><function name="name" model="model" eval="some_data"/></function> <!-- OLS05047 -->
     <function name="name" model="model"/>
     <function name="name" model="model" eval="eval"><invalid_node /></function> <!-- OLS05048 -->
-    <record id="bike_5" model="bikes.bike"><field name="wheel_id" ref=""/></record> <!-- OLS05039 -->
-    <record id="bike_6" model="bikes.bike"><field name="wheel_id" ref="module_for_diagnostics.bike_wheel_6.too.many.dots"/></record> <!-- OLS05051 -->
+    <record id="bike_5" model="bikes.bike"><field name="name">name 5</field><field name="wheel_id" ref=""/></record> <!-- OLS05039 -->
+    <record id="bike_6" model="bikes.bike"><field name="name">name 6</field><field name="wheel_id" ref="module_for_diagnostics.bike_wheel_6.too.many.dots"/></record> <!-- OLS05051 -->
     <menuitem id="whoopla" parent="missing_parent"/> <!-- OLS05052 -->
     <menuitem id="whoopla" action="missing_action"/> <!-- OLS05053 -->
     <menuitem id="whoopla" groups="missing_group1,missing_group2"/> <!-- OLS05054 -->
     <record id="bikes.bike" model="module_2.empty_model"/> <!-- OLS05055 -->
     <record id="bikes.bike" model="wrong.model"/> <!-- OLS05056 -->
-    <record id="bikes.bike" model="bikes.bike"><field name="fine"/></record> <!-- OLS05057 -->
-    <record id="bikes.bike" model="ir.ui.view"><field name="model">module_2.empty_model</field></record> <!-- OLS05055 -->
-    <record id="bikes.bike" model="ir.ui.view"><field name="model">wrong.model</field></record> <!-- OLS05056 -->
+    <record id="bikes.bike" model="bikes.bike"><field name="name">name 7</field><field name="fine"/></record> <!-- OLS05057 -->
+    <record id="bikes.bike" model="ir.ui.view"><field name="name">name 8</field><field name="model">module_2.empty_model</field></record> <!-- OLS05055 -->
+    <record id="bikes.bike" model="ir.ui.view"><field name="name">name 9</field><field name="model">wrong.model</field></record> <!-- OLS05056 -->
     <asset invalid="invalid" id="id" name="name"> <!-- OLS05058 -->
         <bundle>data</bundle>
         <path>ols_tests/tests/something.scss</path>
@@ -119,5 +119,6 @@
         <bundle></bundle> <!-- OLS05066 -->
         <path></path> <!-- OLS05067 -->
     </asset>
-    <record id="bike_translation_1" model="bikes.bike"><field name="name@nl_WV">Da's gin geldige taal, jonge.</field></record> <!-- West Flemish is not a valid language, unfortunately (OLS05068: unknown language code) -->
+    <record id="bike_translation_1" model="bikes.bike"><field name="name">name 10</field><field name="name@nl_WV">Da's gin geldige taal, jonge.</field></record> <!-- West Flemish is not a valid language, unfortunately (OLS05068: unknown language code) -->
+    <record id="bike_wheel_missing_fields" model="bike_parts.wheel"><field name="name">Incomplete Wheel</field></record> <!-- OLS05069: missing mandatory field "price" -->
 </odoo>

--- a/server/tests/diagnostics/ols05000s.rs
+++ b/server/tests/diagnostics/ols05000s.rs
@@ -109,6 +109,7 @@ fn test_ols05000s_xml_file() {
     check_xml_diag("OLS05066", 118);
     check_xml_diag("OLS05067", 119);
     check_xml_warning("OLS05068", 121);
+    check_xml_warning("OLS05069", 122);
 }
 
 #[test]


### PR DESCRIPTION
It works, but too many false positives, for `ir.ui.view`, `ir.cron`, ... . 
- Some models sets fields on create
- False +ves on records that are inheriting other records. We Should maybe only check the first creation, but what about when a field is set to required in an inherited class? 
- Some fields are required, but they are the inherits fields. so they should not be checked
 