### PR TITLE
Optimize trees

### DIFF
--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -16,8 +16,6 @@ pub const DEBUG_REBUILD_NOW: bool = false;
 pub const DEBUG_BORROW_GUARDS: bool = false;
 pub const DEBUG_SYMBOL_TABLE_METRICS: bool = false;
 
-pub type Tree = (Vec<OYarn>, Vec<OYarn>);
-
 //type DebugYarn = String;
 
 #[macro_export]
@@ -42,13 +40,6 @@ use byteyarn::Yarn;
 #[cfg(not(all(feature="debug_yarn", debug_assertions)))]
 pub type OYarn = Yarn;
 
-pub fn tree(a: Vec<&str>, b: Vec<&str>) -> Tree {
-    (a.iter().map(|x| oyarn!("{}", *x)).collect(), b.iter().map(|x| oyarn!("{}", *x)).collect())
-}
-
-pub fn flatten_tree(tree: &Tree) -> Vec<OYarn> {
-    [tree.0.clone(), tree.1.clone()].concat()
-}
 
 
 #[derive(Debug, Eq, Hash, PartialEq, Copy, Clone)]

--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -6,7 +6,8 @@ use tracing::{error, info, warn};
 
 use crate::core::symbols::symbol_keys::{FileKey, RootKey, SourceFileKey, SymbolKey, Wk};
 use crate::{
-    constants::{flatten_tree, BuildSteps, OYarn, Tree},
+    tree::Tree,
+    constants::{BuildSteps, OYarn},
     core::symbols::storage::SymbolTable,
     threads::SessionInfo,
     utils::PathSanitizer,
@@ -93,7 +94,7 @@ impl EntryPointMgr {
         let entry = EntryPoint::new(
             &mut session.sync_odoo.symbol_table,
             path.clone(),
-            flatten_tree(&entry_point_tree),
+            entry_point_tree.flatten(),
             EntryPointType::MAIN,
             None,
             None);
@@ -111,7 +112,7 @@ impl EntryPointMgr {
         let entry = EntryPoint::new(
             &mut session.sync_odoo.symbol_table,
             path.clone(),
-            flatten_tree(&entry_point_tree),
+            entry_point_tree.flatten(),
             EntryPointType::BUILTIN,
             None,
             None);
@@ -142,7 +143,7 @@ impl EntryPointMgr {
         let entry = EntryPoint::new(
             &mut session.sync_odoo.symbol_table,
             path.clone(),
-            flatten_tree(&entry_point_tree),
+            entry_point_tree.flatten(),
             EntryPointType::PUBLIC,
             None,
             None);
@@ -162,7 +163,7 @@ impl EntryPointMgr {
         let shared_root = main_entry.borrow().root;
         let entry = EntryPoint::new_with_shared_root(
             path,
-            flatten_tree(&entry_point_tree),
+            entry_point_tree.flatten(),
             EntryPointType::ADDON,
             addon_to_odoo_path,
             addon_to_odoo_tree,
@@ -180,7 +181,7 @@ impl EntryPointMgr {
         let entry = EntryPoint::new(
             &mut session.sync_odoo.symbol_table,
             path.clone(),
-            flatten_tree(&entry_point_tree),
+            entry_point_tree.flatten(),
             EntryPointType::CUSTOM,
             None,
             None);
@@ -442,8 +443,8 @@ impl EntryPoint {
     }
 
     pub fn get_symbol(&self, symbol_table: &SymbolTable) -> Option<SymbolKey> {
-        let tree = self.addon_to_odoo_tree.as_ref().unwrap_or(&self.tree).clone();
-        let symbol = symbol_table.get_symbol(self.root.into(), &(tree, vec![]), u32::MAX);
+        let tree = self.addon_to_odoo_tree.as_ref().unwrap_or(&self.tree);
+        let symbol = symbol_table.get_symbol(self.root.into(), (tree, &[]), u32::MAX);
         match symbol.len() {
             0 => None,
             1 => Some(symbol[0]),
@@ -464,8 +465,8 @@ impl EntryPoint {
 
     /* Consider the given 'tree' path as updated (or new) and move all symbols that were searching for it
     from the not_found_symbols list to the rebuild list. Return True is something should be rebuilt */
-    pub fn search_symbols_to_rebuild(&mut self, session: &mut SessionInfo, path: &String, tree: &Tree) {
-        let flat_tree = [tree.0.clone(), tree.1.clone()].concat();
+    pub fn search_symbols_to_rebuild(&mut self, session: &mut SessionInfo, path: &String, tree: Tree) {
+        let flat_tree = tree.flatten();
         let mut to_add = [vec![], vec![], vec![]];
         for s in self.not_found_symbols.iter_valid(session.st()) {
             if let SourceFileKey::Module(p) = s {

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -847,7 +847,7 @@ impl Evaluation {
                         if base_sym_weak_eval.instance.unwrap_or(false) {
                             //TODO handle call on class instance
                         } else {
-                            if session.sync_odoo.match_tree_from_any_entry(base_sym, &(vec![Sy!("builtins")], vec![Sy!("super")])) {
+                            if session.sync_odoo.match_tree_from_any_entry(base_sym, (&["builtins"], &["super"])) {
                                 //  - If 1st argument exists, we add that class with symbol_type Super
                                 let super_class = if !expr.arguments.is_empty() {
                                     let (class_eval, diags) = Evaluation::eval_from_ast(session, &expr.arguments.args[0], parent, max_infer, false, required_dependencies);

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -41,7 +41,7 @@ fn resolve_import_stmt_hook(alias: &Alias, from_symbols: &Option<Vec<SymbolKey>>
         return None;
     }
     for &from_symbol in from_symbols.iter().flatten() {
-        if session.sync_odoo.get_main_entry_tree(from_symbol).0 != vec!["odoo", "tests", "common"] {
+        if session.sync_odoo.get_main_entry_tree(from_symbol).0 != &["odoo", "tests", "common"] {
             continue;
         }
         let mut results = resolve_import_stmt(session, source_file_symbol, Some(&Identifier::new(S!("odoo.tests"), from_stmt.unwrap().range)), &[alias.clone()], level, &mut None);
@@ -161,7 +161,7 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
         0);
         if next_symbol.is_none() && name_split.len() == 1 && from_symbols.is_some() {
             //check the last name is not a symbol in the file
-            let name_symbol_vec = from_symbols.as_ref().unwrap().iter().flat_map(|&s| session.st().get_symbol(s, &(vec![], name_first_part.clone()), u32::MAX)).collect::<Vec<_>>();
+            let name_symbol_vec = from_symbols.as_ref().unwrap().iter().flat_map(|&s| session.st().get_symbol(s, (&[], &name_first_part), u32::MAX)).collect::<Vec<_>>();
             next_symbol = if name_symbol_vec.len() > 0 {Some(name_symbol_vec.clone())} else {None};
         }
         if next_symbol.is_none() {
@@ -205,7 +205,7 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
             0);
             if last_symbol.is_none() { //If not a file/package, try to look up in symbols in current file (second parameter of get_symbol)
                 //TODO what if multiple values?
-                let name_symbol_vec = next_symbol.as_ref().unwrap().iter().flat_map(|&s| session.st().get_symbol(s, &(vec![], name_last_name.clone()), u32::MAX)).collect::<Vec<_>>();
+                let name_symbol_vec = next_symbol.as_ref().unwrap().iter().flat_map(|&s| session.st().get_symbol(s, (&[], &name_last_name), u32::MAX)).collect::<Vec<_>>();
                 last_symbol = if name_symbol_vec.len() > 0 {Some(name_symbol_vec.clone())} else {None};
                 if last_symbol.is_none() {
                     if alias.asname.is_some() {
@@ -259,14 +259,14 @@ fn resolve_packages(symbol_table: &SymbolTable, from_file: SymbolKey, level: u32
             lvl -= 1;
         }
         if lvl == 0 {
-            first_part_tree = symbol_table.get_tree(from_file).0.clone();
+            first_part_tree = symbol_table.get_tree(from_file).0;
         } else {
             let tree = symbol_table.get_tree(from_file);
             if lvl > tree.0.len() as u32 {
                 error!("Level is too high and going out of scope");
                 first_part_tree = vec![];
             } else {
-                first_part_tree = Vec::from_iter(tree.0[0..tree.0.len()- lvl as usize].iter().cloned());
+                first_part_tree = tree.0[0..tree.0.len()- lvl as usize].to_vec();
             }
         }
     }
@@ -298,7 +298,7 @@ fn get_or_create_symbol(
             Some(ref symbols) => {
                 let mut next_symbol = vec![];
                 for &s in symbols.iter() {
-                    let mut current_batch_symbol = session.st().get_symbol(s, &(vec![branch.clone()], vec![]), u32::MAX);
+                    let mut current_batch_symbol = session.st().get_symbol(s, (&[branch.clone()], &[]), u32::MAX);
                     if current_batch_symbol.is_empty() && matches!(s, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
                         current_batch_symbol = match resolve_new_symbol(session, s, &branch, asname.clone()) {
                             Ok(v) => vec![v],
@@ -346,7 +346,7 @@ fn get_or_create_symbol(
                     if ((entry.borrow().is_public() && level == 0) || entry.borrow().is_valid_for(&from_path)) && entry.borrow().addon_to_odoo_path.is_none() {
                         let entry_point = entry.borrow().get_symbol(session.st());
                         if let Some(entry_point) = entry_point {
-                            let mut next_symbols = session.st().get_symbol(entry_point, &(vec![branch.clone()], vec![]), u32::MAX);
+                            let mut next_symbols = session.st().get_symbol(entry_point, (&[branch.clone()], &[]), u32::MAX);
                             if next_symbols.is_empty() && matches!(entry_point, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
                                 next_symbols = match resolve_new_symbol(session, entry_point, &branch, asname.clone()) {
                                     Ok(v) => vec![v],

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1175,18 +1175,10 @@ impl SyncOdoo {
 
     pub fn get_main_entry_tree(&self, symbol_key: impl Into<SymbolKey>) -> Tree {
         let symbol_key = symbol_key.into();
-        let symbol_table = &self.symbol_table;
-        let mut tree = symbol_table.get_tree(symbol_key);
-        let len_first_part = tree.0.len();
+        let mut tree = self.symbol_table.get_tree(symbol_key);
         let odoo_tree = &self.main_entry_tree;
-        if len_first_part >= odoo_tree.len() {
-            for component in odoo_tree.iter() {
-                if tree.0.len() > 0 && &tree.0[0] == component {
-                    tree.0.remove(0);
-                } else {
-                    return symbol_table.get_tree(symbol_key);
-                }
-            }
+        if tree.0.starts_with(odoo_tree) {
+            tree.0.drain(0..odoo_tree.len());
         }
         tree
     }

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -42,6 +42,7 @@ use std::path::{Path, PathBuf};
 use std::env;
 use regex::Regex;
 use crate::{constants::*, Sy};
+use crate::tree::{Tree, TreeStrSlice};
 use super::config::{self, DEFAULT_PROFILE_NAME, get_configuration, ConfigEntry, ConfigFile};
 use super::entry_point::{EntryPoint, EntryPointMgr};
 use super::file_mgr::FileMgr;
@@ -362,7 +363,7 @@ impl SyncOdoo {
         };
         let tree_builtins = path.to_tree();
         let entry_stdlib = session.sync_odoo.find_stdlib_entry_point();
-        let disk_dir_builtins = session.st().get_symbol(entry_stdlib.borrow().root.into(), &tree_builtins, u32::MAX);
+        let disk_dir_builtins = session.st().get_symbol(entry_stdlib.borrow().root.into(), tree_builtins.as_slice(), u32::MAX);
         if disk_dir_builtins.is_empty() {
             panic!("Unable to find builtins disk dir symbol");
         }
@@ -477,11 +478,11 @@ impl SyncOdoo {
             return false;
         }
         //search common odoo addons path
-        let addon_symbols = session.sync_odoo.get_symbol(&odoo_path, &tree(vec!["odoo", "addons"], vec![]), u32::MAX);
+        let addon_symbols = session.sync_odoo.get_symbol(&odoo_path, (&["odoo", "addons"], &[]), u32::MAX);
         let addon_symbol = if let Some(&SymbolKey::Namespace(addon_ns)) = addon_symbols.first() {
             addon_ns
         } else {
-            let odoo = session.sync_odoo.get_symbol(&odoo_path, &tree(vec!["odoo"], vec![]), u32::MAX);
+            let odoo = session.sync_odoo.get_symbol(&odoo_path, (&["odoo"], &[]), u32::MAX);
             if odoo.is_empty() {
                 session.log_message(MessageType::WARNING, "Odoo not found. Switching to non-odoo mode...".to_string());
                 session.sync_odoo.has_odoo_main_entry = false;
@@ -522,7 +523,7 @@ impl SyncOdoo {
 
     fn build_modules(session: &mut SessionInfo) {
         let Some(&SymbolKey::Namespace(addons_symbol)) = session.sync_odoo.get_symbol(
-            session.sync_odoo.config.odoo_path.as_ref().unwrap(), &tree(vec!["odoo", "addons"], vec![]), u32::MAX
+            session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "addons"], &[]), u32::MAX
         ).first() else {
             let message = S!("OdooLS: Unable to find 'odoo/addons'. Check the addons_paths in your config or your file structure. Skipping addons loading...");
             warn!("{}", message);
@@ -598,13 +599,17 @@ impl SyncOdoo {
 
 
     //search for a symbol with a tree local to an unknown entrypoint
-    pub fn get_symbol(&self, from_path: &str, tree: &Tree, position: u32) -> Vec<SymbolKey> {
+    pub fn get_symbol(&self, from_path: &str, tree: TreeStrSlice, position: u32) -> Vec<SymbolKey> {
         //find which entrypoint to use
         for entry in self.entry_point_mgr.borrow().iter_all() {
             let entry_point = entry.borrow();
             if entry_point.is_public() || PathBuf::from(from_path).starts_with(&entry_point.path) {
-                let tree: Tree = (entry_point.addon_to_odoo_tree.as_ref().unwrap_or(&entry_point.tree).iter().chain(&tree.0).cloned().collect(), tree.1.clone());
-                let symbols = self.symbol_table.get_symbol(entry_point.root.into(), &tree, position);
+                let prefix = entry_point.addon_to_odoo_tree.as_ref().unwrap_or(&entry_point.tree);
+                let tree_0: Vec<&str> = prefix.iter()
+                    .map(|y| y.as_slice())
+                    .chain(tree.0.iter().copied())
+                    .collect();
+                let symbols = self.symbol_table.get_symbol(entry_point.root.into(), (&tree_0, &tree.1), position);
                 if !symbols.is_empty() {
                     return symbols;
                 }
@@ -673,7 +678,7 @@ impl SyncOdoo {
             let Some(parent) = weak_sym.upgrade(session.st()) else {
                 continue;
             };
-            let in_addons = session.sync_odoo.get_main_entry_tree(parent) == tree(vec!["odoo", "addons"], vec![]);
+            let in_addons = session.sync_odoo.get_main_entry_tree(parent) == (&["odoo", "addons"], &[]);
             let new_symbol = SymbolTable::create_from_path(session, &PathBuf::from(path), parent, in_addons);
             let Some(new_symbol) = new_symbol else {
                 continue;
@@ -1042,7 +1047,7 @@ impl SyncOdoo {
             }
             if entry.borrow().is_valid_for(path) {
                 let tree = entry.borrow().get_tree_for_entry(path);
-                let path_symbols = session.st().get_symbol(entry.borrow().root.into(), &tree, u32::MAX);
+                let path_symbols = session.st().get_symbol(entry.borrow().root.into(), tree.as_slice(), u32::MAX);
                 let Some(&path_symbol) = path_symbols.first() else {
                     continue;
                 };
@@ -1114,7 +1119,7 @@ impl SyncOdoo {
             }
             if (entry.borrow().typ == EntryPointType::MAIN || entry.borrow().addon_to_odoo_path.is_some()) && entry.borrow().is_valid_for(path) {
                 let tree = entry.borrow().get_tree_for_entry(path);
-                let path_symbol = session.st().get_symbol(entry.borrow().root.into(), &tree, u32::MAX);
+                let path_symbol = session.st().get_symbol(entry.borrow().root.into(), tree.as_slice(), u32::MAX);
                 if path_symbol.is_empty() {
                     continue;
                 }
@@ -1134,7 +1139,7 @@ impl SyncOdoo {
             if !entry.borrow().is_public() && &path_in_tree == &PathBuf::from(&entry.borrow().path) {
                 found_an_entry = true;
                 let tree = entry.borrow().get_tree_for_entry(path);
-                let path_symbol = session.st().get_symbol(entry.borrow().root.into(), &tree, u32::MAX);
+                let path_symbol = session.st().get_symbol(entry.borrow().root.into(), tree.as_slice(), u32::MAX);
                 if path_symbol.is_empty() {
                     continue;
                 }
@@ -1183,7 +1188,7 @@ impl SyncOdoo {
         tree
     }
 
-    pub fn match_tree_from_any_entry(&self, symbol_key: SymbolKey, tree: &Tree) -> bool {
+    pub fn match_tree_from_any_entry(&self, symbol_key: SymbolKey, tree: TreeStrSlice) -> bool {
         let symbol_table = &self.symbol_table;
         let (mut self_tree, entry) = symbol_table.get_tree_and_entry(symbol_key);
         'outer: for entry in self.entry_point_mgr.borrow().iter_for_import(&entry) {
@@ -1195,7 +1200,7 @@ impl SyncOdoo {
                     continue 'outer;
                 }
             }
-            return (self_tree.0.split_off(entry.borrow().tree.len()), self_tree.1) == *tree;
+            return Tree(self_tree.0.split_off(entry.borrow().tree.len()), self_tree.1) == tree;
         }
         false
     }
@@ -1213,7 +1218,7 @@ impl SyncOdoo {
         false
     }
 
-    pub fn is_in_main_entry(session: &mut SessionInfo, path: &Vec<OYarn>) -> bool{
+    pub fn is_in_main_entry(session: &mut SessionInfo, path: &[OYarn]) -> bool{
         path.starts_with(session.sync_odoo.main_entry_tree.as_slice())
     }
 
@@ -1299,84 +1304,84 @@ impl SyncOdoo {
 
     pub fn get_ts_dict(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.dict.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.dict = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("dict")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.dict = self.get_symbol("", (&["builtins"], &["dict"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.dict
     }
 
     pub fn get_ts_tuple(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.tuple.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.tuple = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("tuple")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.tuple = self.get_symbol("", (&["builtins"], &["tuple"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.tuple
     }
 
     pub fn get_ts_set(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.set.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.set = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("set")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.set = self.get_symbol("", (&["builtins"], &["set"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.set
     }
 
     pub fn get_ts_list(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.list.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.list = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("list")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.list = self.get_symbol("", (&["builtins"], &["list"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.list
     }
 
     pub fn get_ts_string(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.string.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.string = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("str")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.string = self.get_symbol("", (&["builtins"], &["str"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.string
     }
 
     pub fn get_ts_boolean(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.boolean.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.boolean = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("bool")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.boolean = self.get_symbol("", (&["builtins"], &["bool"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.boolean
     }
 
     pub fn get_ts_int(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.int.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.int = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("int")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.int = self.get_symbol("", (&["builtins"], &["int"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.int
     }
 
     pub fn get_ts_float(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.float.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.float = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("float")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.float = self.get_symbol("", (&["builtins"], &["float"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.float
     }
 
     pub fn get_ts_complex(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.complex.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.complex = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("complex")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.complex = self.get_symbol("", (&["builtins"], &["complex"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.complex
     }
 
     pub fn get_ts_ellipsis(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.ellipsis.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.ellipsis = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("Ellipsis")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.ellipsis = self.get_symbol("", (&["builtins"], &["Ellipsis"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.ellipsis
     }
 
     pub fn get_ts_bytes(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.bytes.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.bytes = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("bytes")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.bytes = self.get_symbol("", (&["builtins"], &["bytes"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.bytes
     }
 
     pub fn get_ts_object(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.object.is_expired(&self.symbol_table) {
-            self.typeshed_weak_cache.object = self.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("object")]), u32::MAX).last().copied().unwrap().into();
+            self.typeshed_weak_cache.object = self.get_symbol("", (&["builtins"], &["object"]), u32::MAX).last().copied().unwrap().into();
         }
         self.typeshed_weak_cache.object
     }
@@ -1891,7 +1896,7 @@ impl Odoo {
                             let tree = session.sync_odoo.path_to_main_entry_tree(&path);
                             let tree_path = path.to_tree_path();
                             if tree.is_none() ||
-                            (session.st().get_symbol(session.sync_odoo.get_main_entry().borrow().root.into(), tree.as_ref().unwrap(), u32::MAX).is_empty()
+                            (session.st().get_symbol(session.sync_odoo.get_main_entry().borrow().root.into(), tree.as_ref().unwrap().as_slice(), u32::MAX).is_empty()
                             && session.sync_odoo.get_main_entry().borrow().data_symbols.get(&path.sanitize()).is_none())
                             {
                                 //main entry doesn't handle this file. Let's test customs entries, or create a new one
@@ -1989,13 +1994,13 @@ impl Odoo {
         let tree = session.sync_odoo.path_to_main_entry_tree(&PathBuf::from(path.clone()));
         if let Some(tree) = tree {
             if let Some(main) = ep_mgr.borrow().main_entry_point.as_ref() {
-                main.borrow_mut().search_symbols_to_rebuild(session, path, &tree);
+                main.borrow_mut().search_symbols_to_rebuild(session, path, tree);
             }
         }
         for entry in ep_mgr.borrow().iter_all_but_main() {
             if entry.borrow().is_valid_for(&PathBuf::from(path)) {
                 let tree = entry.borrow().get_tree_for_entry(&PathBuf::from(path.clone()));
-                entry.borrow_mut().search_symbols_to_rebuild(session, path, &tree);
+                entry.borrow_mut().search_symbols_to_rebuild(session, path, tree);
             }
         }
         //test if the new path is a new module
@@ -2012,7 +2017,7 @@ impl Odoo {
             }
             if parent_path.sanitize() == session.sync_odoo.config.odoo_path.as_deref().unwrap_or_default().to_string() + "/odoo/addons" {
                 let addons_symbol = session.sync_odoo.get_main_entry().borrow().get_symbol(session.st()).map(|ep_sym_key|
-                    session.st().get_symbol(ep_sym_key, &(vec![Sy!("odoo"), Sy!("addons")], vec![]), u32::MAX)
+                    session.st().get_symbol(ep_sym_key, (&["odoo", "addons"], &[]), u32::MAX)
                 );
                 match addons_symbol {
                     Some(addons_symbol) if !addons_symbol.is_empty() => {
@@ -2050,7 +2055,7 @@ impl Odoo {
             SyncOdoo::process_rebuilds(session, false);
             let tree = session.sync_odoo.path_to_main_entry_tree(&new_path_buf);
             if let Some(tree) = tree {
-                if  new_path_buf.is_file() &&  session.st().get_symbol(session.sync_odoo.get_main_entry().borrow().root.into(), &tree, u32::MAX).is_empty() {
+                if  new_path_buf.is_file() &&  session.st().get_symbol(session.sync_odoo.get_main_entry().borrow().root.into(), tree.as_slice(), u32::MAX).is_empty() {
                     //file has not been added to main entry. Let's build a new entry point
                     EntryPointMgr::create_new_custom_entry_for_path(session, &new_path_updated, &new_path_buf.sanitize());
                     SyncOdoo::process_rebuilds(session, false);
@@ -2078,7 +2083,7 @@ impl Odoo {
             let path_updated = PathBuf::from(path.clone()).to_tree_path().sanitize();
             let tree = session.sync_odoo.path_to_main_entry_tree(&PathBuf::from(path.clone()));
             if PathBuf::from(&path).is_file() && (tree.is_none() || (
-                session.st().get_symbol(session.sync_odoo.get_main_entry().borrow().root.into(), &tree.unwrap(), u32::MAX).is_empty()
+                session.st().get_symbol(session.sync_odoo.get_main_entry().borrow().root.into(), tree.unwrap().as_slice(), u32::MAX).is_empty()
                 && session.sync_odoo.get_main_entry().borrow().data_symbols.get(&path_updated).is_none()
             )) {
                 //file has not been added to main entry. Let's build a new entry point

--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -169,18 +169,28 @@ pub struct PythonArchBuilderHooks {}
 impl PythonArchBuilderHooks {
 
     pub fn on_class_def(session: &mut SessionInfo, class_key: ClassKey) {
-        let symbol_key: SymbolKey = class_key.into();
-        let tree = session.st().get_tree(symbol_key);
-        let odoo_tree = session.sync_odoo.get_main_entry_tree(symbol_key);
-        let name = session.st().name(symbol_key).clone();
+        let has_main_entry = session.sync_odoo.has_main_entry;
+        let mut lazy_tree = None;
+        let mut lazy_odoo_tree = None;
+        let name = session.st()[class_key].name.clone();
         for hook in arch_class_hooks.iter() {
-            for hook_tree in hook.trees.iter() {
-                if session.sync_odoo.version >= hook_tree.0 && session.sync_odoo.version < hook_tree.1 {
-                    if name.eq(hook_tree.2.1.last().unwrap()) {
-                        if (hook.odoo_entry && session.sync_odoo.has_main_entry && odoo_tree == hook_tree.2) || (!hook.odoo_entry && tree == hook_tree.2) {
-                            (hook.func)(&mut session.sync_odoo.symbol_table, class_key);
-                        }
-                    }
+            if hook.odoo_entry && !has_main_entry {
+                continue;
+            }
+            for (min_version, max_version, hook_tree) in hook.trees.iter() {
+                if !name.eq(hook_tree.1.last().unwrap()) {
+                    continue; // skip if class name doesn't match
+                }
+                if session.sync_odoo.version < *min_version || session.sync_odoo.version >= *max_version {
+                    continue; //skip if version not in range
+                }
+                let tree = if hook.odoo_entry {
+                    lazy_odoo_tree.get_or_insert_with(|| session.sync_odoo.get_main_entry_tree(class_key))
+                } else {
+                    lazy_tree.get_or_insert_with(|| session.st().get_tree(class_key))
+                };
+                if tree == hook_tree {
+                    (hook.func)(&mut session.sync_odoo.symbol_table, class_key);
                 }
             }
         }

--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -6,8 +6,8 @@ use crate::core::import_resolver::manual_import;
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::symbol_keys::{ClassKey, SourceFileKey, SymbolKey};
 use crate::threads::SessionInfo;
-use crate::{Sy, S};
-use crate::constants::OYarn;
+use crate::S;
+use crate::tree::TreeStrSlice;
 
 use super::odoo::SyncOdoo;
 
@@ -16,7 +16,7 @@ type Version = (u32, u32); // major, minor
 
 pub struct PythonArchClassHook {
     pub odoo_entry: bool,
-    pub trees: Vec<(Version, Version, (Vec<OYarn>, Vec<OYarn>))>,
+    pub trees: Vec<(Version, Version, TreeStrSlice<'static>)>,
     pub func: PythonArchClassHookFn
 }
 
@@ -25,16 +25,16 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
     PythonArchClassHook {
         odoo_entry: true,
         trees: vec![
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel")]))
+            ((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel"]))
         ],
         func: |symbol_table: &mut SymbolTable, class: ClassKey| {
             // ----------- env ------------
             let symbol_key: SymbolKey = class.into();
-            let env = symbol_table.get_symbol(symbol_key, &(vec![], vec![Sy!("env")]), u32::MAX);
+            let env = symbol_table.get_symbol(symbol_key, (&[], &["env"]), u32::MAX);
             if env.is_empty() {
                 let mut range = symbol_table[class].range.clone();
-                let slots = symbol_table.get_symbol(symbol_key, &(vec![], vec![Sy!("__slots__")]), u32::MAX);
+                let slots = symbol_table.get_symbol(symbol_key, (&[], &["__slots__"]), u32::MAX);
                 if slots.len() == 1 {
                     range = symbol_table.range(slots[0]).clone();
                 }
@@ -45,12 +45,12 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
     PythonArchClassHook {
         odoo_entry: true,
         trees: vec![
-            ((15, 3), (19, 2), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("Request")])),
-            ((19, 2), (999, 0), (vec![Sy!("odoo"), Sy!("http"), Sy!("requestlib")], vec![Sy!("Request")]))
+            ((15, 3), (19, 2), (&["odoo", "http"], &["Request"])),
+            ((19, 2), (999, 0), (&["odoo", "http", "requestlib"], &["Request"]))
         ],
         func: |symbol_table: &mut SymbolTable, class: ClassKey| {
             // ----------- Request.env ------------
-            let has_env = !symbol_table.get_content_symbol(class.into(), &Sy!("env"), u32::MAX).symbols.is_empty();
+            let has_env = !symbol_table.get_content_symbol(class.into(), "env", u32::MAX).symbols.is_empty();
             if has_env {
                 return;
             }
@@ -61,11 +61,11 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
     PythonArchClassHook {
         odoo_entry: true,
         trees: vec![
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("Environment")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("environments")], vec![Sy!("Environment")]))
+            ((0, 0), (18, 1), (&["odoo", "api"], &["Environment"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "environments"], &["Environment"]))
         ],
         func: |symbol_table: &mut SymbolTable, class: ClassKey| {
-            let new_sym = symbol_table.get_symbol(class.into(), &(vec![], vec![Sy!("__new__")]), u32::MAX);
+            let new_sym = symbol_table.get_symbol(class.into(), (&[], &["__new__"]), u32::MAX);
             let mut range = symbol_table[class].range.clone();
             if new_sym.len() == 1 {
                 range = symbol_table.range(new_sym[0]).clone();
@@ -88,7 +88,7 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
     PythonArchClassHook {
         odoo_entry: true,
         trees: vec![
-            ((15, 0), (999, 0), (vec![Sy!("odoo"), Sy!("addons"), Sy!("base"), Sy!("models"), Sy!("ir_rule")], vec![Sy!("IrRule")])),
+            ((15, 0), (999, 0), (&["odoo", "addons", "base", "models", "ir_rule"], &["IrRule"])),
         ],
         func: |symbol_table: &mut SymbolTable, class: ClassKey| {
             let range = symbol_table[class].range.clone();
@@ -99,54 +99,54 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
     PythonArchClassHook {
         odoo_entry: true,
         trees: vec![
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Boolean")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Integer")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Float")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Monetary")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Char")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Text")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Html")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Date")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Datetime")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Binary")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Image")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Selection")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Reference")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Many2one")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Many2oneReference")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Json")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Properties")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("PropertiesDefinition")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("One2many")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Many2many")])),
-            ((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Id")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_misc")], vec![Sy!("Boolean")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_numeric")], vec![Sy!("Integer")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_numeric")], vec![Sy!("Float")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_numeric")], vec![Sy!("Monetary")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_textual")], vec![Sy!("Char")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_textual")], vec![Sy!("Text")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_textual")], vec![Sy!("Html")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_temporal")], vec![Sy!("Date")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_temporal")], vec![Sy!("Datetime")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_binary")], vec![Sy!("Binary")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_binary")], vec![Sy!("Image")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_selection")], vec![Sy!("Selection")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_reference")], vec![Sy!("Reference")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_relational")], vec![Sy!("Many2one")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_reference")], vec![Sy!("Many2oneReference")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_misc")], vec![Sy!("Json")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_properties")], vec![Sy!("Properties")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_properties")], vec![Sy!("PropertiesDefinition")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_relational")], vec![Sy!("One2many")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_relational")], vec![Sy!("Many2many")])),
-            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_misc")], vec![Sy!("Id")])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Boolean"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Integer"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Float"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Monetary"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Char"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Text"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Html"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Date"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Datetime"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Binary"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Image"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Selection"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Reference"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Many2one"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Many2oneReference"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Json"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Properties"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["PropertiesDefinition"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["One2many"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Many2many"])),
+            ((0, 0), (18, 1), (&["odoo", "fields"], &["Id"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_misc"], &["Boolean"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_numeric"], &["Integer"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_numeric"], &["Float"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_numeric"], &["Monetary"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_textual"], &["Char"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_textual"], &["Text"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_textual"], &["Html"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_temporal"], &["Date"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_temporal"], &["Datetime"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_binary"], &["Binary"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_binary"], &["Image"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_selection"], &["Selection"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_reference"], &["Reference"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_relational"], &["Many2one"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_reference"], &["Many2oneReference"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_misc"], &["Json"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_properties"], &["Properties"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_properties"], &["PropertiesDefinition"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_relational"], &["One2many"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_relational"], &["Many2many"])),
+            ((18, 1), (999, 0), (&["odoo", "orm", "fields_misc"], &["Id"])),
         ],
         func: |symbol_table: &mut SymbolTable, class: ClassKey| {
             let symbol_key: SymbolKey = class.into();
             let range = symbol_table[class].range.clone();
             // ----------- __get__ ------------
-            let get_sym = symbol_table.get_symbol(symbol_key, &(vec![], vec![Sy!("__get__")]), u32::MAX);
+            let get_sym = symbol_table.get_symbol(symbol_key, (&[], &["__get__"]), u32::MAX);
             if get_sym.is_empty() {
                 symbol_table.add_new_function(symbol_key, &S!("__get__"), &range, &range.end());
             } else {
@@ -156,7 +156,7 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
                 }
             }
             // ----------- __init__ ------------
-            let get_sym = symbol_table.get_symbol(symbol_key, &(vec![], vec![Sy!("__init__")]), u32::MAX);
+            let get_sym = symbol_table.get_symbol(symbol_key, (&[], &["__init__"]), u32::MAX);
             if get_sym.is_empty() {
                 symbol_table.add_new_function(symbol_key, &S!("__init__"), &range, &range.end());
             }
@@ -199,7 +199,7 @@ impl PythonArchBuilderHooks {
     pub fn on_file_done(session: &mut SessionInfo, symbol: SourceFileKey) {
         let name = session.st().name(symbol).clone();
         if name == "release" {
-            if session.sync_odoo.get_main_entry_tree(symbol) == (vec![Sy!("odoo"), Sy!("release")], vec![]) {
+            if session.sync_odoo.get_main_entry_tree(symbol) == (&["odoo", "release"], &[]) {
                 let file_path = session.st().path(symbol);
                 let new_version = SyncOdoo::read_version(session, PathBuf::from(file_path));
                 if new_version != session.sync_odoo.version {
@@ -208,9 +208,9 @@ impl PythonArchBuilderHooks {
             }
         } else if name == "init" {
             if session.sync_odoo.version >= (18, 1) {
-                if session.sync_odoo.get_main_entry_tree(symbol) == (vec![Sy!("odoo"), Sy!("init")], vec![]) {
+                if session.sync_odoo.get_main_entry_tree(symbol) == (&["odoo", "init"], &[]) {
                     let file_path = session.st().path(symbol);
-                    let odoo_namespace = session.sync_odoo.get_symbol(file_path, &(vec![Sy!("odoo")], vec![]), u32::MAX);
+                    let odoo_namespace = session.sync_odoo.get_symbol(file_path, (&["odoo"], &[]), u32::MAX);
                     if let Some(&odoo_namespace) = odoo_namespace.get(0) {
                         // create _ and Command as ext_symbols
                         let owner = symbol.into();
@@ -222,12 +222,12 @@ impl PythonArchBuilderHooks {
                 }
             }
         } else if name == "werkzeug" {
-            if session.sync_odoo.get_main_entry_tree(symbol) == (vec![Sy!("odoo"), Sy!("_monkeypatches"), Sy!("werkzeug")], vec![]) {
+            if session.sync_odoo.get_main_entry_tree(symbol) == (&["odoo", "_monkeypatches", "werkzeug"], &[]) {
                 //doing this patch like this imply that an odoo project will make these functions available for all entrypoints, but heh
                 let file_path = session.st().path(symbol);
-                let werkzeug_url = session.sync_odoo.get_symbol(file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![]), u32::MAX);
+                let werkzeug_url = session.sync_odoo.get_symbol(file_path, (&["werkzeug", "urls"], &[]), u32::MAX);
                 if let Some(&werkzeug_url) = werkzeug_url.first() {
-                    let url_join = session.st().get_symbol(werkzeug_url, &(vec![], vec![Sy!("url_join")]), u32::MAX);
+                    let url_join = session.st().get_symbol(werkzeug_url, (&[], &["url_join"]), u32::MAX);
                     if url_join.is_empty() { //else, installed version is already patched
                         //fake variable, as ext_symbols are not seen through get_symbol, etc...
                         session.st_mut().add_new_variable(werkzeug_url, "url_decode", &TextRange::default());
@@ -246,7 +246,7 @@ impl PythonArchBuilderHooks {
                 }
             }
         } else if name == "urls" {
-            if session.st().get_local_tree(symbol.into()) == (vec![Sy!("werkzeug"), Sy!("urls")], vec![]) {
+            if session.st().get_local_tree(symbol.into()) == (&["werkzeug", "urls"], &[]) {
                 //manually load patch, as a manual dependency
                 let full_path_monkeypatches = S!("odoo._monkeypatches");
                 let mut main_odoo_symbol = None;

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -14,7 +14,7 @@ use crate::core::symbols::{ModuleSymbol, SymbolMgr};
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::symbol_keys::{ClassKey, FunctionKey, ModuleKey, SourceFileKey, SymbolKey, VariableKey};
 use crate::core::symbols::VariableSymbol;
-use crate::{constants::*, oyarn, Sy};
+use crate::{constants::*, oyarn};
 use crate::core::import_resolver::resolve_import_stmt;
 use crate::core::odoo::SyncOdoo;
 use crate::core::evaluation::Evaluation;
@@ -923,7 +923,7 @@ impl PythonArchEval {
                             for context_mgr_eval in context_mgr_evals.iter() {
                                 let symbol = context_mgr_eval.symbol.get_symbol_as_weak(session, &mut None, &mut self.diagnostics, Some(session.st().parent_file_or_function(variable_key.into()).unwrap()));
                                 if let Some(symbol) = symbol.weak.upgrade(session.st()) {
-                                    let _enter_ = session.st().get_symbol(symbol, &(vec![], vec![Sy!("__enter__")]), u32::MAX);
+                                    let _enter_ = session.st().get_symbol(symbol, (&[], &["__enter__"]), u32::MAX);
                                     if let Some(&SymbolKey::Function(_enter_)) = _enter_.last() {
                                         SyncOdoo::ensure_func_evaluations(session, _enter_);
                                         enter_evals.extend(session.st()[_enter_].evaluations.clone());
@@ -987,7 +987,7 @@ impl PythonArchEval {
                     &mut None,
                     false,
                     false,
-                    Some((vec![Sy!("typing")], vec![Sy!("Self")])),
+                    Some((&["typing"], &["Self"])),
                     None
                 ).len() > 0
             ){

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -733,23 +733,37 @@ pub struct PythonArchEvalHooks {
 impl PythonArchEvalHooks {
 
     pub fn on_file_eval(session: &mut SessionInfo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: SourceFileKey) {
-        let tree = session.st().get_tree(symbol.into());
-        let odoo_tree = session.sync_odoo.get_main_entry_tree(symbol);
+        let has_main_entry = session.sync_odoo.has_main_entry;
+        let mut lazy_tree = None;
+        let mut lazy_odoo_tree = None;
         let name = session.st().name(symbol).clone();
         for hook in arch_eval_file_hooks.iter() {
+            if hook.odoo_entry && !has_main_entry {
+                continue;
+            }
             for (min_version, max_version, hook_tree) in hook.trees.iter() {
+                if !name.eq(hook_tree.0.last().unwrap()) {
+                    continue; // skip if file name not matched
+                }
                 if session.sync_odoo.version < *min_version || session.sync_odoo.version >= *max_version {
                     continue; //skip if version not in range
                 }
-                if name.eq(hook_tree.0.last().unwrap()) &&
-                ((hook.odoo_entry && session.sync_odoo.has_main_entry && odoo_tree.0 == hook_tree.0) || (!hook.odoo_entry && tree.0 == hook_tree.0)) {
-                    if hook_tree.1.is_empty() {
-                        (hook.func)(session.sync_odoo, entry_point, symbol, symbol.into());
-                    } else {
-                        let sub_symbol = session.st().get_symbol(symbol.into(), &(vec![], hook_tree.1.clone()), u32::MAX);
-                        if !sub_symbol.is_empty() {
-                            (hook.func)(session.sync_odoo, entry_point, symbol, *sub_symbol.last().unwrap());
-                        }
+                let file_tree_matches = if hook.odoo_entry {
+                    let odoo_tree = lazy_odoo_tree.get_or_insert_with(|| session.sync_odoo.get_main_entry_tree(symbol));
+                    odoo_tree.0 == hook_tree.0
+                } else {
+                    let tree = lazy_tree.get_or_insert_with(|| session.st().get_tree(symbol));
+                    tree.0 == hook_tree.0
+                };
+                if !file_tree_matches {
+                    continue;
+                }
+                if hook_tree.1.is_empty() {
+                    (hook.func)(session.sync_odoo, entry_point, symbol, symbol.into());
+                } else {
+                    let sub_symbol = session.st().get_symbol(symbol.into(), &(vec![], hook_tree.1.clone()), u32::MAX);
+                    if !sub_symbol.is_empty() {
+                        (hook.func)(session.sync_odoo, entry_point, symbol, *sub_symbol.last().unwrap());
                     }
                 }
             }
@@ -758,18 +772,28 @@ impl PythonArchEvalHooks {
 
     pub fn on_function_eval(session: &mut SessionInfo, entry_point: &Rc<RefCell<EntryPoint>>, function: FunctionKey) {
         let symbol_key: SymbolKey = function.into();
-        let tree = session.st().get_tree(symbol_key);
-        let odoo_tree = session.sync_odoo.get_main_entry_tree(symbol_key);
+        let has_main_entry = session.sync_odoo.has_main_entry;
+        let mut lazy_tree = None;
+        let mut lazy_odoo_tree = None;
         let name = session.st().name(symbol_key).clone();
         for hook in arch_eval_function_hooks.iter() {
-            for hook_tree in hook.tree.iter() {
-                if session.sync_odoo.version < hook_tree.0 || session.sync_odoo.version >= hook_tree.1 {
+            if hook.odoo_entry && !has_main_entry {
+                continue;
+            }
+            for (min_version, max_version, hook_tree) in hook.tree.iter() {
+                if !name.eq(hook_tree.1.last().unwrap()) {
+                    continue; // skip if function name not matched
+                }
+                if session.sync_odoo.version < *min_version || session.sync_odoo.version >= *max_version {
                     continue; //skip if version not in range
                 }
-                if name.eq(hook_tree.2.1.last().unwrap()) {
-                    if (hook.odoo_entry && session.sync_odoo.has_main_entry && odoo_tree == hook_tree.2) || (!hook.odoo_entry && tree == hook_tree.2) {
-                        (hook.func)(session.sync_odoo, entry_point, function);
-                    }
+                let tree = if hook.odoo_entry {
+                    lazy_odoo_tree.get_or_insert_with(|| session.sync_odoo.get_main_entry_tree(symbol_key))
+                } else {
+                    lazy_tree.get_or_insert_with(|| session.st().get_tree(symbol_key))
+                };
+                if tree == hook_tree {
+                    (hook.func)(session.sync_odoo, entry_point, function);
                 }
             }
         }

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -14,6 +14,8 @@ use crate::core::evaluation::GetSymbolHook;
 use crate::core::odoo::SyncOdoo;
 use crate::core::evaluation::Context;
 use crate::constants::*;
+use crate::tree::OYarnExt;
+use crate::tree::Tree;
 use crate::core::symbols::symbol_keys::FunctionKey;
 use crate::core::symbols::symbol_keys::SourceFileKey;
 use crate::core::symbols::symbol_keys::SymbolKey;
@@ -23,6 +25,7 @@ use crate::oyarn;
 use crate::threads::SessionInfo;
 use crate::Sy;
 use crate::S;
+use crate::tree::TreeStrSlice;
 
 use super::entry_point::EntryPoint;
 use super::evaluation::{ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationSymbol, EvaluationSymbolWeak};
@@ -33,17 +36,17 @@ type PythonArchEvalHookFile = fn (odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryP
 type Version = (u32, u32); // (major, minor)
 
 fn get_base_model_symbol(odoo: &mut SyncOdoo) -> Option<SymbolKey> {
-    let base_model_tree = if odoo.version >= (18, 1) {
-        (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel")])
+    let base_model_tree: TreeStrSlice = if odoo.version >= (18, 1) {
+        (&["odoo", "orm", "models"], &["BaseModel"])
     } else {
-        (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel")])
+        (&["odoo", "models"], &["BaseModel"])
     };
-    let base_model_symbol = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &base_model_tree, u32::MAX);
+    let base_model_symbol = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), base_model_tree, u32::MAX);
     base_model_symbol.first().copied()
 }
 pub struct PythonArchEvalFileHook {
     pub odoo_entry: bool,
-    pub trees: Vec<(Version, Version, (Vec<OYarn>, Vec<OYarn>))>, //if tree content is set, will provide symbol in file content instead of the file symbol to func
+    pub trees: Vec<(Version, Version, TreeStrSlice<'static>)>, //if tree content is set, will provide symbol in file content instead of the file symbol to func
     pub if_exist_only: bool,
     pub func: PythonArchEvalHookFile
 }
@@ -51,15 +54,15 @@ pub struct PythonArchEvalFileHook {
 #[allow(non_upper_case_globals)]
 static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {vec![
     PythonArchEvalFileHook {odoo_entry: true,
-                        trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("env")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("env")]))],
+                        trees: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "env"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "env"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
-        let env_files = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("api")], vec![]), u32::MAX);
+        let env_files = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "api"], &[]), u32::MAX);
         let Some(env_file) = env_files.last().and_then(|&f| f.as_source_file_key()) else {
             return;
         };
-        let env_classes = odoo.symbol_table.get_symbol(env_file.into(), &(vec![], vec![Sy!("Environment")]), u32::MAX);
+        let env_classes = odoo.symbol_table.get_symbol(env_file.into(), (&[], &["Environment"]), u32::MAX);
         let Some(&env_class) = env_classes.last() else {
             return;
         };
@@ -79,11 +82,11 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
         odoo.symbol_table.add_dependency(file_symbol, env_file, BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                        trees: vec![((0, 0), (15, 3), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("request")]))],
+                        trees: vec![((0, 0), (15, 3), (&["odoo", "http"], &["request"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
         // --------- request: WebRequest (before 15.3) ---------
-        let web_request_class_syms = odoo.symbol_table.get_symbol(file_symbol.into(), &(vec![], vec![Sy!("WebRequest")]), u32::MAX);
+        let web_request_class_syms = odoo.symbol_table.get_symbol(file_symbol.into(), (&[], &["WebRequest"]), u32::MAX);
         let Some(&web_request_class) = web_request_class_syms.last() else {
             return;
         };
@@ -92,13 +95,13 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                         trees: vec![
-                            ((15, 3), (19, 2), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("request")])),
-                            ((19, 2), (999, 0), (vec![Sy!("odoo"), Sy!("http"), Sy!("requestlib")], vec![Sy!("request")]))
+                            ((15, 3), (19, 2), (&["odoo", "http"], &["request"])),
+                            ((19, 2), (999, 0), (&["odoo", "http", "requestlib"], &["request"]))
                         ],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
         // --------- request: Request (15.3+) ---------
-        let request_class_syms = odoo.symbol_table.get_symbol(file_symbol.into(), &(vec![], vec![Sy!("Request")]), u32::MAX);
+        let request_class_syms = odoo.symbol_table.get_symbol(file_symbol.into(), (&[], &["Request"]), u32::MAX);
         let Some(&request_class) = request_class_syms.last() else {
             return;
         };
@@ -107,18 +110,18 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
     }},
     PythonArchEvalFileHook {odoo_entry: true,
                         trees: vec![
-                            ((0, 0), (15, 3), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("WebRequest"), Sy!("env")])),
-                            ((15, 3), (19, 2), (vec![Sy!("odoo"), Sy!("http")], vec![Sy!("Request"), Sy!("env")])),
-                            ((19, 2), (999, 0), (vec![Sy!("odoo"), Sy!("http"), Sy!("requestlib")], vec![Sy!("Request"), Sy!("env")]))
+                            ((0, 0), (15, 3), (&["odoo", "http"], &["WebRequest", "env"])),
+                            ((15, 3), (19, 2), (&["odoo", "http"], &["Request", "env"])),
+                            ((19, 2), (999, 0), (&["odoo", "http", "requestlib"], &["Request", "env"]))
                         ],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
         // --------- (Web)Request.env: Environment | None ---------
-        let env_file_syms = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("api")], vec![]), u32::MAX);
+        let env_file_syms = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "api"], &[]), u32::MAX);
         let Some(env_file) = env_file_syms.last().and_then(|&f| f.as_source_file_key()) else {
             return;
         };
-        let env_class_syms = odoo.symbol_table.get_symbol(env_file.into(), &(vec![], vec![Sy!("Environment")]), u32::MAX);
+        let env_class_syms = odoo.symbol_table.get_symbol(env_file.into(), (&[], &["Environment"]), u32::MAX);
         let Some(&env_class) = env_class_syms.last() else {
             return;
         };
@@ -131,8 +134,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
         odoo.symbol_table.add_dependency(file_symbol, env_file, BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                        trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("ids")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("ids")]))],
+                        trees: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "ids"])),
+                            ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "ids"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
         let values: Vec<ruff_python_ast::Expr> = Vec::new();
@@ -150,11 +153,11 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
         id.set_evaluations(vec![Evaluation::eval_from_symbol(odoo, values, range.clone())]);
     }},*/
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("Environment"), Sy!("registry")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("environments")], vec![Sy!("Environment"), Sy!("registry")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "api"], &["Environment", "registry"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "environments"], &["Environment", "registry"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        let registry_sym = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("modules"), Sy!("registry")], vec![Sy!("Registry")]), u32::MAX);
+        let registry_sym = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "modules", "registry"], &["Registry"]), u32::MAX);
         if !registry_sym.is_empty() {
             odoo.symbol_table.set_evaluations(symbol, vec![Evaluation {
                 symbol: EvaluationSymbol::new_with_symbol(
@@ -170,201 +173,201 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
     }},
     /* As __get__ doesn't exists in each class, the validator will not trigger hooks for them at function level, so we put it at file level. */
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Boolean")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_misc")], vec![Sy!("Boolean")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Boolean"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_misc"], &["Boolean"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("bool")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["bool"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Integer")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_numeric")], vec![Sy!("Integer")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Integer"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_numeric"], &["Integer"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("int")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["int"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Float")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_numeric")], vec![Sy!("Float")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Float"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_numeric"], &["Float"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("float")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["float"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Monetary")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_numeric")], vec![Sy!("Monetary")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Monetary"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_numeric"], &["Monetary"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("float")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["float"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Char")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_textual")], vec![Sy!("Char")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Char"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_textual"], &["Char"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["str"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Text")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_textual")], vec![Sy!("Text")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Text"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_textual"], &["Text"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["str"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Html")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_textual")], vec![Sy!("Html")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Html"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_textual"], &["Html"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("markupsafe")], vec![Sy!("Markup")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["markupsafe"], &["Markup"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Date")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_temporal")], vec![Sy!("Date")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Date"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_temporal"], &["Date"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("datetime")], vec![Sy!("date")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["datetime"], &["date"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Datetime")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_temporal")], vec![Sy!("Datetime")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Datetime"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_temporal"], &["Datetime"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("datetime")], vec![Sy!("datetime")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["datetime"], &["datetime"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Binary")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_binary")], vec![Sy!("Binary")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Binary"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_binary"], &["Binary"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("bytes")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["bytes"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Image")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_binary")], vec![Sy!("Image")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Image"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_binary"], &["Image"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("bytes")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["bytes"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Selection")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_selection")], vec![Sy!("Selection")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Selection"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_selection"], &["Selection"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["str"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Reference")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_reference")], vec![Sy!("Reference")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Reference"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_reference"], &["Reference"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("str")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["str"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Json")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_misc")], vec![Sy!("Json")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Json"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_misc"], &["Json"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("object")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["object"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Properties")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_properties")], vec![Sy!("Properties")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Properties"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_properties"], &["Properties"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("object")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["object"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("PropertiesDefinition")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_properties")], vec![Sy!("PropertiesDefinition")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["PropertiesDefinition"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_properties"], &["PropertiesDefinition"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
-        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (vec![Sy!("builtins")], vec![Sy!("object")]));
+        PythonArchEvalHooks::_update_get_eval(odoo, entry, symbol, (&["builtins"], &["object"]));
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, None);
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Many2one")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_relational")], vec![Sy!("Many2one")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Many2one"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_relational"], &["Many2one"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
         PythonArchEvalHooks::_update_get_eval_relational(&mut odoo.symbol_table, symbol);
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, Some(oyarn!("Many2one")));
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("One2many")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_relational")], vec![Sy!("One2many")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["One2many"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_relational"], &["One2many"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
                 PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, Some(oyarn!("One2many")));
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Many2many")])),
-                            ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_relational")], vec![Sy!("Many2many")]))],
+                            trees: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Many2many"])),
+                                ((18, 1), (999, 0), (&["odoo", "orm", "fields_relational"], &["Many2many"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, _file_symbol: SourceFileKey, symbol: SymbolKey| {
         PythonArchEvalHooks::_update_get_eval_relational(&mut odoo.symbol_table, symbol);
         PythonArchEvalHooks::_update_field_init(&mut odoo.symbol_table, symbol, Some(oyarn!("Many2many")));
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("init")], vec![Sy!("_")]))],
+                            trees: vec![((18, 1), (999, 0), (&["odoo", "init"], &["_"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
-        let odoo_underscore = odoo.get_symbol(odoo.symbol_table.path(file_symbol), &(vec![Sy!("odoo")], vec![Sy!("_")]), u32::MAX);
+        let odoo_underscore = odoo.get_symbol(odoo.symbol_table.path(file_symbol), (&["odoo"], &["_"]), u32::MAX);
         if let Some(&eval_1) = odoo_underscore.first() {
             odoo.symbol_table.set_evaluations(eval_1, vec![Evaluation::eval_from_symbol(&odoo.symbol_table, symbol, Some(false))]);
         }
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("init")], vec![Sy!("SUPERUSER_ID")]))],
+                            trees: vec![((18, 1), (999, 0), (&["odoo", "init"], &["SUPERUSER_ID"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
-        let odoo_superuser_id = odoo.get_symbol(odoo.symbol_table.path(file_symbol), &(vec![Sy!("odoo")], vec![Sy!("SUPERUSER_ID")]), u32::MAX);
+        let odoo_superuser_id = odoo.get_symbol(odoo.symbol_table.path(file_symbol), (&["odoo"], &["SUPERUSER_ID"]), u32::MAX);
         if let Some(&eval_1) = odoo_superuser_id.first() {
             odoo.symbol_table.set_evaluations(eval_1,vec![Evaluation::eval_from_symbol(&odoo.symbol_table, symbol, Some(false))]);
         }
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("init")], vec![Sy!("_lt")]))],
+                            trees: vec![((18, 1), (999, 0), (&["odoo", "init"], &["_lt"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
-        let odoo_lt = odoo.get_symbol(odoo.symbol_table.path(file_symbol), &(vec![Sy!("odoo")], vec![Sy!("_lt")]), u32::MAX);
+        let odoo_lt = odoo.get_symbol(odoo.symbol_table.path(file_symbol), (&["odoo"], &["_lt"]), u32::MAX);
         if let Some(&eval_1) = odoo_lt.first() {
             odoo.symbol_table.set_evaluations(eval_1, vec![Evaluation::eval_from_symbol(&odoo.symbol_table, symbol, Some(false))]);
         }
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("init")], vec![Sy!("Command")]))],
+                            trees: vec![((18, 1), (999, 0), (&["odoo", "init"], &["Command"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
-        let odoo_command = odoo.get_symbol(odoo.symbol_table.path(file_symbol), &(vec![Sy!("odoo")], vec![Sy!("Command")]), u32::MAX);
+        let odoo_command = odoo.get_symbol(odoo.symbol_table.path(file_symbol), (&["odoo"], &["Command"]), u32::MAX);
         if let Some(&eval_1) = odoo_command.first() {
             odoo.symbol_table.set_evaluations(eval_1, vec![Evaluation::eval_from_symbol(&odoo.symbol_table, symbol, Some(false))]);
         }
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((15, 0), (999, 0), (vec![Sy!("odoo"), Sy!("addons"), Sy!("base"), Sy!("models"), Sy!("ir_rule")], vec![Sy!("IrRule"), Sy!("global")]))],
+                            trees: vec![((15, 0), (999, 0), (&["odoo", "addons", "base", "models", "ir_rule"], &["IrRule", "global"]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
         let file_path = odoo.symbol_table.path(file_symbol);
         let boolean_field = if odoo.version >= (18, 1) {
-            odoo.get_symbol(file_path, &(vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_misc")], vec![Sy!("Boolean")]), u32::MAX)
+            odoo.get_symbol(file_path, (&["odoo", "orm", "fields_misc"], &["Boolean"]), u32::MAX)
         } else {
-            odoo.get_symbol(file_path, &(vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Boolean")]), u32::MAX)
+            odoo.get_symbol(file_path, (&["odoo", "fields"], &["Boolean"]), u32::MAX)
         };
         if let Some(&boolean) = boolean_field.first() {
             let mut eval = Evaluation::eval_from_symbol(&odoo.symbol_table, boolean, Some(true));
@@ -374,12 +377,12 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
         }
     }},
     PythonArchEvalFileHook {odoo_entry: true,
-                            trees: vec![((0, 0), (999, 0), (vec![Sy!("odoo"), Sy!("_monkeypatches"), Sy!("werkzeug")], vec![]))],
+                            trees: vec![((0, 0), (999, 0), (&["odoo", "_monkeypatches", "werkzeug"], &[]))],
                             if_exist_only: true,
                             func: |odoo: &mut SyncOdoo, _entry: &Rc<RefCell<EntryPoint>>, file_symbol: SourceFileKey, symbol: SymbolKey| {
         let file_path = odoo.symbol_table.path(file_symbol).to_string();
-        let url_decode = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_decode")]), u32::MAX);
-        let werkzeug_url_decode = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_decode")]), u32::MAX);
+        let url_decode = odoo.symbol_table.get_symbol(symbol, (&[], &["url_decode"]), u32::MAX);
+        let werkzeug_url_decode = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_decode"]), u32::MAX);
         if let Some(&werkzeug_url_decode) = werkzeug_url_decode.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_decode { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_decode.first() {
@@ -389,8 +392,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_encode = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_encode")]), u32::MAX);
-        let werkzeug_url_encode = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_encode")]), u32::MAX);
+        let url_encode = odoo.symbol_table.get_symbol(symbol, (&[], &["url_encode"]), u32::MAX);
+        let werkzeug_url_encode = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_encode"]), u32::MAX);
         if let Some(&werkzeug_url_encode) = werkzeug_url_encode.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_encode { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_encode.first() {
@@ -400,8 +403,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_join = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_join")]), u32::MAX);
-        let werkzeug_url_join = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_join")]), u32::MAX);
+        let url_join = odoo.symbol_table.get_symbol(symbol, (&[], &["url_join"]), u32::MAX);
+        let werkzeug_url_join = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_join"]), u32::MAX);
         if let Some(&werkzeug_url_join) = werkzeug_url_join.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_join { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_join.first() {
@@ -411,8 +414,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_parse = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_parse")]), u32::MAX);
-        let werkzeug_url_parse = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_parse")]), u32::MAX);
+        let url_parse = odoo.symbol_table.get_symbol(symbol, (&[], &["url_parse"]), u32::MAX);
+        let werkzeug_url_parse = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_parse"]), u32::MAX);
         if let Some(&werkzeug_url_parse) = werkzeug_url_parse.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_parse { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_parse.first() {
@@ -422,8 +425,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_quote = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_quote")]), u32::MAX);
-        let werkzeug_url_quote = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_quote")]), u32::MAX);
+        let url_quote = odoo.symbol_table.get_symbol(symbol, (&[], &["url_quote"]), u32::MAX);
+        let werkzeug_url_quote = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_quote"]), u32::MAX);
         if let Some(&werkzeug_url_quote) = werkzeug_url_quote.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_quote { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_quote.first() {
@@ -433,8 +436,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_unquote = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_unquote")]), u32::MAX);
-        let werkzeug_url_unquote = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_unquote")]), u32::MAX);
+        let url_unquote = odoo.symbol_table.get_symbol(symbol, (&[], &["url_unquote"]), u32::MAX);
+        let werkzeug_url_unquote = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_unquote"]), u32::MAX);
         if let Some(&werkzeug_url_unquote) = werkzeug_url_unquote.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_unquote { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_unquote.first() {
@@ -444,8 +447,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_quote_plus = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_quote_plus")]), u32::MAX);
-        let werkzeug_url_quote_plus = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_quote_plus")]), u32::MAX);
+        let url_quote_plus = odoo.symbol_table.get_symbol(symbol, (&[], &["url_quote_plus"]), u32::MAX);
+        let werkzeug_url_quote_plus = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_quote_plus"]), u32::MAX);
         if let Some(&werkzeug_url_quote_plus) = werkzeug_url_quote_plus.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_quote_plus { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_quote_plus.first() {
@@ -455,8 +458,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_unquote_plus = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_unquote_plus")]), u32::MAX);
-        let werkzeug_url_unquote_plus = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_unquote_plus")]), u32::MAX);
+        let url_unquote_plus = odoo.symbol_table.get_symbol(symbol, (&[], &["url_unquote_plus"]), u32::MAX);
+        let werkzeug_url_unquote_plus = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_unquote_plus"]), u32::MAX);
         if let Some(&werkzeug_url_unquote_plus) = werkzeug_url_unquote_plus.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_unquote_plus { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_unquote_plus.first() {
@@ -466,8 +469,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url_unparse = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("url_unparse")]), u32::MAX);
-        let werkzeug_url_unparse = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("url_unparse")]), u32::MAX);
+        let url_unparse = odoo.symbol_table.get_symbol(symbol, (&[], &["url_unparse"]), u32::MAX);
+        let werkzeug_url_unparse = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["url_unparse"]), u32::MAX);
         if let Some(&werkzeug_url_unparse) = werkzeug_url_unparse.first() {
             if let SymbolKey::Variable(v) = werkzeug_url_unparse { //if not variable, no need to patch it
                 if let Some(&eval_1) = url_unparse.first() {
@@ -477,8 +480,8 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 }
             }
         }
-        let url = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("URL")]), u32::MAX);
-        let werkzeug_url_syms = odoo.get_symbol(&file_path, &(vec![Sy!("werkzeug"), Sy!("urls")], vec![Sy!("URL")]), u32::MAX);
+        let url = odoo.symbol_table.get_symbol(symbol, (&[], &["URL"]), u32::MAX);
+        let werkzeug_url_syms = odoo.get_symbol(&file_path, (&["werkzeug", "urls"], &["URL"]), u32::MAX);
         if let Some(&werkzeug_url) = werkzeug_url_syms.first() {
             if let SymbolKey::Variable(v) = werkzeug_url { //if not variable, no need to patch it
                 if let Some(&eval_1) = url.first() {
@@ -495,7 +498,7 @@ type PythonArchEvalHookFunc = fn (odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<
 
 pub struct PythonArchEvalFunctionHook {
     pub odoo_entry: bool,
-    pub tree: Vec<(Version, Version, Tree)>, //min_version, max_version, tree
+    pub tree: Vec<(Version, Version, TreeStrSlice<'static>)>, //min_version, max_version, tree
     pub if_exist_only: bool,
     pub func: PythonArchEvalHookFunc
 }
@@ -503,8 +506,8 @@ pub struct PythonArchEvalFunctionHook {
 #[allow(non_upper_case_globals)]
 static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::new(|| {vec![
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("Environment"), Sy!("__getitem__")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("environments")], vec![Sy!("Environment"), Sy!("__getitem__")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "api"], &["Environment", "__getitem__"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "environments"], &["Environment", "__getitem__"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
        odoo.symbol_table[symbol].evaluations = vec![Evaluation {
@@ -518,8 +521,8 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
         }];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("modules"), Sy!("registry")], vec![Sy!("Registry"), Sy!("__getitem__")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("registry")], vec![Sy!("Registry"), Sy!("__getitem__")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "modules", "registry"], &["Registry", "__getitem__"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "registry"], &["Registry", "__getitem__"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         odoo.symbol_table[symbol].evaluations = vec![Evaluation {
@@ -533,64 +536,64 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
         }];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__iter__")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__iter__")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "__iter__"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "__iter__"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__getitem__")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("__getitem__")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "__getitem__"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "__getitem__"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_env")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_env")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "with_env"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "with_env"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("sudo")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("sudo")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "sudo"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "sudo"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("create")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("create")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "create"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "create"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "filtered"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "filtered"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered_domain")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("filtered_domain")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "filtered_domain"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "filtered_domain"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("search")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("search")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "search"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "search"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
@@ -607,78 +610,78 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
         }
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("browse")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("browse")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "browse"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "browse"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_company")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_company")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "with_company"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "with_company"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_context")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_context")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "with_context"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "with_context"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_prefetch")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_prefetch")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "with_prefetch"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "with_prefetch"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_user")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("with_user")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "with_user"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "with_user"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("exists")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel"), Sy!("exists")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "models"], &["BaseModel", "exists"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "models"], &["BaseModel", "exists"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let base_model = get_base_model_symbol(odoo);
         odoo.symbol_table[symbol].evaluations = vec![Evaluation::new_self(base_model.unwrap(), Some(true))];
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Id"), Sy!("__get__")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_misc")], vec![Sy!("Id"), Sy!("__get__")]))], //We have to put it at function level hook to remove evaluation from existing code
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Id", "__get__"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "fields_misc"], &["Id", "__get__"]))], //We have to put it at function level hook to remove evaluation from existing code
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
-        PythonArchEvalHooks::_update_get_eval_func_level(odoo, &entry_point, symbol, (vec![Sy!("builtins")], vec![Sy!("int")]));
+        PythonArchEvalHooks::_update_get_eval_func_level(odoo, &entry_point, symbol, (&["builtins"], &["int"]));
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("One2many"), Sy!("__get__")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields_relational")], vec![Sy!("One2many"), Sy!("__get__")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["One2many", "__get__"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "fields_relational"], &["One2many", "__get__"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         PythonArchEvalHooks::_update_get_eval_func_relational(&mut odoo.symbol_table, symbol);
     }},
     PythonArchEvalFunctionHook {
                         odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("Environment"), Sy!("ref")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("environments")], vec![Sy!("Environment"), Sy!("ref")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "api"], &["Environment", "ref"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "environments"], &["Environment", "ref"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         PythonArchEvalHooks::validation_env_ref(&mut odoo.symbol_table, symbol);
     }},
     PythonArchEvalFunctionHook {odoo_entry: true,
-                        tree: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Field"), Sy!("__init__")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields")], vec![Sy!("Field"), Sy!("__init__")]))],
+                        tree: vec![((0, 0), (18, 1), (&["odoo", "fields"], &["Field", "__init__"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "fields"], &["Field", "__init__"]))],
                         if_exist_only: true,
                         func: |odoo: &mut SyncOdoo, _entry_point: &Rc<RefCell<EntryPoint>>, symbol: FunctionKey| {
         let Some(fields_class_sym) = odoo.symbol_table.get_in_parents(symbol.into(), &[SymType::CLASS], true) else {
@@ -701,28 +704,28 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
 type PythonArchEvalHookDecorator = fn (session: &mut SessionInfo, func_sym: FunctionKey, arguments: &Arguments) -> Vec<Diagnostic>;
 
 pub struct PythonArchEvalDecoratorHook {
-    pub trees: Vec<(Version, Version, Tree)>, //min_version, max_version, tree
+    pub trees: Vec<(Version, Version, TreeStrSlice<'static>)>, //min_version, max_version, tree
     pub func: PythonArchEvalHookDecorator
 }
 
 #[allow(non_upper_case_globals)]
 static arch_eval_decorator_hooks: Lazy<Vec<PythonArchEvalDecoratorHook>> = Lazy::new(|| {vec![
-    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("returns")]))], //disappear in 18.1
+    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (&["odoo", "api"], &["returns"]))], //disappear in 18.1
                         func: |session: &mut SessionInfo, func_sym: FunctionKey, arguments: &Arguments| {
                             PythonArchEvalHooks::handle_api_returns_decorator(session, func_sym, arguments)
     }},
-    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("onchange")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("decorators")], vec![Sy!("onchange")]))],
+    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (&["odoo", "api"], &["onchange"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "decorators"], &["onchange"]))],
                         func: |session: &mut SessionInfo, func_sym: FunctionKey, arguments: &Arguments| {
                             PythonArchEvalHooks::handle_api_simple_field_decorator(session, func_sym, arguments)
     }},
-    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("constrains")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("decorators")], vec![Sy!("constrains")]))],
+    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (&["odoo", "api"], &["constrains"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "decorators"], &["constrains"]))],
                         func: |session: &mut SessionInfo, func_sym: FunctionKey, arguments: &Arguments| {
                             PythonArchEvalHooks::handle_api_simple_field_decorator(session, func_sym, arguments)
     }},
-    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (vec![Sy!("odoo"), Sy!("api")], vec![Sy!("depends")])),
-                        ((18, 1), (999, 0), (vec![Sy!("odoo"), Sy!("orm"), Sy!("decorators")], vec![Sy!("depends")]))],
+    PythonArchEvalDecoratorHook {trees: vec![((0, 0), (18, 1), (&["odoo", "api"], &["depends"])),
+                        ((18, 1), (999, 0), (&["odoo", "orm", "decorators"], &["depends"]))],
                         func: |session: &mut SessionInfo, func_sym: FunctionKey, arguments: &Arguments| {
                             PythonArchEvalHooks::handle_api_nested_field_decorator(session, func_sym, arguments)
     }},
@@ -734,8 +737,8 @@ impl PythonArchEvalHooks {
 
     pub fn on_file_eval(session: &mut SessionInfo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: SourceFileKey) {
         let has_main_entry = session.sync_odoo.has_main_entry;
-        let mut lazy_tree = None;
-        let mut lazy_odoo_tree = None;
+        let mut lazy_tree: Option<Tree> = None;
+        let mut lazy_odoo_tree: Option<Tree> = None;
         let name = session.st().name(symbol).clone();
         for hook in arch_eval_file_hooks.iter() {
             if hook.odoo_entry && !has_main_entry {
@@ -761,7 +764,7 @@ impl PythonArchEvalHooks {
                 if hook_tree.1.is_empty() {
                     (hook.func)(session.sync_odoo, entry_point, symbol, symbol.into());
                 } else {
-                    let sub_symbol = session.st().get_symbol(symbol.into(), &(vec![], hook_tree.1.clone()), u32::MAX);
+                    let sub_symbol = session.st().get_symbol(symbol.into(), (&[], hook_tree.1), u32::MAX);
                     if !sub_symbol.is_empty() {
                         (hook.func)(session.sync_odoo, entry_point, symbol, *sub_symbol.last().unwrap());
                     }
@@ -773,8 +776,8 @@ impl PythonArchEvalHooks {
     pub fn on_function_eval(session: &mut SessionInfo, entry_point: &Rc<RefCell<EntryPoint>>, function: FunctionKey) {
         let symbol_key: SymbolKey = function.into();
         let has_main_entry = session.sync_odoo.has_main_entry;
-        let mut lazy_tree = None;
-        let mut lazy_odoo_tree = None;
+        let mut lazy_tree: Option<Tree> = None;
+        let mut lazy_odoo_tree: Option<Tree> = None;
         let name = session.st().name(symbol_key).clone();
         for hook in arch_eval_function_hooks.iter() {
             if hook.odoo_entry && !has_main_entry {
@@ -843,10 +846,12 @@ impl PythonArchEvalHooks {
                         if session.sync_odoo.version < *min_version || session.sync_odoo.version >= *max_version {
                             continue; //skip if version not in range
                         }
-                        if !dec_sym_tree.0.ends_with(&hook_tree.0) || !dec_sym_tree.1.ends_with(&hook_tree.1) || !SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0) {
-                            continue;
+
+                        if dec_sym_tree.0.ends_with_strs(hook_tree.0)
+                        && dec_sym_tree.1.ends_with_strs(hook_tree.1)
+                        && SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0) {
+                            diagnostics.extend((hook.func)(session, func_sym, decorator_args));
                         }
-                        diagnostics.extend((hook.func)(session, func_sym, decorator_args));
                     }
                 }
             }
@@ -877,14 +882,14 @@ impl PythonArchEvalHooks {
             if let Some(scope_file) = scope.and_then(|s| session.st().get_file(s)) {
                 //exclude orm files
                 if session.sync_odoo.version < (18, 1) {
-                    let env_files = session.sync_odoo.get_symbol(session.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("api")], vec![]), u32::MAX);
+                    let env_files = session.sync_odoo.get_symbol(session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "api"], &[]), u32::MAX);
                     let env_file = *env_files.last().unwrap();
                     if env_file != scope_file {
                         session.st_mut().add_model_dependencies(scope_file, &model);
                     }
                 } else {
                     let tree = session.sync_odoo.get_main_entry_tree(scope_file);
-                    if !tree.0.starts_with(&[Sy!("odoo"), Sy!("orm")]) {
+                    if !tree.0.starts_with_strs(&["odoo", "orm"]) {
                         session.st_mut().add_model_dependencies(scope_file, &model);
                     }
                 }
@@ -978,11 +983,11 @@ impl PythonArchEvalHooks {
         Some(EvaluationSymbolPtr::WEAK(evaluation_sym.get_weak().clone()))
     }
 
-    fn _update_get_eval_func_level(odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, function: FunctionKey, tree: Tree) {
-        let return_sym = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &tree, u32::MAX);
+    fn _update_get_eval_func_level(odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, function: FunctionKey, tree: TreeStrSlice<'static>) {
+        let return_sym = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), tree, u32::MAX);
         let Some(&return_sym) = return_sym.last() else {
             let file = odoo.symbol_table.get_file(function.into()).unwrap();
-            odoo.symbol_table.not_found_paths_mut(file).push((BuildSteps::ARCH_EVAL, flatten_tree(&tree)));
+            odoo.symbol_table.not_found_paths_mut(file).push((BuildSteps::ARCH_EVAL, Tree::from(tree).flatten()));
             entry_point.borrow_mut().not_found_symbols.insert(file);
             return;
         };
@@ -998,15 +1003,15 @@ impl PythonArchEvalHooks {
         }];
     }
 
-    fn _update_get_eval(odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: SymbolKey, tree: Tree) {
-        let get_syms = odoo.symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("__get__")]), u32::MAX);
+    fn _update_get_eval(odoo: &mut SyncOdoo, entry_point: &Rc<RefCell<EntryPoint>>, symbol: SymbolKey, tree: TreeStrSlice<'static>) {
+        let get_syms = odoo.symbol_table.get_symbol(symbol, (&[], &["__get__"]), u32::MAX);
         let Some(&get_sym) = get_syms.last() else {
             return;
         };
-        let return_syms = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), &tree, u32::MAX);
+        let return_syms = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(), tree, u32::MAX);
         let Some(&return_sym) = return_syms.last() else {
             let file = odoo.symbol_table.get_file(symbol).unwrap();
-            odoo.symbol_table.not_found_paths_mut(file).push((BuildSteps::ARCH_EVAL, flatten_tree(&tree)));
+            odoo.symbol_table.not_found_paths_mut(file).push((BuildSteps::ARCH_EVAL, Tree::from(tree).flatten()));
             entry_point.borrow_mut().not_found_symbols.insert(file);
             return;
         };
@@ -1021,12 +1026,12 @@ impl PythonArchEvalHooks {
             range: None
         }]);
 
-        let tree = if odoo.version < (18, 1) {
-            (vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Field"), Sy!("__get__")])
+        let tree: TreeStrSlice = if odoo.version < (18, 1) {
+            (&["odoo", "fields"], &["Field", "__get__"])
         } else {
-            (vec![Sy!("odoo"), Sy!("orm"), Sy!("fields")], vec![Sy!("Field"), Sy!("__get__")])
+            (&["odoo", "orm", "fields"], &["Field", "__get__"])
         };
-        let Some(SymbolKey::Function(field_get)) = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(),  &tree, u32::MAX).first().copied()
+        let Some(SymbolKey::Function(field_get)) = odoo.get_symbol(odoo.config.odoo_path.as_ref().unwrap(),  tree, u32::MAX).first().copied()
         else {
             return;
         };
@@ -1084,7 +1089,7 @@ impl PythonArchEvalHooks {
     }
 
     fn _update_get_eval_relational(symbol_table: &mut SymbolTable, symbol: SymbolKey) {
-        let get_sym = symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("__get__")]), u32::MAX);
+        let get_sym = symbol_table.get_symbol(symbol, (&[], &["__get__"]), u32::MAX);
         if get_sym.is_empty() {
             return;
         }
@@ -1213,7 +1218,7 @@ impl PythonArchEvalHooks {
     }
 
     fn _update_field_init(symbol_table: &mut SymbolTable, symbol: SymbolKey, relational: Option<OYarn>) {
-        let init_sym = symbol_table.get_symbol(symbol, &(vec![], vec![Sy!("__init__")]), u32::MAX);
+        let init_sym = symbol_table.get_symbol(symbol, (&[], &["__init__"]), u32::MAX);
         if init_sym.is_empty() {
             return;
         }

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -4,12 +4,13 @@ use ruff_python_ast::Expr;
 use lsp_types::Diagnostic;
 use tracing::error;
 
-use crate::constants::OYarn;
+use crate::constants::{OYarn};
 use crate::core::model::{Model, ModelData};
 use crate::core::symbols::{ClassSymbol, ModuleSymbol};
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::symbol_keys::{ClassKey, SymbolKey, XmlId};
 use crate::threads::SessionInfo;
+use crate::tree::TreeStrSlice;
 use crate::{oyarn, Sy, S};
 
 use super::evaluation::{ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationValue};
@@ -69,7 +70,7 @@ impl PythonOdooBuilder {
 
     fn _load_class_inherit(&mut self, session: &mut SessionInfo, diagnostics: &mut Vec<Diagnostic>) {
         let symbol = self.symbol;
-        let _inherit = session.st().get_symbol(symbol.into(), &(vec![], vec![Sy!("_inherit")]), u32::MAX);
+        let _inherit = session.st().get_symbol(symbol.into(), (&[], &["_inherit"]), u32::MAX);
         let Some(&SymbolKey::Variable(_inherit)) = _inherit.last() else { return };
         let evaluations = &session.st()[_inherit].evaluations;
         if evaluations.len() == 0 {
@@ -101,7 +102,7 @@ impl PythonOdooBuilder {
 
     fn _evaluate_name(&mut self, session: &mut SessionInfo, diagnostics: &mut Vec<Diagnostic>) -> OYarn {
         let symbol = self.symbol;
-        let _name = session.st().get_symbol(symbol.into(), &(vec![], vec![Sy!("_name")]), u32::MAX);
+        let _name = session.st().get_symbol(symbol.into(), (&[], &["_name"]), u32::MAX);
         if let Some(&_name) = _name.last() {
             for eval in session.st().evaluations(_name).unwrap().clone() {
                 let eval = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
@@ -133,7 +134,7 @@ impl PythonOdooBuilder {
 
     fn _load_class_inherits(&mut self, session: &mut SessionInfo, diagnostics: &mut Vec<Diagnostic>) {
         let symbol = self.symbol;
-        let _inherits = session.st().get_symbol(symbol.into(), &(vec![], vec![Sy!("_inherits")]), u32::MAX);
+        let _inherits = session.st().get_symbol(symbol.into(), (&[], &["_inherits"]), u32::MAX);
         if let Some(&SymbolKey::Variable(_inherits)) = _inherits.last() {
             if let Some(eval) = session.st()[_inherits].evaluations.last().cloned() {
                 let eval = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
@@ -280,14 +281,14 @@ impl PythonOdooBuilder {
         //id
         let range = session.st()[symbol].range.clone();
         let id = session.st_mut().add_new_variable(symbol, "id", &range);
-        let id_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Id")]), u32::MAX);
+        let id_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "fields"], &["Id"]), u32::MAX);
         if let Some(&id_field) = id_field.last() {
             let evaluation = Evaluation::eval_from_symbol(session.st(), id_field, Some(true));
             session.st_mut()[id].evaluations.push(evaluation);
         }
         //display_name
         let display_name = session.st_mut().add_new_variable(symbol, "display_name", &range);
-        let char_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Char")]), u32::MAX);
+        let char_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "fields"], &["Char"]), u32::MAX);
         if let Some(&char_field) = char_field.last() {
             let evaluation = Evaluation::eval_from_symbol(session.st(), char_field, Some(true));
             session.st_mut()[display_name].evaluations.push(evaluation);
@@ -296,28 +297,28 @@ impl PythonOdooBuilder {
         if session.st()[symbol]._model.as_ref().unwrap().log_access {
             //create_uid
             let create_uid = session.st_mut().add_new_variable(symbol, "create_uid", &range);
-            let many2one_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Many2one")]), u32::MAX);
+            let many2one_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "fields"], &["Many2one"]), u32::MAX);
             if let Some(&many2one_field) = many2one_field.last() {
                 let evaluation = Evaluation::eval_from_symbol(session.st(), many2one_field, Some(true));
                 session.st_mut()[create_uid].evaluations.push(evaluation);
             }
             //create_date
             let create_date = session.st_mut().add_new_variable(symbol, "create_date", &range);
-            let datetime_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Datetime")]), u32::MAX);
+            let datetime_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "fields"], &["Datetime"]), u32::MAX);
             if let Some(&datetime_field) = datetime_field.last() {
                 let evaluation = Evaluation::eval_from_symbol(session.st(), datetime_field, Some(true));
                 session.st_mut()[create_date].evaluations.push(evaluation);
             }
             //write_uid
             let write_uid = session.st_mut().add_new_variable(symbol, "write_uid", &range);
-            let many2one_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Many2one")]), u32::MAX);
+            let many2one_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "fields"], &["Many2one"]), u32::MAX);
             if let Some(&many2one_field) = many2one_field.last() {
                 let evaluation = Evaluation::eval_from_symbol(session.st(), many2one_field, Some(true));
                 session.st_mut()[write_uid].evaluations.push(evaluation);
             }
             //write_date
             let write_date = session.st_mut().add_new_variable(symbol, "write_date", &range);
-            let datetime_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), &(vec![Sy!("odoo"), Sy!("fields")], vec![Sy!("Datetime")]), u32::MAX);
+            let datetime_field = session.sync_odoo.get_symbol(&session.sync_odoo.config.odoo_path.as_ref().unwrap(), (&["odoo", "fields"], &["Datetime"]), u32::MAX);
             if let Some(&datetime_field) = datetime_field.last() {
                 let evaluation = Evaluation::eval_from_symbol(session.st(), datetime_field, Some(true));
                 session.st_mut()[write_date].evaluations.push(evaluation);
@@ -332,12 +333,12 @@ impl PythonOdooBuilder {
             // We only consider symbols that has inheritance base or defined in modules as models
             return false;
         }
-        let base_model_tree = if session.sync_odoo.version >= (18, 1) {
-            (vec![Sy!("odoo"), Sy!("orm"), Sy!("models")], vec![Sy!("BaseModel")])
+        let base_model_tree: TreeStrSlice = if session.sync_odoo.version >= (18, 1) {
+            (&["odoo", "orm", "models"], &["BaseModel"])
         } else {
-            (vec![Sy!("odoo"), Sy!("models")], vec![Sy!("BaseModel")])
+            (&["odoo", "models"], &["BaseModel"])
         };
-        let base_model_syms = session.sync_odoo.get_symbol(session.sync_odoo.config.odoo_path.as_ref().unwrap(), &base_model_tree, u32::MAX);
+        let base_model_syms = session.sync_odoo.get_symbol(session.sync_odoo.config.odoo_path.as_ref().unwrap(), base_model_tree, u32::MAX);
         let Some(&SymbolKey::Class(base)) = base_model_syms.first() else {
             // base_model_syms empty so sym cannot be a model, otherwise we would have found it earlier
             return false;
@@ -346,7 +347,7 @@ impl PythonOdooBuilder {
             return false;
         }
         // Check if we have a _register = False
-        let register = session.st().get_symbol(symbol.into(), &(vec![], vec![Sy!("_register")]), u32::MAX);
+        let register = session.st().get_symbol(symbol.into(), (&[], &["_register"]), u32::MAX);
         if let Some(&register) = register.last() {
             let register_evals = session.st().evaluations(register).unwrap().clone();
             // Read all boolean values, ignore non-boolean-value evaluations, as they can be dynamic or type annotations

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -9,7 +9,7 @@ use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
 use crate::core::evaluation::ContextValue;
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SourceFileKey, SymbolKey};
-use crate::{constants::*, oyarn, Sy};
+use crate::{constants::*, oyarn};
 use crate::core::odoo::SyncOdoo;
 use crate::core::symbols::ModuleSymbol;
 use crate::threads::SessionInfo;
@@ -613,7 +613,7 @@ impl PythonValidator {
             }
         }
         //Check inherit field
-        let inherit = session.st().get_symbol(class.into(), &(vec![], vec![Sy!("_inherit")]), u32::MAX);
+        let inherit = session.st().get_symbol(class.into(), (&[], &["_inherit"]), u32::MAX);
         if let Some(&inherit) = inherit.last() {
             let inherit_evals = session.st().evaluations(inherit).cloned().unwrap();
             for inherit_eval in inherit_evals {
@@ -655,7 +655,7 @@ impl PythonValidator {
         }).count() > 0 {
             // This a model with a name that already exists in models and in dependencies,
             // and it is not inherited, so it is basically shadowing the existing model.
-            let _name = session.st().get_symbol(class.into(), &(vec![], vec![Sy!("_name")]), u32::MAX);
+            let _name = session.st().get_symbol(class.into(), (&[], &["_name"]), u32::MAX);
             if let Some(&_name) = _name.last() {
                 let mut range = session.st().range(_name).clone();
                 let evals = session.st().evaluations(_name).cloned().unwrap();
@@ -677,7 +677,7 @@ impl PythonValidator {
             }
         }
         // check inherits
-        let inherits = session.st().get_symbol(class.into(), &(vec![], vec![Sy!("_inherits")]), u32::MAX);
+        let inherits = session.st().get_symbol(class.into(), (&[], &["_inherits"]), u32::MAX);
         if let Some(&inherits) = inherits.last() {
             let inherits_evals = session.st().evaluations(inherits).cloned().unwrap();
             for inherits_eval in inherits_evals {

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -11,19 +11,32 @@ use ruff_text_size::TextRange;
 use tracing::trace;
 
 use crate::{
-    S, Sy, constants::{BuildStatus, BuildSteps, OYarn, PackageType, SymType, Tree, flatten_tree, tree}, core::{
-        diagnostics::{DiagnosticCode, create_diagnostic},
+    constants::{BuildStatus, BuildSteps, OYarn, PackageType, SymType},
+    core::{
+        diagnostics::{create_diagnostic, DiagnosticCode},
         entry_point::EntryPoint,
         evaluation::{Context, ContextValue, Evaluation, EvaluationSymbolPtr},
         file_mgr::{FileMgr, NoqaInfo},
         model::Model,
         odoo::SyncOdoo,
         symbols::{
-            Buildable, Dependencies, storage::{SymbolTable, dependency_mgr::{DependenciesTable, DependentsTable}}, symbol_keys::{
-                ClassKey, FunctionKey, KeyValidator, ModuleKey, NamespaceKey, RootKey, SourceFileKey, SymbolKey, VariableKey, XmlDataKey
-            }, symbol_mgr::{ContentSymbols, SectionIndex, SectionRange, SymbolMgr, iter_symbol_keys}
+            storage::{
+                dependency_mgr::{DependenciesTable, DependentsTable},
+                SymbolTable,
+            },
+            symbol_keys::{
+                ClassKey, FunctionKey, KeyValidator, ModuleKey, NamespaceKey, RootKey,
+                SourceFileKey, SymbolKey, VariableKey, XmlDataKey,
+            },
+            symbol_mgr::{iter_symbol_keys, ContentSymbols, SectionIndex, SectionRange, SymbolMgr},
+            Buildable, Dependencies,
         },
-    }, threads::SessionInfo, utils::{PathSanitizer}, weak_collections::WeakSet
+    },
+    threads::SessionInfo,
+    tree::{OYarnExt, Tree},
+    utils::PathSanitizer,
+    weak_collections::WeakSet,
+    S,
 };
 
 impl SymbolTable {
@@ -543,7 +556,7 @@ impl SymbolTable {
             return Some(session.st_mut().add_new_file(parent, &name, &path_str).into());
         }
         let main_entry_tree = session.sync_odoo.get_main_entry_tree(parent);
-        if main_entry_tree == tree(vec!["odoo", "addons"], vec![]) && path.join("__manifest__.py").exists() {
+        if main_entry_tree == (&["odoo", "addons"], &[]) && path.join("__manifest__.py").exists() {
             if let SymbolKey::Namespace(addons) = parent {
                 let module = Self::add_new_module_package(session, addons, &name, path);
                 let dir_name = session.st()[module].dir_name.clone();
@@ -561,7 +574,7 @@ impl SymbolTable {
         } else {
             let symbol_table = session.st_mut();
             if path.join("__init__.py").exists() || path.join("__init__.pyi").exists() {
-                if main_entry_tree == tree(vec!["odoo"], vec![]) && path_str.ends_with("addons") {
+                if main_entry_tree == (&["odoo"], &[]) && path_str.ends_with("addons") {
                     //Force namespace for odoo/addons
                     let namespace_key = symbol_table.add_new_namespace(parent, &name, &path_str);
                     return Some(namespace_key.into());
@@ -580,7 +593,7 @@ impl SymbolTable {
 
     pub fn create_module_from_path(session: &mut SessionInfo, path: &PathBuf, addons: NamespaceKey) -> Option<ModuleKey> {
         let main_entry_tree = session.sync_odoo.get_main_entry_tree(addons);
-        if !(main_entry_tree == tree(vec!["odoo", "addons"], vec![]) && path.join("__manifest__.py").exists()) {
+        if !(main_entry_tree == (&["odoo", "addons"], &[]) && path.join("__manifest__.py").exists()) {
             return None;
         }
         let name = path.components().last().unwrap().as_os_str().to_str().unwrap();
@@ -591,7 +604,7 @@ impl SymbolTable {
     }
 
     fn get_tree_helper(&self, symbol_key: SymbolKey) -> (Tree, RootKey) {
-        let mut tree = (vec![], vec![]);
+        let mut tree = Tree::default();
         let mut current_key = symbol_key;
         while !matches!(current_key, SymbolKey::Root(_)) {
             if self.is_file_content(current_key) {
@@ -634,19 +647,21 @@ impl SymbolTable {
     }
 
 
-    pub fn get_symbol(&self, target: SymbolKey, tree: &Tree, position: u32) -> Vec<SymbolKey> {
-        let symbol_tree_files: &Vec<OYarn> = &tree.0;
-        let symbol_tree_content: &Vec<OYarn> = &tree.1;
+    /// The generic type `S` allows for flexibility: `tree` can be a tuple of `&[OYarn]` or `&[&str]`
+    /// To call this function with a param of type `Tree`, transform it into its slice form: `tree.as_slice()`
+    pub fn get_symbol<S: AsRef<str>>(&self, target: SymbolKey, tree: (&[S], &[S]), position: u32) -> Vec<SymbolKey> {
+        let symbol_tree_files = tree.0;
+        let symbol_tree_content = tree.1;
         let mut iter_sym: Vec<SymbolKey>;
         if symbol_tree_files.len() != 0 {
-            let _mod_iter_sym = self.get_module_symbol(target, &symbol_tree_files[0]);
+            let _mod_iter_sym = self.get_module_symbol(target, symbol_tree_files[0].as_ref());
             if _mod_iter_sym.is_none() {
                 return vec![];
             }
             iter_sym = vec![_mod_iter_sym.unwrap()];
             if symbol_tree_files.len() > 1 {
                 for fk in symbol_tree_files[1..symbol_tree_files.len()].iter() {
-                    if let Some(s) = self.get_module_symbol(*iter_sym.last().unwrap(), fk) {
+                    if let Some(s) = self.get_module_symbol(*iter_sym.last().unwrap(), fk.as_ref()) {
                         iter_sym = vec![s];
                     } else {
                         return vec![];
@@ -658,7 +673,7 @@ impl SymbolTable {
                     if iter_sym.len() > 1 {
                         trace!("TODO: explore all implementation possibilities");
                     }
-                    let _iter_sym = self.get_sub_symbol(iter_sym[0], fk, position);
+                    let _iter_sym = self.get_sub_symbol(iter_sym[0], fk.as_ref(), position);
                     iter_sym = _iter_sym.symbols;
                     if iter_sym.is_empty() {
                         return vec![];
@@ -669,7 +684,7 @@ impl SymbolTable {
             if symbol_tree_content.len() == 0 {
                 return vec![];
             }
-            iter_sym = self.get_sub_symbol(target, &symbol_tree_content[0], position).symbols;
+            iter_sym = self.get_sub_symbol(target, symbol_tree_content[0].as_ref(), position).symbols;
             if iter_sym.is_empty() {
                 return vec![];
             }
@@ -678,7 +693,7 @@ impl SymbolTable {
                     trace!("TODO: explore all implementation possibilities");
                 }
                 for fk in symbol_tree_content[1..symbol_tree_content.len()].iter() {
-                    let _iter_sym = self.get_sub_symbol(iter_sym[0], fk, position);
+                    let _iter_sym = self.get_sub_symbol(iter_sym[0], fk.as_ref(), position);
                     iter_sym = _iter_sym.symbols;
                     // TODO: this is a loop that runs only once! Fix me!
                     return iter_sym;
@@ -1262,12 +1277,12 @@ impl SymbolTable {
     If a symbol in the chain is a descriptor, return the __get__ return evaluation.
     If filter_on_tree is set, stop following when one of the symbols in the chain is in the tree, and only return those symbols.
         */
-    pub fn follow_ref(evaluation: &EvaluationSymbolPtr, session: &mut SessionInfo, context: &mut Option<Context>, stop_on_type: bool, stop_on_value: bool, filter_on_tree: Option<Tree>, max_scope: Option<SymbolKey>) -> Vec<EvaluationSymbolPtr> {
+    pub fn follow_ref(evaluation: &EvaluationSymbolPtr, session: &mut SessionInfo, context: &mut Option<Context>, stop_on_type: bool, stop_on_value: bool, filter_on_tree: Option<(&[&str], &[&str])>, max_scope: Option<SymbolKey>) -> Vec<EvaluationSymbolPtr> {
         let default_result = match filter_on_tree.as_ref() {
             Some(_) => vec![],
             None => vec![evaluation.clone()],
         };
-        let stop_on_tree_syms = filter_on_tree.map(|tree| session.sync_odoo.get_symbol("", &tree, u32::MAX));
+        let stop_on_tree_syms = filter_on_tree.map(|tree| session.sync_odoo.get_symbol("", tree, u32::MAX));
         if matches!(stop_on_tree_syms.as_ref(), Some(syms) if syms.is_empty()) {
             // can't find the tree symbol, stop here
             return default_result;
@@ -1637,7 +1652,7 @@ impl SymbolTable {
             // A function can reference another name from the full outer scope so no position is needed
             Self::infer_name(odoo, parent, name, None)
         } else if symbol_table.name(on_symbol) != "builtins" || on_symbol_type != SymType::FILE {
-            let builtins = odoo.get_symbol("", &(vec![Sy!("builtins")], vec![]), u32::MAX)[0];
+            let builtins = odoo.get_symbol("", (&["builtins"], &[]), u32::MAX)[0];
             Self::infer_name(odoo, builtins, name, None)
         } else {
             ContentSymbols::default()
@@ -1652,7 +1667,7 @@ impl SymbolTable {
     fn member_symbol_hook(session: &SessionInfo, target: SymbolKey, name: &str, diagnostics: &mut Vec<Diagnostic>){
         if session.sync_odoo.version.major >= 17 && name == "Form"{
             let tree = session.sync_odoo.symbol_table.get_tree(target);
-            if tree.0.ends_with(&[Sy!("odoo"), Sy!("tests"), Sy!("common")]) && tree.1.is_empty() {
+            if tree.0.ends_with_strs(&["odoo", "tests", "common"]) && tree.1.is_empty() {
                 if let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS03301, &[]) {
                     diagnostics.push(
                         Diagnostic {
@@ -1713,14 +1728,14 @@ impl SymbolTable {
 
 
     pub fn is_inheriting_from_field(session: &SessionInfo, class_key: ClassKey) -> bool {
-        let tree = flatten_tree(&session.sync_odoo.get_main_entry_tree(class_key));
+        let tree = session.sync_odoo.get_main_entry_tree(class_key).flatten();
         if session.sync_odoo.version <= (18, 0) {
-            if tree.as_slice() == ["odoo", "fields", "Field"] {
+            if tree == ["odoo", "fields", "Field"] {
                 return true;
             }
 
         } else {
-            if tree.as_slice() == ["odoo", "orm", "fields", "Field"] {
+            if tree == ["odoo", "orm", "fields", "Field"] {
                 return true;
             }
         }
@@ -1794,7 +1809,7 @@ impl SymbolTable {
     }
 
     pub fn is_specific_field_class(session: &SessionInfo, target: SymbolKey, field_names: &[&str]) -> bool {
-        let tree = flatten_tree(&session.sync_odoo.get_main_entry_tree(target));
+        let tree = session.sync_odoo.get_main_entry_tree(target).flatten();
         let Some(tree_last) = tree.last() else {
             return false;
         };

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -595,19 +595,21 @@ impl SymbolTable {
         let mut current_key = symbol_key;
         while !matches!(current_key, SymbolKey::Root(_)) {
             if self.is_file_content(current_key) {
-                tree.1.insert(0, self.name(current_key).clone());
+                tree.1.push(self.name(current_key).clone());
             } else {
-                tree.0.insert(0, self.name(current_key).clone());
+                tree.0.push(self.name(current_key).clone());
             }
             current_key = self.parent(current_key).unwrap();
         }
         let root = current_key.unwrap_root_key();
+        tree.0.reverse();
+        tree.1.reverse();
         (tree, root)
     }
 
 
-    pub fn get_tree(&self, symbol_key: SymbolKey) -> Tree {
-        self.get_tree_helper(symbol_key).0
+    pub fn get_tree(&self, symbol_key: impl Into<SymbolKey>) -> Tree {
+        self.get_tree_helper(symbol_key.into()).0
     }
 
     pub fn get_tree_and_entry(&self, symbol_key: SymbolKey) -> (Tree, Rc<RefCell<EntryPoint>>) {

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -1485,17 +1485,16 @@ impl SymbolTable {
         is_super: bool
     ) -> HashMap<OYarn, Vec<(SymbolKey, Option<OYarn>)>> {
         let mut result: HashMap<OYarn, Vec<(SymbolKey, Option<OYarn>)>> = HashMap::default();
-        let mut acc: HashSet<Tree> = HashSet::default();
+        let mut acc = HashSet::default();
         Self::_all_members(symbol, session, &mut result, with_co_models, only_fields, only_methods, from_module, &mut acc, is_super);
         return  result;
     }
 
-    fn _all_members(symbol_key: SymbolKey, session: &mut SessionInfo, result: &mut HashMap<OYarn, Vec<(SymbolKey, Option<OYarn>)>>, with_co_models: bool, only_fields: bool, only_methods: bool, from_module: Option<ModuleKey>, acc: &mut HashSet<Tree>, is_super: bool) {
-        let tree = session.st().get_tree(symbol_key);
-        if acc.contains(&tree) {
+    fn _all_members(symbol_key: SymbolKey, session: &mut SessionInfo, result: &mut HashMap<OYarn, Vec<(SymbolKey, Option<OYarn>)>>, with_co_models: bool, only_fields: bool, only_methods: bool, from_module: Option<ModuleKey>, acc: &mut HashSet<SymbolKey>, is_super: bool) {
+        if acc.contains(&symbol_key) {
             return;
         }
-        acc.insert(tree);
+        acc.insert(symbol_key);
         let mut append_result = |name: OYarn, symbol: SymbolKey, dep: Option<OYarn>| {
             if let Some(vec) = result.get_mut(&name) {
                 vec.push((symbol, dep));

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -13,6 +13,7 @@ use crate::core::symbols::VariableSymbol;
 use crate::features::ast_utils::AstUtils;
 use crate::features::features_utils::FeaturesUtils;
 use crate::threads::SessionInfo;
+use crate::tree::OYarnExt;
 use crate::{Sy, S};
 use itertools::Itertools;
 use lsp_types::{
@@ -565,11 +566,11 @@ fn complete_decorator_call(
         };
         let dec_sym_tree = session.st().get_tree(dec_sym);
         let is_18_1_or_later = session.sync_odoo.version >= (18, 1);
-        let expected_types = if (!is_18_1_or_later && dec_sym_tree.0.ends_with(&[Sy!("odoo"), Sy!("api")])) ||
-                (is_18_1_or_later && dec_sym_tree.0.ends_with(&[Sy!("odoo"), Sy!("orm"), Sy!("decorators")])) {
-            if [vec![Sy!("onchange")], vec![Sy!("constrains")]].contains(&dec_sym_tree.1) && SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0) {
+        let expected_types = if (!is_18_1_or_later && dec_sym_tree.0.ends_with_strs(&["odoo", "api"])) ||
+                (is_18_1_or_later && dec_sym_tree.0.ends_with_strs(&["odoo", "orm", "decorators"])) {
+            if (dec_sym_tree.1 == &["onchange"] || dec_sym_tree.1 == &["constrains"]) && SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0) {
                 &vec![ExpectedType::SIMPLE_FIELD(None)]
-            } else if dec_sym_tree.1 == vec![Sy!("depends")] && SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0){
+            } else if dec_sym_tree.1 == &["depends"] && SyncOdoo::is_in_main_entry(session, &dec_sym_tree.0){
                 &vec![ExpectedType::NESTED_FIELD(None)]
             } else {
                 continue;
@@ -901,7 +902,7 @@ fn complete_subscript(session: &mut SessionInfo, file: SourceFileKey, expr_subsc
             let symbol_types = SymbolTable::follow_ref(&eval_symbol, session, &mut None, false, false, None, None);
             for symbol_type in symbol_types.iter() {
                 if let Some(symbol_type) = symbol_type.upgrade_weak(session.st()) {
-                    let get_item = session.st().get_symbol(symbol_type, &(vec![], vec![Sy!("__getitem__")]), u32::MAX);
+                    let get_item = session.st().get_symbol(symbol_type, (&[], &["__getitem__"]), u32::MAX);
                     if let Some(&get_item) = get_item.last() {
                         let evaluations = session.st().evaluations(get_item).unwrap();
                         if evaluations.len() == 1 {

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -7,9 +7,10 @@ use crate::core::symbols::function_symbol::Argument;
 use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SourceFileKey, SymbolKey, Wk};
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::{FunctionSymbol, VariableSymbol};
+use crate::tree::OYarnExt;
 use crate::utils::HashMap;
 
-use crate::constants::SymType;
+use crate::constants::{SymType};
 use crate::constants::OYarn;
 use crate::core::evaluation::{Context, ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationSymbolWeak, EvaluationValue};
 use crate::threads::SessionInfo;
@@ -260,15 +261,15 @@ impl FeaturesUtils {
                 let func_sym_tree = session.st().get_tree(callable_sym);
                 // TODO: account for change in tree after 18.1 odoo.orm.decorators
                 let is_18_1_or_later = session.sync_odoo.version >= (18, 1);
-                if (!is_18_1_or_later && func_sym_tree.0.ends_with(&[Sy!("odoo"), Sy!("api")])) ||
-                    (is_18_1_or_later && func_sym_tree.0.ends_with(&[Sy!("odoo"), Sy!("orm"), Sy!("decorators")])) {
+                if (!is_18_1_or_later && func_sym_tree.0.ends_with_strs(&["odoo", "api"])) ||
+                    (is_18_1_or_later && func_sym_tree.0.ends_with_strs(&["odoo", "orm", "decorators"])) {
                     if [vec![Sy!("onchange")], vec![Sy!("constrains")]].contains(&func_sym_tree.1) && SyncOdoo::is_in_main_entry(session, &func_sym_tree.0) {
                         arg_symbols.extend(
                             FeaturesUtils::find_simple_decorator_field_symbol(session, scope, from_module, field_name)
                             .into_iter().map(|symbol| (symbol, field_range.clone()))
                         );
                         continue;
-                    } else if func_sym_tree.1 == vec![Sy!("depends")] && SyncOdoo::is_in_main_entry(session, &func_sym_tree.0){
+                    } else if func_sym_tree.1 == &["depends"] && SyncOdoo::is_in_main_entry(session, &func_sym_tree.0){
                         arg_symbols.extend(
                             FeaturesUtils::find_nested_fields_in_class(session, scope, from_module, &field_range, field_name, &offset)
                         );

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -12,3 +12,4 @@ pub mod utils;
 pub mod crash_buffer;
 pub mod weak_collections;
 pub mod odoo_version;
+pub mod tree;

--- a/server/src/tree.rs
+++ b/server/src/tree.rs
@@ -1,0 +1,60 @@
+use crate::constants::OYarn;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct Tree(pub Vec<OYarn>, pub Vec<OYarn>);
+
+pub type TreeSlice<'a> = (&'a [OYarn], &'a [OYarn]);
+pub type TreeStrSlice<'a> = (&'a [&'a str], &'a [&'a str]);
+
+impl Tree {
+    pub fn as_slice(&self) -> TreeSlice<'_> {
+        (&self.0, &self.1)
+    }
+
+    pub fn flatten(mut self) -> Vec<OYarn> {
+        self.0.extend(self.1);
+        self.0
+    }
+}
+
+/// Builds a Tree from a tuple of &'static str slices, e.g. `Tree::from((&["a"], &["b"]))`
+impl From<TreeStrSlice<'static>> for Tree {
+    fn from(tree: TreeStrSlice<'static>) -> Self {
+        Tree(tree.0.iter().copied().map(OYarn::from).collect(),
+             tree.1.iter().copied().map(OYarn::from).collect())
+    }
+}
+
+/// Allows comparing a Tree to a pair of &str slices
+impl PartialEq<TreeStrSlice<'_>> for Tree {
+    fn eq(&self, other: &TreeStrSlice<'_>) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+/// Allows comparing a Tree to a pair of &str arrays of any size, e.g. `(&["a"], &["b"])`
+// In certain cases (&["a"], &["b"]) gets inferred as type (&[&str; 1], &[&str; 1])
+// (tuple of references to arrays) instead of (&[&str], &[&str]) (tuple of slices)
+// This impl allows the same ergonomics and the one above: `some_tree == (&["a"], &["b"])`
+impl<const N: usize, const M: usize> PartialEq<(&[&str; N], &[&str; M])> for Tree {
+    fn eq(&self, other: &(&[&str; N], &[&str; M])) -> bool {
+        self.0 == *other.0 && self.1 == *other.1
+    }
+}
+
+
+pub trait OYarnExt {
+    fn starts_with_strs(&self, prefix: &[&str]) -> bool;
+    fn ends_with_strs(&self, suffix: &[&str]) -> bool;
+}
+
+impl OYarnExt for [OYarn] {
+    /// Equivalent of `&[OYarn].starts_with` that accepts `&[&str]` as the prefix
+    fn starts_with_strs(&self, prefix: &[&str]) -> bool {
+        self.len() >= prefix.len() && &self[..prefix.len()] == prefix
+    }
+    /// Equivalent of `&[OYarn].ends_with` that accepts `&[&str]` as the suffix
+    fn ends_with_strs(&self, suffix: &[&str]) -> bool {
+        self.len() >= suffix.len() && &self[self.len() - suffix.len()..] == suffix
+    }
+}

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use std::sync::atomic::Ordering;
 use std::{fs::{self, DirEntry}, path::{Path, PathBuf}, str::FromStr, sync::LazyLock};
 
-use crate::{constants::Tree, oyarn};
+use crate::{tree::Tree, oyarn};
 
 static TEMPLATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\$\{([^}]+)\}").unwrap()
@@ -183,7 +183,7 @@ impl PathSanitizer for PathBuf {
         } else {
             self.clone()
         };
-        (
+        Tree(
             modified_path
                 .components()
                 .map(|c| oyarn!("{}", c.as_os_str().to_str().unwrap()))

--- a/server/tests/self_propagation_tests/self_propagation_tests.rs
+++ b/server/tests/self_propagation_tests/self_propagation_tests.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use odoo_ls_server::{Sy, constants::OYarn, core::{odoo::SyncOdoo, symbols::{symbol_keys::SymbolKey, storage::SymbolTable}}, utils::PathSanitizer};
+use odoo_ls_server::{core::{odoo::SyncOdoo, symbols::{symbol_keys::SymbolKey, storage::SymbolTable}}, utils::PathSanitizer};
 
 use crate::{setup::setup, test_utils};
 
@@ -52,9 +52,9 @@ fn test_model_subscription() {
 
     let file_mgr = session.sync_odoo.get_file_mgr();
     let file_info = file_mgr.borrow().get_file_info(&test_file).unwrap();
-    let model_a_sym = session.st().get_symbol(file_symbol.into(),&(vec![], vec![Sy!("ModelA")]), u32::MAX);
+    let model_a_sym = session.st().get_symbol(file_symbol.into(),(&[], &["ModelA"]), u32::MAX);
     assert_eq!(model_a_sym.len(), 1, "Expected 1 symbol for ModelA");
-    let model_b_sym = session.st().get_symbol(file_symbol.into(),&(vec![], vec![Sy!("ModelB")]), u32::MAX);
+    let model_b_sym = session.st().get_symbol(file_symbol.into(),(&[], &["ModelB"]), u32::MAX);
     assert_eq!(model_b_sym.len(), 1, "Expected 1 symbol for ModelB");
 
     let create_new_in_model_a = follow_evaluation_refs(
@@ -98,9 +98,9 @@ fn test_model_subscription() {
 
     // Test on normal classes
 
-    let a_sym = session.st().get_symbol(file_symbol.into(), &(vec![], vec![Sy!("A")]), u32::MAX);
+    let a_sym = session.st().get_symbol(file_symbol.into(), (&[], &["A"]), u32::MAX);
     assert_eq!(a_sym.len(), 1, "Expected 1 symbol for A");
-    let b_sym = session.st().get_symbol(file_symbol.into(), &(vec![], vec![Sy!("B")]), u32::MAX);
+    let b_sym = session.st().get_symbol(file_symbol.into(), (&[], &["B"]), u32::MAX);
     assert_eq!(b_sym.len(), 1, "Expected 1 symbol for B");
 
     let method_self_in_a = follow_evaluation_refs(

--- a/server/tests/test_basics.rs
+++ b/server/tests/test_basics.rs
@@ -2,12 +2,10 @@
 
 use odoo_ls_server::utils::HashSet;
 use std::env;
-use odoo_ls_server::{core::evaluation::EvaluationValue, oyarn};
-use odoo_ls_server::constants::OYarn;
+use odoo_ls_server::{core::evaluation::EvaluationValue};
 use odoo_ls_server::utils::PathSanitizer;
 use ruff_python_ast::Expr;
 
-use odoo_ls_server::Sy;
 
 mod setup;
 
@@ -41,7 +39,7 @@ fn test_assigns() {
     assert!(session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.len() == 1);
     let st = &session.sync_odoo.symbol_table;
 
-    let a = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("a")]), u32::MAX);
+    let a = session.sync_odoo.get_symbol(path.as_str(), (&[], &["a"]), u32::MAX);
     assert!(a.len() == 1);
     assert!(st.name(a[0]) == "a");
     assert!(st.evaluations(a[0]).as_ref().unwrap().len() == 1);
@@ -51,7 +49,7 @@ fn test_assigns() {
     assert!(st.evaluations(a[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.is_int());
     assert!(st.evaluations(a[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 5);
 
-    let b = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("b")]), u32::MAX);
+    let b = session.sync_odoo.get_symbol(path.as_str(), (&[], &["b"]), u32::MAX);
     assert!(b.len() == 1);
     assert!(st.name(b[0]) == "b");
     assert!(st.evaluations(b[0]).as_ref().unwrap().len() == 1);
@@ -60,7 +58,7 @@ fn test_assigns() {
     assert!(st.evaluations(b[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_string_literal_expr());
     assert!(st.evaluations(b[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_string_literal_expr().unwrap().value.to_str() == "test");
 
-    let c = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("c")]), u32::MAX);
+    let c = session.sync_odoo.get_symbol(path.as_str(), (&[], &["c"]), u32::MAX);
     assert!(c.len() == 1);
     assert!(st.name(c[0]) == "c");
     assert!(st.evaluations(c[0]).as_ref().unwrap().len() == 1);
@@ -70,7 +68,7 @@ fn test_assigns() {
     assert!(st.evaluations(c[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.is_float());
     assert!(st.evaluations(c[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_float().unwrap() == &3.14);
 
-    let d = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("d")]), u32::MAX);
+    let d = session.sync_odoo.get_symbol(path.as_str(), (&[], &["d"]), u32::MAX);
     assert!(d.len() == 1);
     assert!(st.name(d[0]) == "d");
     assert!(st.evaluations(d[0]).as_ref().unwrap().len() == 1);
@@ -79,7 +77,7 @@ fn test_assigns() {
     assert!(st.evaluations(d[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_boolean_literal_expr());
     assert!(st.evaluations(d[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_boolean_literal_expr().unwrap().value == true);
 
-    let e = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("e")]), u32::MAX);
+    let e = session.sync_odoo.get_symbol(path.as_str(), (&[], &["e"]), u32::MAX);
     assert!(e.len() == 1);
     assert!(st.name(e[0]) == "e");
     assert!(st.evaluations(e[0]).as_ref().unwrap().len() == 1);
@@ -88,7 +86,7 @@ fn test_assigns() {
     assert!(st.evaluations(e[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_boolean_literal_expr());
     assert!(st.evaluations(e[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_boolean_literal_expr().unwrap().value == false);
 
-    let f = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("f")]), u32::MAX);
+    let f = session.sync_odoo.get_symbol(path.as_str(), (&[], &["f"]), u32::MAX);
     assert!(f.len() == 1);
     assert!(st.name(f[0]) == "f");
     assert!(st.evaluations(f[0]).as_ref().unwrap().len() == 1);
@@ -96,7 +94,7 @@ fn test_assigns() {
     assert!(matches!(st.evaluations(f[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::NoneLiteral(_))));
     assert!(st.evaluations(f[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_none_literal_expr());
 
-    let g = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("g")]), u32::MAX);
+    let g = session.sync_odoo.get_symbol(path.as_str(), (&[], &["g"]), u32::MAX);
     assert!(g.len() == 1);
     assert!(st.name(g[0]) == "g");
     assert!(st.evaluations(g[0]).as_ref().unwrap().len() == 1);
@@ -110,7 +108,7 @@ fn test_assigns() {
     assert!(st.evaluations(g[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_list()[2].is_number_literal_expr());
     assert!(st.evaluations(g[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_list()[2].as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 3);
 
-    let h = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("h")]), u32::MAX);
+    let h = session.sync_odoo.get_symbol(path.as_str(), (&[], &["h"]), u32::MAX);
     assert!(h.len() == 1);
     assert!(st.name(h[0]) == "h");
     assert!(st.evaluations(h[0]).as_ref().unwrap().len() == 1);
@@ -124,7 +122,7 @@ fn test_assigns() {
     assert!(st.evaluations(h[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_tuple()[2].is_number_literal_expr());
     assert!(st.evaluations(h[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_tuple()[2].as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 3);
 
-    let i = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("i")]), u32::MAX);
+    let i = session.sync_odoo.get_symbol(path.as_str(), (&[], &["i"]), u32::MAX);
     assert!(i.len() == 1);
     assert!(st.name(i[0]) == "i");
     assert!(st.evaluations(i[0]).as_ref().unwrap().len() == 1);
@@ -140,7 +138,7 @@ fn test_assigns() {
     assert!(st.evaluations(i[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_dict()[1].1.is_number_literal_expr());
     assert!(st.evaluations(i[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_dict()[1].1.as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 2);
 
-    let j = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("j")]), u32::MAX);
+    let j = session.sync_odoo.get_symbol(path.as_str(), (&[], &["j"]), u32::MAX);
     assert!(j.len() == 1);
     assert!(st.name(j[0]) == "j");
     assert!(st.evaluations(j[0]).as_ref().unwrap().len() == 1);
@@ -158,7 +156,7 @@ fn test_sections() {
     let st = &session.sync_odoo.symbol_table;
 
     let assert_get_int_eval_values = |var_name: &str, values: HashSet<i32>|{
-        let syms = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![oyarn!("{}", var_name)]), u32::MAX);
+        let syms = session.sync_odoo.get_symbol(path.as_str(), (&[], &[var_name]), u32::MAX);
         assert_eq!(syms.len(), values.len()); // Check Number of symbols
         assert_eq!(syms.iter()
         .map(|&sym| {

--- a/server/tests/test_build_cycle.rs
+++ b/server/tests/test_build_cycle.rs
@@ -5,7 +5,6 @@ use odoo_ls_server::constants::{BuildStatus, BuildSteps};
 use odoo_ls_server::core::entry_point::EntryPointMgr;
 use odoo_ls_server::core::odoo::SyncOdoo;
 use odoo_ls_server::core::symbols::symbol_keys::SymbolKey;
-use odoo_ls_server::oyarn;
 use odoo_ls_server::threads::SessionInfo;
 use odoo_ls_server::utils::PathSanitizer;
 
@@ -54,7 +53,7 @@ fn test_build_now_arch_eval_cycle_does_not_overflow() {
 fn get_file(session: &SessionInfo, module_dir: &str, name: &str) -> SymbolKey {
     let syms = session
         .sync_odoo
-        .get_symbol(module_dir, &(vec![oyarn!("{}", name)], vec![]), u32::MAX);
+        .get_symbol(module_dir, (&[name], &[]), u32::MAX);
     assert!(!syms.is_empty(), "expected file symbol for {}", name);
     syms[0]
 }

--- a/server/tests/test_follow_ref.rs
+++ b/server/tests/test_follow_ref.rs
@@ -2,11 +2,9 @@ mod setup;
 mod test_utils;
 use odoo_ls_server::core::file_mgr::FileInfo;
 use odoo_ls_server::core::odoo::SyncOdoo;
-use odoo_ls_server::constants::OYarn;
 use odoo_ls_server::core::symbols::symbol_keys::{SourceFileKey};
 use odoo_ls_server::threads::SessionInfo;
 use odoo_ls_server::utils::PathSanitizer;
-use odoo_ls_server::Sy;
 use std::cell::RefCell;
 use std::env;
 use std::path::PathBuf;
@@ -37,8 +35,8 @@ fn test_variable_type_resolution(
     file_symbol: SourceFileKey,
 ) {
     let test_class = session.st().get_sub_symbol(file_symbol.into(), "TestClass", u32::MAX).symbols[0].clone();
-    let int_type = session.sync_odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("int")]), u32::MAX)[0].clone();
-    let str_type = session.sync_odoo.get_symbol("", &(vec![Sy!("builtins")], vec![Sy!("str")]), u32::MAX)[0].clone();
+    let int_type = session.sync_odoo.get_symbol("", (&["builtins"], &["int"]), u32::MAX)[0].clone();
+    let str_type = session.sync_odoo.get_symbol("", (&["builtins"], &["str"]), u32::MAX)[0].clone();
 
     // Test cases: (var_name, (line, character), expected_types)
     let test_cases = [

--- a/server/tests/test_get_symbol.rs
+++ b/server/tests/test_get_symbol.rs
@@ -296,7 +296,7 @@ fn test_definition() {
     let compute_arg_locs = test_utils::get_definition_locs(&mut session, m1_tf_file_symbol, &m1_tf_file_info, 8, 50);
     assert_eq!(compute_arg_locs.len(), 1, "Expected 1 location for compute method '_compute_something'");
     assert_eq!(compute_arg_locs[0].target_uri.to_file_path().unwrap().sanitize(), module1_test_file, "Expected location to be in the same file");
-    let sym_compute_something = session.st().get_symbol(m1_tf_file_symbol.into(), &(vec![], vec![Sy!("BaseTestModel"), Sy!("_compute_something")]), u32::MAX);
+    let sym_compute_something = session.st().get_symbol(m1_tf_file_symbol.into(), (&[], &["BaseTestModel", "_compute_something"]), u32::MAX);
     assert_eq!(sym_compute_something.len(), 1, "Expected 1 symbol for _compute_something");
     let range = session.st().range(sym_compute_something[0]).clone();
     assert_eq!(file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, &range), compute_arg_locs[0].target_range, "Expected _compute_something to be at the same location as the compute argument");
@@ -313,7 +313,7 @@ fn test_definition() {
     assert_eq!(compute_kwarg_locs.len(), 2, "Expected 2 locations for compute method '_compute_something'");
     assert!(compute_kwarg_locs.iter().any(|loc| loc.target_uri.to_file_path().unwrap().sanitize() == module1_test_file), "Expected one location to be in module_1 file");
     assert!(compute_kwarg_locs.iter().any(|loc| loc.target_uri.to_file_path().unwrap().sanitize() == module2_test_file), "Expected one location to be in module_2 file");
-    let sym_compute_something_m2 = session.st().get_symbol(m2_tf_file_symbol.into(), &(vec![], vec![Sy!("BaseTestModel"), Sy!("_compute_something")]), u32::MAX);
+    let sym_compute_something_m2 = session.st().get_symbol(m2_tf_file_symbol.into(), (&[], &["BaseTestModel", "_compute_something"]), u32::MAX);
     assert_eq!(sym_compute_something_m2.len(), 1, "Expected 1 symbol for _compute_something in module_2");
 
     // Check that compute_kwarg_locs contains the range of the compute something syms from both files
@@ -326,13 +326,13 @@ fn test_definition() {
     let partner_id_locs = test_utils::get_definition_locs(&mut session, m1_tf_file_symbol, &m1_tf_file_info, 33, 25);
     assert_eq!(partner_id_locs.len(), 1, "Expected 1 location for partner_id");
     assert_eq!(partner_id_locs[0].target_uri.to_file_path().unwrap().sanitize(), module1_test_file, "Expected location to be in the same file");
-    let sym_partner_id = session.st().get_symbol(m1_tf_file_symbol.into(), &(vec![], vec![Sy!("BaseTestModel"), Sy!("partner_id")]), u32::MAX);
+    let sym_partner_id = session.st().get_symbol(m1_tf_file_symbol.into(), (&[], &["BaseTestModel", "partner_id"]), u32::MAX);
     assert_eq!(sym_partner_id.len(), 1, "Expected 1 symbol for partner_id");
     let range = session.st().range(sym_partner_id[0]).clone();
     assert_eq!(file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, &range), partner_id_locs[0].target_range, "Expected partner_id to be at the same location as the field");
 
     let country_id_locs = test_utils::get_definition_locs(&mut session, m1_tf_file_symbol, &m1_tf_file_info, 10, 74);
-    let country_id_field_sym = session.sync_odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("base"), Sy!("models"), Sy!("res_partner")], vec![Sy!(partner_class_name), Sy!("country_id")]), u32::MAX);
+    let country_id_field_sym = session.sync_odoo.get_symbol(odoo_path, (&["odoo", "addons", "base", "models", "res_partner"], &[partner_class_name, "country_id"]), u32::MAX);
     assert_eq!(country_id_field_sym.len(), 1, "Expected 1 location for country_id");
     let country_id_field_sym = country_id_field_sym[0].clone();
     let country_id_file = session.st().path(session.st().get_file(country_id_field_sym).unwrap()).to_string();
@@ -343,7 +343,7 @@ fn test_definition() {
 
     // now the same for phone_code
     let phone_code_locs = test_utils::get_definition_locs(&mut session, m1_tf_file_symbol, &m1_tf_file_info, 10, 86);
-    let phone_code_field_sym = session.sync_odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("base"), Sy!("models"), Sy!("res_country")], vec![Sy!(country_class_name), Sy!("phone_code")]), u32::MAX);
+    let phone_code_field_sym = session.sync_odoo.get_symbol(odoo_path, (&["odoo", "addons", "base", "models", "res_country"], &[country_class_name, "phone_code"]), u32::MAX);
     assert_eq!(phone_code_field_sym.len(), 1, "Expected 1 location for phone_code");
     let phone_code_field_sym = phone_code_field_sym[0].clone();
     let phone_code_file = session.st().path(session.st().get_file(phone_code_field_sym).unwrap()).to_string();
@@ -380,20 +380,20 @@ fn test_definition_csv() {
     };
 
     // Test definition for country_id header
-    let res_country_file = session.sync_odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("base"), Sy!("models"), Sy!("res_country")], vec![]), u32::MAX);
+    let res_country_file = session.sync_odoo.get_symbol(odoo_path, (&["odoo", "addons", "base", "models", "res_country"], &[]), u32::MAX);
     assert!(res_country_file.len() == 1);
     let res_country_file = res_country_file[0];
     let path = session.st().file_path(res_country_file.as_source_file_key().unwrap()).to_string();
     let country_id_loc = test_utils::get_definition_locs(&mut session, mcsv_tf_file_symbol, &mcsv_tf_file_info, 0, 8);
     assert_eq!(country_id_loc.len(), 1, "Expected 1 location for header 'country_id_loc'");
     assert_eq!(country_id_loc[0].target_uri.to_file_path().unwrap().sanitize(), path, "Expected location to be in res_country.py file");
-    let country_id_sym = session.st().get_symbol(res_country_file, &(vec![], vec![Sy!("ResCountryState"), Sy!("country_id")]), u32::MAX);
+    let country_id_sym = session.st().get_symbol(res_country_file, (&[], &["ResCountryState", "country_id"]), u32::MAX);
     assert_eq!(country_id_sym.len(), 1, "Expected 1 symbol for country_id_sym");
     let range = session.st().range(country_id_sym[0]).clone();
     assert_eq!(file_mgr.borrow().text_range_to_range(&mut session, &path, &range), country_id_loc[0].target_range, "Expected country_id to be at the same location as the compute argument");
 
     // Test definition for code header (id part)
-    let ir_model_file = session.sync_odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("base"), Sy!("models"), Sy!("ir_model")], vec![]), u32::MAX);
+    let ir_model_file = session.sync_odoo.get_symbol(odoo_path, (&["odoo", "addons", "base", "models", "ir_model"], &[]), u32::MAX);
     assert!(ir_model_file.len() == 1);
     let ir_model_file = ir_model_file[0].clone();
     let path = session.st().file_path(ir_model_file.as_source_file_key().unwrap()).to_string();
@@ -403,7 +403,7 @@ fn test_definition_csv() {
     for loc in country_id_id_loc.iter() {
         if loc.target_uri.to_file_path().unwrap().sanitize() == path {
             found_base = true;
-            let base_sym = session.st().get_symbol(ir_model_file, &(vec![], vec![Sy!("Base")]), u32::MAX);
+            let base_sym = session.st().get_symbol(ir_model_file, (&[], &["Base"]), u32::MAX);
             assert_eq!(base_sym.len(), 1, "Expected 1 symbol for Base id field");
             let range = session.st().range(base_sym[0]).clone();
             assert_eq!(file_mgr.borrow().text_range_to_range(&mut session, &path, &range), loc.target_range, "Expected the location of Base class");
@@ -418,7 +418,7 @@ fn test_definition_csv() {
     assert_eq!(lsp_types::Range{start: lsp_types::Position { line: 1, character: 0 }, end: lsp_types::Position { line: 1, character: 13 }}, state_loc[0].target_range, "Expected code to be at the same location as the compute argument");
 
     // Test definition for base.au record field
-    let base = session.sync_odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("base")], vec![]), u32::MAX);
+    let base = session.sync_odoo.get_symbol(odoo_path, (&["odoo", "addons", "base"], &[]), u32::MAX);
     assert!(base.len() == 1);
     let base_module = base[0].unwrap_module_key();
     let base_path = session.st()[base_module].path.clone();
@@ -464,7 +464,7 @@ fn test_model_subscription() {
     };
     let file_mgr = session.sync_odoo.get_file_mgr();
     let file_info = file_mgr.borrow().get_file_info(&test_file).unwrap();
-    let base_test_model_sym = session.st().get_symbol(file_symbol.into(), &(vec![], vec![Sy!("BaseTestModel")]), u32::MAX);
+    let base_test_model_sym = session.st().get_symbol(file_symbol.into(), (&[], &["BaseTestModel"]), u32::MAX);
     assert_eq!(base_test_model_sym.len(), 1, "Expected 1 symbol for BaseTestModel");
     let resolved_syms = test_utils::get_resolved_symbols_at_position(&mut session, file_symbol, &file_info, 34, 10);
     assert!(

--- a/server/tests/test_ls.rs
+++ b/server/tests/test_ls.rs
@@ -4,8 +4,6 @@ use std::path::PathBuf;
 use std::env;
 use odoo_ls_server::core::odoo::SyncOdoo;
 use odoo_ls_server::utils::PathSanitizer;
-use odoo_ls_server::Sy;
-use odoo_ls_server::constants::OYarn;
 
 mod setup;
 
@@ -19,24 +17,24 @@ fn test_structure() {
     let odoo_path = env::var("COMMUNITY_PATH").unwrap();
     let odoo_path = PathBuf::from(odoo_path).sanitize();
     let odoo_path = odoo_path.as_str();
-    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo")], vec![]), u32::MAX).is_empty());
-    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons")], vec![]), u32::MAX).is_empty());
-    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![]), u32::MAX).is_empty());
-    assert!(!odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_2")], vec![]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("not_a_module")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, (&["odoo"], &[]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, (&["odoo", "addons"], &[]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1"], &[]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_2"], &[]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, (&["odoo", "addons", "not_a_module"], &[]), u32::MAX).is_empty());
 
-    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded")], vec![]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded"), Sy!("not_loaded_file")], vec![]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded"), Sy!("not_loaded_file")], vec![Sy!("NotLoadedClass")]), u32::MAX).is_empty());
-    assert!(odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("not_loaded"), Sy!("not_loaded_file")], vec![Sy!("NotLoadedFunc")]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "not_loaded"], &[]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "not_loaded", "not_loaded_file"], &[]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "not_loaded", "not_loaded_file"], &["NotLoadedClass"]), u32::MAX).is_empty());
+    assert!(odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "not_loaded", "not_loaded_file"], &["NotLoadedFunc"]), u32::MAX).is_empty());
 
-    let models = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("models")], vec![]), u32::MAX);
+    let models = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "models"], &[]), u32::MAX);
     assert!(models.len() == 1);
-    assert!(st.get_symbol(models[0], &(vec![Sy!("base_test_models")], vec![]), u32::MAX).len() == 1);
-    assert!(st.get_symbol(models[0], &(vec![], vec![Sy!("base_test_models")]), u32::MAX).len() == 1);
-    assert!(st.get_symbol(models[0], &(vec![Sy!("base_test_models")], vec![]), u32::MAX)[0] !=
-            st.get_symbol(models[0], &(vec![], vec![Sy!("base_test_models")]), u32::MAX)[0]);
-    let module_1 = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![]), u32::MAX);
+    assert!(st.get_symbol(models[0], (&["base_test_models"], &[]), u32::MAX).len() == 1);
+    assert!(st.get_symbol(models[0], (&[], &["base_test_models"]), u32::MAX).len() == 1);
+    assert!(st.get_symbol(models[0], (&["base_test_models"], &[]), u32::MAX)[0] !=
+            st.get_symbol(models[0], (&[], &["base_test_models"]), u32::MAX)[0]);
+    let module_1 = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1"], &[]), u32::MAX);
     assert!(module_1.len() == 1);
     //assert!(compare_symbol_with_json(module_1, "tests/module_1_structure.json"))
     test_imports(&odoo);
@@ -48,54 +46,54 @@ fn test_imports(odoo: &SyncOdoo) {
     let odoo_path = env::var("COMMUNITY_PATH").unwrap();
     let odoo_path = PathBuf::from(odoo_path).sanitize();
     let odoo_path = odoo_path.as_str();
-    let model_var = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![Sy!("models")]), u32::MAX);
-    let model_dir = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("models")], vec![]), u32::MAX);
+    let model_var = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1"], &["models"]), u32::MAX);
+    let model_dir = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "models"], &[]), u32::MAX);
     assert!(model_var.len() == 1);
     assert!(model_dir.len() == 1);
     assert!(model_dir[0] != model_var[0]);
     assert!(st.evaluations(model_var[0]).as_ref().unwrap().len() == 1);
     assert!(st.evaluations(model_var[0]).as_ref().unwrap()[0].symbol.get_symbol_ptr().upgrade_weak(st) == Some(model_dir[0]));
-    let data_var = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![Sy!("data")]), u32::MAX);
+    let data_var = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1"], &["data"]), u32::MAX);
     assert!(data_var.len() == 1);
     assert!(st.evaluations(data_var[0]).as_ref().unwrap().is_empty());
 
     //test * imports
-    let constants_dir = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("constants")], vec![]), u32::MAX);
+    let constants_dir = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "constants"], &[]), u32::MAX);
     assert!(constants_dir.len() == 1);
     let constants_dir = constants_dir[0];
     assert!(st.all_symbols(constants_dir).len() == 3);
-    assert!(st.get_symbol(constants_dir, &(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX).len() == 1);
-    assert!(st.get_symbol(constants_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX).len() == 1);
-    assert!(st.get_symbol(constants_dir, &(vec![], vec![Sy!("CONSTANT_3")]), u32::MAX).len() == 0);
-    assert!(st.get_symbol(constants_dir, &(vec![Sy!("data")], vec![]), u32::MAX).len() == 1);
-    assert!(st.evaluations(st.get_symbol(constants_dir, &(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
-    assert!(st.evaluations(st.get_symbol(constants_dir, &(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_none());
-    assert!(st.evaluations(st.get_symbol(constants_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
-    assert!(st.evaluations(st.get_symbol(constants_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_none());
-    let data_dir = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("constants"), Sy!("data")], vec![]), u32::MAX);
+    assert!(st.get_symbol(constants_dir, (&[], &["CONSTANT_1"]), u32::MAX).len() == 1);
+    assert!(st.get_symbol(constants_dir, (&[], &["CONSTANT_2"]), u32::MAX).len() == 1);
+    assert!(st.get_symbol(constants_dir, (&[], &["CONSTANT_3"]), u32::MAX).len() == 0);
+    assert!(st.get_symbol(constants_dir, (&["data"], &[]), u32::MAX).len() == 1);
+    assert!(st.evaluations(st.get_symbol(constants_dir, (&[], &["CONSTANT_1"]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
+    assert!(st.evaluations(st.get_symbol(constants_dir, (&[], &["CONSTANT_1"]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_none());
+    assert!(st.evaluations(st.get_symbol(constants_dir, (&[], &["CONSTANT_2"]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
+    assert!(st.evaluations(st.get_symbol(constants_dir, (&[], &["CONSTANT_2"]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_none());
+    let data_dir = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "constants", "data"], &[]), u32::MAX);
     assert!(data_dir.len() == 1);
     let data_dir = data_dir[0];
     assert!(st.all_symbols(data_dir).len() == 4);
-    assert!(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX).len() == 1);
-    assert!(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX).len() == 1);
-    assert!(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_3")]), u32::MAX).len() == 0);
-    assert!(st.get_symbol(data_dir, &(vec![Sy!("constants")], vec![]), u32::MAX).len() == 1);
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_1")]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_none());
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_some());
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_number_literal_expr());
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), u32::MAX)[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 22);
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), 26)[0]).as_ref().unwrap().len() == 1);
-    assert!(st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), 26)[0]).as_ref().unwrap()[0].value.is_none());
-    assert!(!st.evaluations(st.get_symbol(data_dir, &(vec![], vec![Sy!("CONSTANT_2")]), 26)[0]).as_ref().unwrap()[0].symbol.get_weak().weak.is_expired(st));
+    assert!(st.get_symbol(data_dir, (&[], &["CONSTANT_1"]), u32::MAX).len() == 1);
+    assert!(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), u32::MAX).len() == 1);
+    assert!(st.get_symbol(data_dir, (&[], &["CONSTANT_3"]), u32::MAX).len() == 0);
+    assert!(st.get_symbol(data_dir, (&["constants"], &[]), u32::MAX).len() == 1);
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_1"]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_1"]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_none());
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), u32::MAX)[0]).as_ref().unwrap().len() == 1);
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), u32::MAX)[0]).as_ref().unwrap()[0].value.is_some());
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), u32::MAX)[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_number_literal_expr());
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), u32::MAX)[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 22);
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), 26)[0]).as_ref().unwrap().len() == 1);
+    assert!(st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), 26)[0]).as_ref().unwrap()[0].value.is_none());
+    assert!(!st.evaluations(st.get_symbol(data_dir, (&[], &["CONSTANT_2"]), 26)[0]).as_ref().unwrap()[0].symbol.get_weak().weak.is_expired(st));
 
     //Test odoo.addons import
-    let constant_1_var = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("models"), Sy!("base_test_models")], vec![Sy!("CONSTANT_1")]), u32::MAX);
+    let constant_1_var = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "models", "base_test_models"], &["CONSTANT_1"]), u32::MAX);
     println!("test");
     assert!(constant_1_var.len() == 1);
     assert!(st.evaluations(constant_1_var[0]).as_ref().unwrap().len() == 1);
-    let constant_1_var_data = odoo.get_symbol(odoo_path, &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1"), Sy!("constants")], vec![Sy!("CONSTANT_1")]), u32::MAX);
+    let constant_1_var_data = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "constants"], &["CONSTANT_1"]), u32::MAX);
     assert!(constant_1_var_data.len() == 1);
     assert!(st.evaluations(constant_1_var[0]).as_ref().unwrap()[0].symbol.get_symbol_ptr().upgrade_weak(st) == Some(constant_1_var_data[0]));
 

--- a/server/tests/test_ls.rs
+++ b/server/tests/test_ls.rs
@@ -90,7 +90,6 @@ fn test_imports(odoo: &SyncOdoo) {
 
     //Test odoo.addons import
     let constant_1_var = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "models", "base_test_models"], &["CONSTANT_1"]), u32::MAX);
-    println!("test");
     assert!(constant_1_var.len() == 1);
     assert!(st.evaluations(constant_1_var[0]).as_ref().unwrap().len() == 1);
     let constant_1_var_data = odoo.get_symbol(odoo_path, (&["odoo", "addons", "module_1", "constants"], &["CONSTANT_1"]), u32::MAX);

--- a/server/tests/test_setup.rs
+++ b/server/tests/test_setup.rs
@@ -1,9 +1,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-use odoo_ls_server::constants::OYarn;
 use odoo_ls_server::utils::PathSanitizer;
-use odoo_ls_server::Sy;
 
 mod setup;
 
@@ -26,9 +24,9 @@ fn test_start_odoo_server() {
     let odoo_path = PathBuf::from(env::var("COMMUNITY_PATH").unwrap()).sanitize();
 
     /* Let's ensure that the architecture is loaded */
-    assert!(!odoo.get_symbol(odoo_path.as_str(), &(vec![Sy!("odoo")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path.as_str(), (&["odoo"], &[]), u32::MAX).is_empty());
     /* Let's ensure that odoo/addons is loaded */
-    assert!(!odoo.get_symbol(odoo_path.as_str(), &(vec![Sy!("odoo"), Sy!("addons")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path.as_str(), (&["odoo", "addons"], &[]), u32::MAX).is_empty());
     /* And let's test that our test module has well been added and available in odoo/addons */
-    assert!(!odoo.get_symbol(odoo_path.as_str(), &(vec![Sy!("odoo"), Sy!("addons"), Sy!("module_1")], vec![]), u32::MAX).is_empty());
+    assert!(!odoo.get_symbol(odoo_path.as_str(), (&["odoo", "addons", "module_1"], &[]), u32::MAX).is_empty());
 }

--- a/server/tests/test_type_hints.rs
+++ b/server/tests/test_type_hints.rs
@@ -1,13 +1,11 @@
 mod setup;
 mod test_utils;
 
-use odoo_ls_server::constants::OYarn;
 use odoo_ls_server::core::file_mgr::FileInfo;
 use odoo_ls_server::core::odoo::SyncOdoo;
 use odoo_ls_server::core::symbols::symbol_keys::{SourceFileKey, SymbolKey};
 use odoo_ls_server::threads::SessionInfo;
 use odoo_ls_server::utils::PathSanitizer;
-use odoo_ls_server::Sy;
 use std::cell::RefCell;
 use std::env;
 use std::path::PathBuf;
@@ -33,7 +31,7 @@ where
     let file_symbol = SyncOdoo::get_symbol_of_opened_file(&mut session, &PathBuf::from(&path))
         .expect("Failed to get file symbol");
 
-    let my_class = session.sync_odoo.get_symbol(path.as_str(), &(vec![], vec![Sy!("MyClass")]), u32::MAX);
+    let my_class = session.sync_odoo.get_symbol(path.as_str(), (&[], &["MyClass"]), u32::MAX);
     assert!(!my_class.is_empty(), "MyClass should be found in the test file");
     let my_class = my_class[0].clone();
 


### PR DESCRIPTION
This PR is based on alpha-odoo_version_type-rcdl to avoid massive conflicts.

Benchmarks alpha-1.5.0 x this branch (includes OdooVersion commit): about 4% faster load.

Community only:
```
 Aggregated results (5 runs each, mean ± stddev)            
════════════════════════════════════════════════════════════════
commit                  user (s)             sys (s)       total CPU (s)         peak RSS (MB)
──────────  ──────────────────  ──────────────────  ──────────────────  ────────────────────
f5d97f94         17.110 ± 0.067      2.310 ± 0.023     19.420 ± 0.070         1637.5 ± 0.3
a4e7e7cb         16.244 ± 0.052      2.330 ± 0.036     18.574 ± 0.054         1637.3 ± 0.2

Δ (after − before):
  total CPU (s):         -0.846  ( -4.36%)   z=9.6
  peak RSS (MB):           -0.2  ( -0.01%)   z=0.6

z = |Δ| / sqrt(σ_before² + σ_after²) — rough significance:
  z > 3 : clearly significant   1 < z < 3 : suggestive   z < 1 : likely noise
```

Community + enterprise:
```
 Aggregated results (5 runs each, mean ± stddev)            
════════════════════════════════════════════════════════════════
commit                  user (s)             sys (s)       total CPU (s)         peak RSS (MB)
──────────  ──────────────────  ──────────────────  ──────────────────  ────────────────────
f5d97f94         35.552 ± 0.020      4.002 ± 0.124     39.554 ± 0.142         2822.9 ± 0.3
a4e7e7cb         34.194 ± 0.110      3.882 ± 0.073     38.076 ± 0.143         2822.6 ± 0.3

Δ (after − before):
  total CPU (s):         -1.478  ( -3.74%)   z=7.3
  peak RSS (MB):           -0.3  ( -0.01%)   z=0.7
```