### PR TITLE
[FIX] dedup bugs in references engine and model walker

### DIFF
--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -256,6 +256,23 @@ impl AnalyzeAstResult {
     }
 }
 
+/// Record a hit for the active `evaluation_search` at `range` inside `parent`'s file.
+/// Innermost expressions are analyzed first, so the first record at a given start
+/// position wins; outer enclosing expressions starting at the same place are skipped.
+/// Different start positions on the same line are kept (for multiple uses of a name).
+fn record_evaluation_hit(session: &mut SessionInfo, parent: SymbolKey, range: TextRange) -> bool {
+    let Some(file) = session.st().get_file(parent) else { return false };
+    let file_path = session.st().path(file).to_string();
+    let Some(file_info) = session.sync_odoo.get_file_mgr().borrow().get_file_info(&file_path) else { return false };
+    let transformed_range = file_info.borrow().text_range_to_range(&range, session.sync_odoo.encoding);
+    let uri = FileMgr::pathname2uri(&file_path);
+    if session.sync_odoo.evaluation_locations.iter().any(|loc| loc.uri == uri && loc.range.start == transformed_range.start) {
+        return false;
+    }
+    session.sync_odoo.evaluation_locations.push(Location { uri, range: transformed_range });
+    true
+}
+
 impl Evaluation {
 
     pub fn new_list(odoo: &mut SyncOdoo, values: Option<Vec<Expr>>, range: TextRange) -> Evaluation {
@@ -1521,7 +1538,8 @@ impl Evaluation {
             ExprOrIdent::Expr(Expr::Starred(_starred_expr)) => {},
             ExprOrIdent::Expr(Expr::IpyEscapeCommand(_ipy_escape_command_expr)) =>{},
         }
-        if let Some(evaluation_search) = session.sync_odoo.evaluation_search.as_ref() {
+        let evaluation_search = session.sync_odoo.evaluation_search.clone();
+        if let Some(evaluation_search) = evaluation_search.as_ref() {
             for eval in evals.iter() {
                 if found_one_reference {
                     //if we have multiple matches, it means that that ast can reference it multiple times, but we only want to know if that ast matches or not
@@ -1529,24 +1547,7 @@ impl Evaluation {
                 }
                 if eval.symbol.sym.has_weak() && let Some(weak) = eval.symbol.sym.get_weak().weak.upgrade(session.st()) {
                     if let Some(evaluation_search_sym) = evaluation_search.as_symbol() && weak == evaluation_search_sym {
-                        let file = session.st().get_file(parent).unwrap();
-                        let file_path = session.st().path(file);
-                        let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(file_path);
-                        if let Some(file_info) = file_info {
-                            found_one_reference = true;
-                            let range= ast.range();
-                            let transformed_range = file_info.borrow().text_range_to_range(&range, session.sync_odoo.encoding);
-                            //check that a previous call to analyze_ast (recursively for ex) didn't already add this expression
-                            let uri = FileMgr::pathname2uri(file_path);
-                            if session.sync_odoo.evaluation_locations.is_empty() ||
-                            session.sync_odoo.evaluation_locations.last().unwrap().uri != uri ||
-                            session.sync_odoo.evaluation_locations.last().unwrap().range.start.line != transformed_range.start.line {
-                                session.sync_odoo.evaluation_locations.push(Location {
-                                    uri: uri,
-                                    range: transformed_range,
-                                });
-                            }
-                        }
+                        found_one_reference |= record_evaluation_hit(session, parent, ast.range());
                     }
                 }
                 if let Some(value) = eval.value.as_ref() {
@@ -1555,41 +1556,14 @@ impl Evaluation {
                             match evaluation_search {
                                 ReferenceTarget::String(evaluation_search_string) => {
                                     if constant.value.to_str() == evaluation_search_string {
-                                        let file = session.st().get_file(parent).unwrap();
-                                        let file_path = session.st().path(file);
-                                        let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(file_path);
-                                        if let Some(file_info) = file_info {
-                                            found_one_reference = true;
-                                            let range = ast.range();
-                                            let transformed_range = file_info.borrow().text_range_to_range(&range, session.sync_odoo.encoding);
-                                            //check that a previous call to analyze_ast (recursively for ex) didn't already add this expression
-                                            let uri = FileMgr::pathname2uri(file_path);
-                                            if session.sync_odoo.evaluation_locations.is_empty() ||
-                                            session.sync_odoo.evaluation_locations.last().unwrap().uri != uri ||
-                                            session.sync_odoo.evaluation_locations.last().unwrap().range.start.line != transformed_range.start.line{
-                                                session.sync_odoo.evaluation_locations.push(Location {
-                                                    uri: uri,
-                                                    range: transformed_range,
-                                                });
-                                            }
-                                        }
+                                        found_one_reference |= record_evaluation_hit(session, parent, ast.range());
                                     }
                                 },
                                 ReferenceTarget::Symbol(evaluation_search_sym) => {
                                     if let SymbolKey::Class(class_key) = *evaluation_search_sym {
                                         if let Some(model_data) = session.st()[class_key]._model.as_ref() {
                                             if model_data.name == constant.value.to_str() {
-                                                let file = session.st().get_file(parent).unwrap();
-                                                let file_path = session.st().path(file);
-                                                let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(file_path);
-                                                if let Some(file_info) = file_info {
-                                                    let transformed_range = file_info.borrow().text_range_to_range(&constant.range, session.sync_odoo.encoding);
-                                                    let uri = FileMgr::pathname2uri(file_path);
-                                                    session.sync_odoo.evaluation_locations.push(Location {
-                                                        uri: uri,
-                                                        range: transformed_range,
-                                                    });
-                                                }
+                                                record_evaluation_hit(session, parent, constant.range);
                                             }
                                         }
                                     }

--- a/server/src/core/model.rs
+++ b/server/src/core/model.rs
@@ -208,6 +208,13 @@ impl Model {
     }
 
     fn all_symbols_helper(&self, session: &SessionInfo, from_module: Option<ModuleKey>, with_inheritance: bool, seen_inherited_models: &mut HashSet<OYarn>) -> Vec<(ClassKey, Option<OYarn>)> {
+        // Inheriting classes carry the current model in their own `_inherit`,
+        // so a naive recursion would re-walk this model's classes for every
+        // such class. Mark self as visited up front (mirrors all_inherits_helper).
+        if seen_inherited_models.contains(&self.name) {
+            return Vec::new();
+        }
+        seen_inherited_models.insert(self.name.clone());
         let st = &session.sync_odoo.symbol_table;
         let mut symbols = Vec::new();
         for s in self.symbols.iter_valid(st) { // filter stale keys

--- a/server/tests/data/addons/module_1/models/base_test_models.py
+++ b/server/tests/data/addons/module_1/models/base_test_models.py
@@ -62,3 +62,8 @@ dict_ref = {1: basic_var}
 call_ref = print(basic_var)
 binop_ref = basic_var + 1
 lambda_scope = lambda basic_var: basic_var
+
+def annotated_param_func(field_names: list | None = None) -> None:
+    if field_names is None or 'a' in field_names or 'b' in field_names:
+        return
+    return field_names

--- a/server/tests/test_references.rs
+++ b/server/tests/test_references.rs
@@ -22,6 +22,7 @@ fn test_references() {
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 3, 0);
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 4, 12);
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 15, 8);
+    assert_in_result(&mut references, "module_1/models/base_test_models.py", 32, 8);  // self in self.env[...]
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 32, 17);
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 33, 8);
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 34, 18);
@@ -78,6 +79,20 @@ fn test_references() {
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 61, 17);
     // usage as left-hand side of a binary operation
     assert_in_result(&mut references, "module_1/models/base_test_models.py", 62, 12);
+    assert!(references.len() == 0, "Some references were not expected: {}",
+        references.iter().map(|r| format!("{}:{}:{}", r.uri.as_str(), r.range.start.line + 1, r.range.start.character + 1)).collect::<Vec<String>>().join(", ")
+    );
+
+    //reference of a function parameter, exercising multiple uses of the same name on a single line
+    let mut references = get_references(&mut session, &test_file, Position::new(65, 28));
+    // parameter declaration
+    assert_in_result(&mut references, "module_1/models/base_test_models.py", 65, 25);
+    // three same-line usages inside the `if` test
+    assert_in_result(&mut references, "module_1/models/base_test_models.py", 66, 7);
+    assert_in_result(&mut references, "module_1/models/base_test_models.py", 66, 37);
+    assert_in_result(&mut references, "module_1/models/base_test_models.py", 66, 59);
+    // usage in the return statement
+    assert_in_result(&mut references, "module_1/models/base_test_models.py", 68, 11);
     assert!(references.len() == 0, "Some references were not expected: {}",
         references.iter().map(|r| format!("{}:{}:{}", r.uri.as_str(), r.range.start.line + 1, r.range.start.character + 1)).collect::<Vec<String>>().join(", ")
     );


### PR DESCRIPTION
Two small walker bugs in the language server, both surfacing as duplicated or missed results in references / goto-def / hover.

- **References dedup by start position** (6f88cd5): the visitor deduped each new hit against the previous entry *by line*, collapsing multiple same-line uses (e.g. `if x is None or 'a' in x or 'b' in x` kept only the first `x`). The line-based dedup also masked a separate issue: nested expressions record at the same start position from different recursion depths. Switch to `(uri, range.start)` over the full list. Innermost is analyzed first, so the most specific token wins. `test_references` gains one expected entry (find-refs on the model now records `self` in `self.env[...]`).

- **Stop `Model::all_symbols` from re-walking self** (5367c5e): `all_symbols_helper` tracked visited *inherited* models but never marked the current model. Inheriting classes carry the current model in their own `_inherit`, so the recursion re-entered self once per inheriting class, doubling every entry. Symptoms: two LocationLinks from goto-def on `<field name="X"/>`, doc string rendered twice on hover, validation walking every class N+1 times. Mirror the self-visited check `all_inherits_helper` already had.