### PR TITLE
[FIX] GDB failing to start

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
             "cwd": "${workspaceFolder}/server",
             "externalConsole": false,
             "MIMode": "gdb",
-            "miDebuggerPath": "rust-gdb",
+            "miDebuggerPath": "${workspaceFolder}/server/debug_tools/rust-gdb-wrapper.sh",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",

--- a/server/debug_tools/rust-gdb-wrapper.sh
+++ b/server/debug_tools/rust-gdb-wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DEBUGINFOD_URLS=""
+exec rust-gdb "$@"


### PR DESCRIPTION
Alternatively, just `export DEBUGINFOD_URLS=""` in your .bashrc or equivalent