### PR TITLE
[FIX] WeakSet::retain exposing invalid keys

### DIFF
--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -502,7 +502,7 @@ impl EntryPoint {
             session.st_mut().invalidate_sub_functions(s);
             session.sync_odoo.add_to_validations(s);
         }
-        self.not_found_symbols.retain(|&sym| {
+        self.not_found_symbols.retain_valid(session.st(), |&sym| {
             if !session.st().not_found_paths(sym).is_empty() {
                 return true;
             }
@@ -538,7 +538,7 @@ impl EntryPoint {
             session.st_mut().invalidate_sub_functions(s);
             session.sync_odoo.add_to_validations(s);
         }
-        self.not_found_symbols_for_models.retain(|&sym| {
+        self.not_found_symbols_for_models.retain_valid(session.st(), |&sym| {
             !session.st().not_found_models(sym).map(|models| models.is_empty()).unwrap_or(true)
         });
 

--- a/server/src/weak_collections.rs
+++ b/server/src/weak_collections.rs
@@ -47,8 +47,8 @@ impl<K: Eq + Hash + Copy> WeakSet<K> {
         snapshot.into_iter()
     }
 
-    pub fn retain(&mut self, f: impl Fn(&K) -> bool) {
-        self.set.get_mut().retain(|k| f(k));
+    pub fn retain_valid(&mut self, table: &impl KeyValidator<K>, f: impl Fn(&K) -> bool) {
+        self.set.get_mut().retain(|k| table.is_key_valid(*k) && f(k));
     }
 
     pub fn drain_valid(&mut self, table: &impl KeyValidator<K>) -> IntoIter<K> {


### PR DESCRIPTION
WeakSet::retain takes function as arg, which receives a potentially invalid key as argument. This commit removes this foot-gun.