### PR TITLE
[IMP] 'access' domain operator

### DIFF
--- a/server/src/core/diagnostic_codes_list.rs
+++ b/server/src/core/diagnostic_codes_list.rs
@@ -181,6 +181,10 @@ OLS03023, DiagnosticSetting::Error, "Inverse field {0} is not pointing to the cu
  */
 OLS03024, DiagnosticSetting::Info, "Models declared in a function are not supported by OdooLS. OdooLS will use it as a normal class for the rest of the function only",
 /**
+* The 'access' operator in search domain tuples was introduced in 19.3. Thus it is only a valid operator from this version.
+*/
+OLS03025, DiagnosticSetting::Error, "Invalid comparison operator: 'access' is only available from Odoo version 19.3",
+/**
 * Form is no longer available on odoo.tests.common, thus it should not be imported from there.
 */
 OLS03301, DiagnosticSetting::Warning, "Deprecation Warning: Since 17.0: odoo.tests.common.Form is deprecated, use odoo.tests.Form",

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -4,14 +4,14 @@ use ruff_python_ast::{Arguments, Expr, ExprCall, FStringPart, Identifier, Number
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use lsp_types::{Diagnostic, Location, Position, Range};
 use weak_table::traits::WeakElement;
-use std::cmp::{max, min};
+use std::cmp::{Ordering, max, min};
 use std::collections::{HashMap, HashSet};
 use std::i32;
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
 use crate::features::references::ReferenceTarget;
-use crate::utils::NoHashBuilder;
+use crate::utils::{NoHashBuilder, compare_semver};
 use crate::{Sy, constants::*, oyarn};
 use crate::core::odoo::SyncOdoo;
 use crate::threads::SessionInfo;
@@ -570,7 +570,7 @@ impl Evaluation {
     * The result is a list, because some ast can give various possible results. For example: a = func()
     * required_dependencies will be filled with dependencies required to build the value, step by step.
     * You have to provide a vector with the length matching the available steps. For example, in arch_eval, required_dependencies
-    * should be equal to vec![vec![], vec![]] to be able to get arch and arch_eval deps at index 0 and 1. It means that if validation is 
+    * should be equal to vec![vec![], vec![]] to be able to get arch and arch_eval deps at index 0 and 1. It means that if validation is
     * not build but required during the eval_from_ast, it will NOT be built
     */
     pub fn eval_from_ast(session: &mut SessionInfo, ast: &Expr, parent: Rc<RefCell<Symbol>>, max_infer: &TextSize, for_annotation: bool, required_dependencies: &mut Vec<Vec<Rc<RefCell<Symbol>>>>) -> (Vec<Evaluation>, Vec<Diagnostic>) {
@@ -968,7 +968,7 @@ impl Evaluation {
                                 if let Some(init) = init.0.first() {
                                     SyncOdoo::ensure_func_evaluations(session, init);
                                     if let Some(init_eval) = init.borrow().evaluations() {
-                                        //init will always return an instance of the class, so we are not searching the method to check its return type, but rather to check if there is 
+                                        //init will always return an instance of the class, so we are not searching the method to check its return type, but rather to check if there is
                                         //an hook on it. Hooks, can be used to use parameters for context (see relational fields for example).
                                         if init_eval.len() == 1 && init_eval[0].symbol.get_symbol_hook.is_some() {
                                             context.as_mut().unwrap().insert(S!("constructing_class"), ContextValue::SYMBOL(Rc::downgrade(&base_sym)));
@@ -2010,11 +2010,21 @@ impl Evaluation {
                     match s.value.to_str() {
                         "=" | "!=" | ">" | ">=" | "<" | "<=" | "=?" | "=like" | "like" | "not like" | "ilike" |
                         "not ilike" | "=ilike" | "in" | "not in" | "child_of" | "parent_of" | "any" | "not any" => {},
+                        "access" => {
+                            if compare_semver(&session.sync_odoo.full_version, "19.3") == Ordering::Less {
+                                if let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS03025, &[]) {
+                                    diagnostics.push(Diagnostic {
+                                        range: Range::new(Position::new(s.range().start().to_u32(), 0), Position::new(s.range().end().to_u32(), 0)),
+                                        ..diagnostic_base
+                                    });
+                                }
+                            }
+                        }
                         _ => {
                             if let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS03009, &[]) {
                                 diagnostics.push(Diagnostic {
                                     range: Range::new(Position::new(s.range().start().to_u32(), 0), Position::new(s.range().end().to_u32(), 0)),
-                                    ..diagnostic_base.clone()
+                                    ..diagnostic_base
                                 });
                             }
                         }

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -792,8 +792,16 @@ fn complete_string_literal(session: &mut SessionInfo, file: &Rc<RefCell<Symbol>>
             },
             ExpectedType::DOMAIN_LIST(_) => {},
             ExpectedType::DOMAIN_COMPARATOR => {
-                for (operator, sort_text) in vec![("=", "a"), ("!=", "b"), (">", "c"), (">=", "d"), ("<", "e"), ("<=", "f"), ("=?", "g"),  ("like", "h"), ("=like", "i"), ("not like", "j"), ("ilike", "k"),
-                    ("=ilike", "l"),  ("not ilike", "m"),  ("in", "n"),  ("not in", "o"), ("child_of", "p"), ("parent_of", "q"), ("any", "r"), ("not any", "s")].iter() {
+                const BASE_OPERATORS: &[(&str, &str)] = &[("=", "a"), ("!=", "b"), (">", "c"), (">=", "d"),
+                    ("<", "e"), ("<=", "f"), ("=?", "g"),  ("like", "h"), ("=like", "i"), ("not like", "j"),
+                    ("ilike", "k"), ("=ilike", "l"),  ("not ilike", "m"),  ("in", "n"),  ("not in", "o"),
+                    ("child_of", "p"), ("parent_of", "q"), ("any", "r"), ("not any", "s")];
+                let extra: &[(&str, &str)] = if compare_semver(&session.sync_odoo.full_version, "19.3") >= Ordering::Equal {
+                   &[("access", "t")]
+                } else {
+                    &[]
+                };
+                for (operator, sort_text) in BASE_OPERATORS.iter().chain(extra) {
                     items.push(CompletionItem {
                         label: operator.to_string(),
                         insert_text: None,

--- a/server/tests/data/addons/module_for_diagnostics/models/__init__.py
+++ b/server/tests/data/addons/module_for_diagnostics/models/__init__.py
@@ -1,1 +1,2 @@
 from . import bike_parts_wheel
+from . import access_operator

--- a/server/tests/data/addons/module_for_diagnostics/models/access_operator.py
+++ b/server/tests/data/addons/module_for_diagnostics/models/access_operator.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+
+
+class BikeShop(models.Model):
+    _name = 'bike_parts.shop'
+    _description = 'Bike Shop'
+
+    name = fields.Char(string='Shop Name', required=True)
+    manager_id = fields.Many2one('res.users', string='Manager')
+
+
+class BikeOrder(models.Model):
+    _name = 'bike_parts.order'
+    _description = 'Bike Order'
+
+    name = fields.Char(string='Reference', required=True)
+    shop_id = fields.Many2one('bike_parts.shop', string='Shop')
+
+    def find_orders_for_user(self):
+        return self.search([('shop_id.manager_id', 'access', 'read')])

--- a/server/tests/diagnostics/mod.rs
+++ b/server/tests/diagnostics/mod.rs
@@ -14,6 +14,7 @@ pub mod ols01011;
 pub mod ols02001;
 pub mod ols02002;
 pub mod ols03000_1_to_23;
+pub mod ols03025;
 pub mod ols03301;
 pub mod ols03302;
 pub mod ols04000_1_to_20;

--- a/server/tests/diagnostics/ols03025.rs
+++ b/server/tests/diagnostics/ols03025.rs
@@ -1,0 +1,69 @@
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use lsp_types::NumberOrString;
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::core::symbols::symbol::Symbol;
+use odoo_ls_server::threads::SessionInfo;
+use odoo_ls_server::utils::PathSanitizer;
+
+use crate::setup::setup::*;
+use crate::test_utils::diag_on_line;
+
+const ACCESS_LINE: u32 = 19;
+
+fn revalidate(session: &mut SessionInfo, file_sym: &Rc<RefCell<Symbol>>) {
+    file_sym.borrow_mut().invalidate_sub_functions(session);
+    session.sync_odoo.add_to_validations(file_sym.clone());
+    SyncOdoo::process_rebuilds(session, false);
+}
+
+#[test]
+fn test_ols03025_access_operator_version_gated() {
+    let (mut odoo, config) = setup_server(true);
+    let mut session = create_init_session(&mut odoo, config);
+
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/addons/module_for_diagnostics/models/access_operator.py")
+        .sanitize();
+
+    let file_sym = SyncOdoo::get_symbol_of_opened_file(&mut session, &PathBuf::from(&path))
+        .expect("file symbol for access_operator.py");
+
+    // drain initial diagnostics so the next process_rebuilds publishes a clean set
+    let _ = get_diagnostics_for_path(&mut session, &path);
+
+    // version < 19.3 → exactly one OLS03025 on the search line
+    session.sync_odoo.full_version = "19.2.0".to_string();
+    revalidate(&mut session, &file_sym);
+    let diagnostics = get_diagnostics_for_path(&mut session, &path);
+    let on_line = diag_on_line(&diagnostics, ACCESS_LINE);
+    assert_eq!(
+        on_line.len(),
+        1,
+        "expected exactly one diagnostic on line {} for version 19.2, got: {:?}",
+        ACCESS_LINE + 1,
+        on_line
+    );
+    let only = on_line[0];
+    assert!(
+        matches!(&only.code, Some(NumberOrString::String(c)) if c == "OLS03025"),
+        "expected OLS03025 on line {} for version 19.2, got: {:?}",
+        ACCESS_LINE + 1,
+        only.code
+    );
+
+    // version >= 19.3 → no diagnostic at all on that line: 'access' is a valid operator,
+    // so no OLS03009 or OLS03025 should be raised
+    session.sync_odoo.full_version = "19.3.0".to_string();
+    revalidate(&mut session, &file_sym);
+    let diagnostics = get_diagnostics_for_path(&mut session, &path);
+    let on_line = diag_on_line(&diagnostics, ACCESS_LINE);
+    assert!(
+        on_line.is_empty(),
+        "expected no diagnostics on line {} for version 19.3 (neither OLS03025 nor OLS03009), got: {:?}",
+        ACCESS_LINE + 1,
+        on_line
+    );
+}


### PR DESCRIPTION
This commit adds the "access" domain operator for versions 19.3+, following its introduction by https://github.com/odoo/odoo/pull/239862.

This ensures no false positive diagnostic for invalid operator, and offers completion when suitable.