### PR TITLE
[IMP] enable XML hover for non-Class and XML data symbols

### DIFF
--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -528,6 +528,11 @@ impl FeaturesUtils {
                 }
                 continue;
             };
+            // XML data symbols have no Symbol.name() and don't fit the aggregator below.
+            if let Some(block) = FeaturesUtils::xml_data_hover_block(session, symbol) {
+                blocks.push(block);
+                continue;
+            }
             let context = &eval_symbol.get_weak().context;
             let evaluation_ptrs = SymbolTable::follow_ref(&eval_symbol, session, Some(context), false, false, None, None);
 
@@ -558,6 +563,46 @@ impl FeaturesUtils {
             blocks.push(block);
         }
         blocks.iter().join("  \n***  \n")
+    }
+
+    fn xml_data_hover_block(session: &mut SessionInfo, symbol: SymbolKey) -> Option<String> {
+        let (kind, label, model): (&str, String, Option<String>) = match symbol {
+            SymbolKey::XmlRecord(k) => {
+                let r = &session.st()[k];
+                ("xml record", r.xml_id.as_ref()?.to_string(), Some(r.model.0.to_string()))
+            }
+            SymbolKey::XmlTemplate(k) => {
+                ("xml template", session.st()[k].xml_id.as_ref()?.to_string(), None)
+            }
+            SymbolKey::XmlMenuItem(k) => {
+                ("xml menuitem", session.st()[k].xml_id.as_ref()?.to_string(), None)
+            }
+            SymbolKey::XmlAsset(k) => {
+                ("xml asset", session.st()[k].xml_id.as_ref()?.to_string(), None)
+            }
+            SymbolKey::XmlDelete(k) => {
+                let d = &session.st()[k];
+                ("xml delete", d.xml_id.as_ref()?.to_string(), Some(d.model.to_string()))
+            }
+            SymbolKey::XmlField(k) => {
+                ("xml field", session.st()[k].field_name.to_string(), None)
+            }
+            _ => return None,
+        };
+        let module = session.st().find_module(symbol)
+            .map(|m| session.st()[m].dir_name.to_string());
+        let qualified = match (&module, matches!(symbol, SymbolKey::XmlField(_))) {
+            (Some(m), false) => format!("{}.{}", m, label),
+            _ => label,
+        };
+        let mut block = format!("({}) **{}**", kind, qualified);
+        if let Some(model) = model {
+            block += &format!("  \nModel: `{}`", model);
+        }
+        if let Some(module) = module {
+            block += &format!("  \nDefined in: `{}`", module);
+        }
+        Some(block)
     }
 
     fn get_type_symbol_tag(symbol_table: &SymbolTable, symbol_key: SymbolKey) -> String {

--- a/server/src/features/hover.rs
+++ b/server/src/features/hover.rs
@@ -1,7 +1,7 @@
 use lsp_types::{Hover, HoverContents, MarkupContent};
 use crate::core::evaluation::Evaluation;
 use crate::core::file_mgr::FileInfo;
-use crate::core::symbols::symbol_keys::{SourceFileKey, SymbolKey};
+use crate::core::symbols::symbol_keys::SourceFileKey;
 use crate::features::xml_ast_utils::XmlAstUtils;
 use crate::threads::SessionInfo;
 use std::rc::Rc;
@@ -43,7 +43,7 @@ impl HoverFeature {
             let root = document.root_element();
             let (symbols, range) = XmlAstUtils::get_symbols(session, file_symbol, root, offset, true);
             let range = range.map(|r| file_info.borrow().std_range_to_range(&r, session.sync_odoo.encoding));
-            let evals = symbols.iter().filter(|s| matches!(s, SymbolKey::Class(_)))
+            let evals = symbols.iter()
                 .map(|s| Evaluation::eval_from_symbol(session.st(), *s, Some(false))).collect::<Vec<Evaluation>>();
             return Some(Hover { contents:
                 HoverContents::Markup(MarkupContent {

--- a/server/tests/test_get_symbol.rs
+++ b/server/tests/test_get_symbol.rs
@@ -161,6 +161,48 @@ fn test_hover_on_model_field_and_method() {
 }
 
 #[test]
+fn test_hover_on_xml_symbols() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let test_addons_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("data").join("addons");
+    let bikes_xml = test_addons_path.join("module_for_diagnostics").join("data").join("bikes.xml").sanitize();
+    assert!(PathBuf::from(&bikes_xml).exists(), "Test file does not exist: {}", bikes_xml);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&bikes_xml).unwrap();
+    let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(
+        &mut session,
+        &PathBuf::from(&bikes_xml),
+    ) else {
+        panic!("Failed to get file symbol for bikes.xml");
+    };
+
+    // <record id="bike_wheel_1" model="bike_parts.wheel"> - XmlRecord hover via the new data path
+    let hover_record = test_utils::get_hover_xml_markdown(&mut session, file_symbol, &file_info, 2, 18).unwrap_or_default();
+    assert!(
+        hover_record.contains("xml record") && hover_record.contains("bike_wheel_1") && hover_record.contains("bike_parts.wheel"),
+        "Hover on <record id=...> should describe kind, id, and model. Got: {}",
+        hover_record
+    );
+
+    // <field name="name">Standard Wheel</field> - non-Class symbol (Variable) now renders instead of empty
+    let hover_field = test_utils::get_hover_xml_markdown(&mut session, file_symbol, &file_info, 3, 22).unwrap_or_default();
+    assert!(
+        hover_field.contains("name"),
+        "Hover on <field name=\"name\"> should mention the field. Got: {}",
+        hover_field
+    );
+
+    // ref="bike_wheel_1" - should resolve to the XmlRecord via the data symbol path
+    let hover_ref = test_utils::get_hover_xml_markdown(&mut session, file_symbol, &file_info, 17, 40).unwrap_or_default();
+    assert!(
+        hover_ref.contains("xml record") && hover_ref.contains("bike_wheel_1"),
+        "Hover on ref=\"bike_wheel_1\" should resolve to the XmlRecord. Got: {}",
+        hover_ref
+    );
+}
+
+#[test]
 fn test_hover_inverse_name_o2m(){
     // Setup server and session with test addons
     let (mut odoo, config) = setup::setup::setup_server(true);

--- a/server/tests/test_utils.rs
+++ b/server/tests/test_utils.rs
@@ -53,6 +53,22 @@ pub fn get_hover_markdown(session: &mut SessionInfo, file_symbol: SourceFileKey,
     })
 }
 
+/// Helper to get hover markdown string for an XML file at a given (line, character)
+pub fn get_hover_xml_markdown(session: &mut SessionInfo, file_symbol: SourceFileKey, file_info: &Rc<RefCell<FileInfo>>, line: u32, character: u32) -> Option<String> {
+    let hover = odoo_ls_server::features::hover::HoverFeature::hover_xml(
+        session,
+        file_symbol,
+        file_info,
+        line,
+        character,
+    );
+    hover.and_then(|h| match h.contents {
+        lsp_types::HoverContents::Markup(m) => Some(m.value),
+        lsp_types::HoverContents::Scalar(lsp_types::MarkedString::String(s)) => Some(s),
+        _ => None,
+    })
+}
+
 /// Helper to get hover markdown string at a given (line, character)
 pub fn get_definition_locs(session: &mut SessionInfo, f_sym: SourceFileKey, f_info: &Rc<RefCell<FileInfo>>, line: u32, character: u32) -> Vec<lsp_types::LocationLink> {
     let locations = odoo_ls_server::features::definition::DefinitionFeature::get_location(


### PR DESCRIPTION
`hover_xml` filtered the resolved cursor symbols down to `SymbolKey::Class` before rendering, leaving every other XML cursor target (field declarations, xml-id refs, method names) with empty hover. The Python hover already passes everything through `build_markdown_description` for Variables and Functions; dropping the Class-only filter gets those for free.

XML data symbols (`XmlRecord`, `XmlField`, `XmlMenuItem`, `XmlTemplate`, `XmlAsset`, `XmlDelete`) have no `Symbol.name()` and don't fit the existing aggregator, so they get a dedicated rendering path showing the kind, qualified xml-id, declaring module, and model where applicable.

Hovering on `<record id=...>`, `<field name=...>`, `<menuitem id=...>` etc. now produces something useful instead of empty content.