### PR TITLE
[PERF] quick wins

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,6 +46,8 @@ rustc-hash = "2.1"
 # ittapi = "0.3" # profiling with VTune profiler
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 nix = { version = "0.29.0", features = ["process"] }
+tikv-jemallocator = "0.6"
+tikv-jemalloc-ctl = "0.6"
 
 [[bench]]
 name = "gungraun_bench"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -58,3 +58,11 @@ assert_fs = "1.1"
 [features]
 default = []
 debug_yarn = []  # use a readable structure instead of Yarn for debug purpose
+
+[profile.profiling]
+inherits = "release"
+debug = true
+
+[profile.release]
+codegen-units = 1
+lto = "thin"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -42,6 +42,7 @@ toml = "0.9.12"
 schemars = "1.2.1"
 csv = "1.4.0"
 slotmap = "1.1.1"
+rustc-hash = "2.1"
 # ittapi = "0.3" # profiling with VTune profiler
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 nix = { version = "0.29.0", features = ["process"] }

--- a/server/src/cli_backend.rs
+++ b/server/src/cli_backend.rs
@@ -11,7 +11,7 @@ use crate::core::odoo::SyncOdoo;
 use crate::threads::SessionInfo;
 use crate::utils::{PathSanitizer, is_addon_path, is_odoo_path, is_python_path};
 use serde_json::json;
-use std::collections::HashMap;
+use crate::utils::HashMap;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;

--- a/server/src/core/config.rs
+++ b/server/src/core/config.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::{Expr, Mod};
 use ruff_python_parser::{Mode, ParseOptions};
 use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::{HashMap, HashSet};
+use crate::utils::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::path::PathBuf;
@@ -369,7 +369,7 @@ impl<T: Default> Default for Sourced<T> {
     fn default() -> Self {
         Sourced {
             value: T::default(),
-            sources: HashSet::from([S!("$default")]),
+            sources: HashSet::from_iter([S!("$default")]),
             info: String::new(),
         }
     }
@@ -381,7 +381,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Sourced<T> {
         let value = T::deserialize(deserializer)?;
         Ok(Sourced {
             value,
-            sources: HashSet::new(),
+            sources: HashSet::default(),
             info: String::new(),
         })
     }
@@ -531,7 +531,7 @@ fn process_version(
         unreachable!("Expected at least one source for sourced_path: {:?}", var);
     };
     let config_dir = config_path.parent().map(PathBuf::from).unwrap_or_else(|| PathBuf::from("."));
-    match fill_validate_path(unique_ws_folders, current_ws, var.value(), |p| PathBuf::from(p).exists(), HashMap::new(), &config_dir) {
+    match fill_validate_path(unique_ws_folders, current_ws, var.value(), |p| PathBuf::from(p).exists(), HashMap::default(), &config_dir) {
         Ok(filled_path) => {
             let var_pb = PathBuf::from(&filled_path);
             if var_pb.is_file() {
@@ -755,10 +755,10 @@ impl Default for ConfigEntry {
         Self {
             name: DEFAULT_PROFILE_NAME.to_string(),
             odoo_path: None,
-            addons_paths: HashSet::new(),
+            addons_paths: HashSet::default(),
             python_path: S!(get_python_command().unwrap_or_default()),
-            additional_stubs: HashSet::new(),
-            additional_languages: HashSet::new(),
+            additional_stubs: HashSet::default(),
+            additional_languages: HashSet::default(),
             file_cache: true,
             diag_missing_imports: DiagMissingImportsMode::default(),
             ac_filter_model_names: true,
@@ -828,7 +828,7 @@ fn process_paths(
     unique_ws_folders: &HashMap<String, String>,
     current_ws: Option<&(String, String)>,
 ){
-    let mut var_map: HashMap<String, String> = HashMap::new();
+    let mut var_map: HashMap<String, String> = HashMap::default();
     if let Some(v) = entry.version.clone() {
         var_map.insert(S!("version"), v.value().clone());
     }
@@ -858,7 +858,7 @@ fn process_paths(
         if let Some((name, workspace_path)) = current_ws {
             let workspace_path = PathBuf::from(workspace_path).sanitize();
             if is_addon_path(&workspace_path) {
-                let addon_path = Sourced { value: workspace_path.clone(), sources: HashSet::from([S!(format!("$workspaceFolder:{name}"))]), ..Default::default()};
+                let addon_path = Sourced { value: workspace_path.clone(), sources: HashSet::from_iter([S!(format!("$workspaceFolder:{name}"))]), ..Default::default()};
                 match entry.addons_paths {
                     Some(ref mut paths) => paths.push(addon_path),
                     None => entry.addons_paths = Some(vec![addon_path]),
@@ -1094,7 +1094,7 @@ fn apply_extends(
     let mut nodes: HashMap<String, Node> = keys.iter().map(|key|
         (key.clone(), Node {
             parent: None,
-            children: HashSet::new(),
+            children: HashSet::default(),
         })
     ).collect();
     let edges: Vec<(String, String)> = keys.iter().filter_map(|key| {
@@ -1112,7 +1112,7 @@ fn apply_extends(
     }
 
     let mut ordered_nodes= vec![];
-    let mut visited = HashSet::new();
+    let mut visited = HashSet::default();
     for parent in nodes.iter().filter(|(_, n)| n.parent.is_none()){
         let mut stack = vec![parent.0.clone()];
         while let Some(current) = stack.pop().map(|value| {ordered_nodes.push(value.clone()); value}) {
@@ -1147,9 +1147,9 @@ fn merge_configs(
     child: &HashMap<String, ConfigEntryRaw>,
     parent: &HashMap<String, ConfigEntryRaw>,
 ) -> HashMap<String, ConfigEntryRaw> {
-    let mut merged = HashMap::new();
+    let mut merged = HashMap::default();
 
-    let keys: std::collections::HashSet<_> = child.keys()
+    let keys: HashSet<_> = child.keys()
         .chain(parent.keys())
         .cloned()
         .collect();
@@ -1186,8 +1186,8 @@ fn load_config_from_workspace(
 ) -> Result<HashMap<String, ConfigEntryRaw>, String> {
     let ws_path_pb = PathBuf::from(&current_ws.1);
     let mut current_dir = ws_path_pb.clone();
-    let mut visited_dirs = HashSet::new();
-    let mut merged_config: HashMap<String, ConfigEntryRaw> = HashMap::new();
+    let mut visited_dirs = HashSet::default();
+    let mut merged_config: HashMap<String, ConfigEntryRaw> = HashMap::default();
     merged_config.insert(DEFAULT_PROFILE_NAME.to_string(), ConfigEntryRaw::new());
 
     loop {
@@ -1256,7 +1256,7 @@ fn load_config_from_workspace(
                 unique_ws_folders,
                 Some(current_ws),
                 &|p| PathBuf::from(p).is_dir(),
-                HashMap::new(),
+                HashMap::default(),
             ){
                 Ok(parent_dir) => parent_dir,
                 Err(err) => {
@@ -1325,7 +1325,7 @@ fn merge_all_workspaces(
     unique_ws_folders: &HashMap<String, String>,
     workspace_configs: Vec<HashMap<String, ConfigEntryRaw>>,
 ) -> Result<(ConfigNew, ConfigFile), String> {
-    let mut merged_raw_config: HashMap<String, ConfigEntryRaw> = HashMap::new();
+    let mut merged_raw_config: HashMap<String, ConfigEntryRaw> = HashMap::default();
 
     for workspace_config in workspace_configs {
         for (key, raw_entry) in workspace_config {
@@ -1426,7 +1426,7 @@ fn merge_all_workspaces(
                             S!("More than one workspace folder is a valid odoo_path\nPlease set the odoo_path in the config file.")
                         );
                     }
-                    entry.odoo_path = Some(Sourced { value: path.clone(), sources: HashSet::from([S!(format!("$workspaceFolder:{name}"))]), ..Default::default()});
+                    entry.odoo_path = Some(Sourced { value: path.clone(), sources: HashSet::from_iter([S!(format!("$workspaceFolder:{name}"))]), ..Default::default()});
                 }
             }
         }
@@ -1435,7 +1435,7 @@ fn merge_all_workspaces(
     let config_file = ConfigFile { config: merged_raw_config.values().cloned().collect::<Vec<_>>()};
 
     // Convert the merged ConfigEntryRaw structure into ConfigEntry
-    let mut final_config: ConfigNew = HashMap::new();
+    let mut final_config: ConfigNew = HashMap::default();
     for (key, raw_entry) in merged_raw_config {
         final_config.insert(
             key.clone(),

--- a/server/src/core/diagnostics.rs
+++ b/server/src/core/diagnostics.rs
@@ -51,7 +51,7 @@ macro_rules! diagnostic_codes {
             }
         }
 
-        pub static DIAGNOSTIC_INFOS: once_cell::sync::Lazy<std::collections::HashMap<DiagnosticCode, DiagnosticInfo>> = once_cell::sync::Lazy::new(|| std::collections::HashMap::from([
+        pub static DIAGNOSTIC_INFOS: once_cell::sync::Lazy<crate::utils::HashMap<DiagnosticCode, DiagnosticInfo>> = once_cell::sync::Lazy::new(|| crate::utils::HashMap::from_iter([
             $( (DiagnosticCode::$name, DiagnosticInfo { default_setting: $default_setting, template: $msg }), )*
         ]));
     }

--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -1,4 +1,5 @@
-use std::{cell::RefCell, cmp, collections::HashMap, path::PathBuf, rc::Rc, u32};
+use std::{cell::RefCell, cmp, path::PathBuf, rc::Rc, u32};
+use crate::utils::HashMap;
 
 use slotmap::Key;
 use tracing::{error, info, warn};
@@ -396,7 +397,7 @@ impl EntryPoint {
             not_found_symbols_for_models: WeakSet::new(),
             root: RootKey::null(), // set below
             to_delete: false,
-            data_symbols: HashMap::new(),
+            data_symbols: HashMap::default(),
         }));
         let root = symbol_table.new_root(entry.clone());
         entry.borrow_mut().root = root;
@@ -421,7 +422,7 @@ impl EntryPoint {
             not_found_symbols_for_models: WeakSet::new(),
             root,
             to_delete: false,
-            data_symbols: HashMap::new(),
+            data_symbols: HashMap::default(),
         }))
     }
 

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -5,7 +5,7 @@ use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::{FunctionSymbol, VariableSymbol};
 use crate::features::references::ReferenceTarget;
 use crate::threads::SessionInfo;
-use crate::utils::{NoHashBuilder, compare_semver};
+use crate::utils::compare_semver;
 use crate::S;
 use crate::{constants::*, Sy};
 use itertools::FoldWhile::{Continue, Done};
@@ -474,7 +474,7 @@ impl Evaluation {
     /// else:
     ///     i="test"
     /// It will return two evaluation for i, one with 5 and one for "test"
-    pub fn from_sections(symbol_table: &SymbolTable, parent_key: SymbolKey, sections: &std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>) -> Vec<Evaluation> {
+    pub fn from_sections(symbol_table: &SymbolTable, parent_key: SymbolKey, sections: &HashMap<u32, Vec<SymbolKey>>) -> Vec<Evaluation> {
         let parent_sym_mgr = symbol_table.as_symbol_mgr(parent_key);
         let mut res = vec![];
         let section = parent_sym_mgr.get_section_for(u32::MAX);

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -16,7 +16,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use std::cmp::{Ordering, max, min};
-use std::collections::{HashMap, HashSet};
+use crate::utils::{HashMap, HashSet};
 use std::i32;
 
 use super::file_mgr::FileMgr;
@@ -214,7 +214,7 @@ impl EvaluationSymbolWeak {
     pub fn new(key: impl Into<Wk<SymbolKey>>, instance: Option<bool>, is_super: bool) -> Self {
         EvaluationSymbolWeak {
             weak: key.into(),
-            context: HashMap::new(),
+            context: HashMap::default(),
             instance,
             is_super
         }
@@ -263,7 +263,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_list(),
-                    context: HashMap::new(),
+                    context: HashMap::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -279,7 +279,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_tuple(),
-                    context: HashMap::new(),
+                    context: HashMap::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -295,7 +295,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_dict(),
-                    context: HashMap::new(),
+                    context: HashMap::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -311,7 +311,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_set(),
-                    context: HashMap::new(),
+                    context: HashMap::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -368,7 +368,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak {
                     weak: symbol,
-                    context: HashMap::new(),
+                    context: HashMap::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -474,11 +474,11 @@ impl Evaluation {
     /// else:
     ///     i="test"
     /// It will return two evaluation for i, one with 5 and one for "test"
-    pub fn from_sections(symbol_table: &SymbolTable, parent_key: SymbolKey, sections: &HashMap<u32, Vec<SymbolKey>, NoHashBuilder>) -> Vec<Evaluation> {
+    pub fn from_sections(symbol_table: &SymbolTable, parent_key: SymbolKey, sections: &std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>) -> Vec<Evaluation> {
         let parent_sym_mgr = symbol_table.as_symbol_mgr(parent_key);
         let mut res = vec![];
         let section = parent_sym_mgr.get_section_for(u32::MAX);
-        let content_symbols = symbol_table.get_loc_symbol(parent_sym_mgr, sections, u32::MAX, &SectionIndex::INDEX(section.index), &mut HashSet::new());
+        let content_symbols = symbol_table.get_loc_symbol(parent_sym_mgr, sections, u32::MAX, &SectionIndex::INDEX(section.index), &mut HashSet::default());
         for sym_key in content_symbols.symbols {
             let mut is_instance = None;
             let sym_type = sym_key.typ();
@@ -513,7 +513,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: symbol,
-                    context: HashMap::new(),
+                    context: HashMap::default(),
                     instance: instance,
                     is_super: false,
                 }),
@@ -551,7 +551,7 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from([
+        let mut context: Option<Context> = Some(HashMap::from_iter([
             (S!("module"), from_module),
             (S!("range"), ContextValue::RANGE(ast.range()))
         ]));
@@ -567,7 +567,7 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from([
+        let mut context: Option<Context> = Some(HashMap::from_iter([
             (S!("module"), from_module),
             (S!("range"), ContextValue::RANGE(ast.range()))
         ]));
@@ -600,7 +600,7 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from([
+        let mut context: Option<Context> = Some(HashMap::from_iter([
             (S!("module"), from_module),
             (S!("range"), ContextValue::RANGE(ast.range()))
         ]));
@@ -916,7 +916,7 @@ impl Evaluation {
                                         symbol: EvaluationSymbol {
                                             sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{
                                                 weak: super_class,
-                                                context: HashMap::new(),
+                                                context: HashMap::default(),
                                                 instance,
                                                 is_super: true,
                                             }),
@@ -983,7 +983,7 @@ impl Evaluation {
                                         symbol: EvaluationSymbol {
                                             sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak {
                                                 weak: base_sym_weak_eval.weak,
-                                                context: HashMap::new(),
+                                                context: HashMap::default(),
                                                 instance: Some(true),
                                                 is_super: false,
                                             }),
@@ -1266,7 +1266,7 @@ impl Evaluation {
                                 // For example for models, since you get the same type of recordset when subscripted
                                 evals.push(Evaluation{
                                     symbol: EvaluationSymbol {
-                                        sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: base.into(), context: HashMap::new(), instance: Some(true), is_super: false}),
+                                        sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: base.into(), context: HashMap::default(), instance: Some(true), is_super: false}),
                                         get_symbol_hook: None,
                                     },
                                     value: None,
@@ -1305,7 +1305,7 @@ impl Evaluation {
                             symbol: EvaluationSymbol {
                                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                                     weak: odoo.get_ts_boolean(),
-                                    context: HashMap::new(),
+                                    context: HashMap::default(),
                                     instance: Some(true),
                                     is_super: false,
                                 }),
@@ -1355,7 +1355,7 @@ impl Evaluation {
                         symbol: EvaluationSymbol {
                             sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                                 weak: odoo.get_ts_string(),
-                                context: HashMap::new(),
+                                context: HashMap::default(),
                                 instance: Some(true),
                                 is_super: false,
                             }),
@@ -1618,7 +1618,7 @@ impl Evaluation {
         //validate pos args first
         let mut arg_index = 0;
         let mut number_pos_arg = 0;
-        let mut pos_only_args = HashSet::new();
+        let mut pos_only_args = HashSet::default();
         let mut kword_only_args = Vec::new();
         let mut vararg_index = i32::MAX;
         let mut kwarg_index = i32::MAX;
@@ -2040,7 +2040,7 @@ impl EvaluationSymbol {
 
     pub fn new_self(get_symbol_hook: Option<GetSymbolHook>, base: Wk<SymbolKey>, instance: Option<bool>) -> EvaluationSymbol {
         Self {
-            sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{weak: base, context: HashMap::new(), instance, is_super: false}),
+            sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{weak: base, context: HashMap::default(), instance, is_super: false}),
             get_symbol_hook,
         }
     }
@@ -2081,14 +2081,14 @@ impl EvaluationSymbol {
             | EvaluationSymbolPtr::ARG(_)
             | EvaluationSymbolPtr::NONE
             | EvaluationSymbolPtr::UNBOUND(_)
-            | EvaluationSymbolPtr::DOMAIN => EvaluationSymbolWeak{ weak: Wk::null(), context: HashMap::new(), instance: Some(false), is_super: false },
+            | EvaluationSymbolPtr::DOMAIN => EvaluationSymbolWeak{ weak: Wk::null(), context: HashMap::default(), instance: Some(false), is_super: false },
             EvaluationSymbolPtr::SELF(_) => {
                 let class = context.as_ref().
                 and_then(|context| context.get("parent_for").or(context.get("base_attr")))
                 .unwrap_or(&ContextValue::BOOLEAN(false));
                 match class {
-                    ContextValue::SYMBOL(s) => EvaluationSymbolWeak{weak: *s, context: HashMap::new(), instance: Some(true), is_super: false},
-                    _ => EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::new(), instance: Some(false), is_super: false}
+                    ContextValue::SYMBOL(s) => EvaluationSymbolWeak{weak: *s, context: HashMap::default(), instance: Some(true), is_super: false},
+                    _ => EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::default(), instance: Some(false), is_super: false}
                 }
             }
         }
@@ -2107,7 +2107,7 @@ impl EvaluationSymbol {
             EvaluationSymbolPtr::UNBOUND(_) => eval,
             EvaluationSymbolPtr::DOMAIN => eval,
             EvaluationSymbolPtr::SELF(_) => {
-                let default = EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::new(), instance: Some(false), is_super: false});
+                let default = EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::default(), instance: Some(false), is_super: false});
                 let class = context.as_ref().and_then(|context| context.get("base_call")).unwrap_or(&ContextValue::BOOLEAN(false));
                 let class_sym = match class {
                     ContextValue::SYMBOL(s) => match s.upgrade(&session.sync_odoo.symbol_table) {
@@ -2116,7 +2116,7 @@ impl EvaluationSymbol {
                     },
                     _ => {return default;}
                 };
-                let eval_symbol_weak = EvaluationSymbolWeak{weak: class_sym.into(), context: HashMap::new(), instance: Some(true), is_super: false};
+                let eval_symbol_weak = EvaluationSymbolWeak{weak: class_sym.into(), context: HashMap::default(), instance: Some(true), is_super: false};
                 let base_is_self = context
                     .as_ref()
                     .and_then(|context| context.get("base_is_self"))

--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -5,12 +5,13 @@ use lsp_types::notification::{Notification, PublishDiagnostics};
 use ruff_source_file::{OneIndexed, PositionEncoding, SourceLocation};
 use tracing::{error, warn};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashSet;
+use crate::utils::HashSet;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{atomic::{AtomicBool, Ordering}, Arc, OnceLock};
-use std::{collections::HashMap, fs};
+use std::{fs};
+use crate::utils::HashMap;
 use crate::core::config::{DiagnosticFilter, DiagnosticFilterPathType};
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode, DiagnosticSetting};
 use crate::core::text_document::TextDocument;
@@ -40,7 +41,7 @@ pub enum NoqaInfo {
 }
 
 pub fn combine_noqa_info(noqas: &[NoqaInfo]) -> NoqaInfo {
-    let mut codes = HashSet::new();
+    let mut codes = HashSet::default();
     for noqa in noqas.iter() {
         match noqa {
             NoqaInfo::None => {},
@@ -108,9 +109,9 @@ impl FileInfo {
                 indexed_module: None,
                 ast_type: AstType::Python,
             })),
-            diagnostics: HashMap::new(),
-            noqas_blocs: HashMap::new(),
-            noqas_lines: HashMap::new(),
+            diagnostics: HashMap::default(),
+            noqas_blocs: HashMap::default(),
+            noqas_lines: HashMap::default(),
             diagnostic_filters: Vec::new(),
             diag_test_comments: vec![],
         }
@@ -485,9 +486,9 @@ impl FileMgr {
 
     pub fn new() -> Self {
         Self {
-            files: HashMap::new(),
-            untitled_files: HashMap::new(),
-            workspace_folders: HashSet::new(),
+            files: HashMap::default(),
+            untitled_files: HashMap::default(),
+            workspace_folders: HashSet::default(),
         }
     }
 
@@ -680,8 +681,8 @@ impl FileMgr {
     /// Get a map of workspace folder name to sanitized path string
     /// of only unique workspace names, repeated names are skipped
     pub fn get_unique_workspace_folders(&self) -> HashMap<String, String> {
-        let mut visited_names= HashSet::new();
-        let mut unique_folders = HashMap::new();
+        let mut visited_names= HashSet::default();
+        let mut unique_folders = HashMap::default();
         for (name, uri) in self.workspace_folders.iter() {
             if visited_names.insert(name.clone()) {
                 unique_folders.insert(name.clone(), FileMgr::uri2pathname(uri.as_str()));

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -2,7 +2,7 @@ use glob::glob;
 use lsp_types::{Diagnostic, DiagnosticTag, Position, Range};
 use ruff_python_ast::name::Name;
 use tracing::error;
-use std::collections::HashMap;
+use crate::utils::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
@@ -496,7 +496,7 @@ pub fn get_all_valid_names(session: &mut SessionInfo, source_file_symbol: Source
     let entry = session.st().get_entry(source_file_symbol);
     let (mut from_symbol, _fallback_sym, file_tree) = resolve_from_stmt(session, source_file_symbol.into(), identifier_from.as_ref(), level);
     let source_path = session.st().path(source_file_symbol).to_string();
-    let mut result = HashMap::new();
+    let mut result = HashMap::default();
     let mut symbols_to_browse = vec![];
     if from_symbol.is_none() {
         if !file_tree.is_empty() { //symbol was not found
@@ -558,7 +558,7 @@ pub fn get_all_valid_names(session: &mut SessionInfo, source_file_symbol: Source
 }
 
 fn valid_names_for_a_symbol(symbol_table: &SymbolTable, symbol: SymbolKey, start_filter: &str, only_on_disk: bool) -> HashMap<OYarn, SymType> {
-    let mut res = HashMap::new();
+    let mut res = HashMap::default();
     match symbol {
         SymbolKey::File(_) => {
             if only_on_disk {
@@ -590,7 +590,7 @@ fn valid_names_for_a_symbol(symbol_table: &SymbolTable, symbol: SymbolKey, start
 }
 
 fn valid_name_from_disk(path: &String, start_filter: &str) -> HashMap<OYarn, SymType> {
-    let mut res = HashMap::new();
+    let mut res = HashMap::default();
     if is_dir_cs(path.clone()) {
         if let Ok(entries) = std::fs::read_dir(path) {
             for entry in entries {
@@ -627,7 +627,7 @@ fn valid_name_from_disk(path: &String, start_filter: &str) -> HashMap<OYarn, Sym
 }
 
 fn valid_name_from_symbol(symbol_table: &SymbolTable, symbol: SymbolKey, start_filter: &str) -> HashMap<OYarn, SymType> {
-    let mut res = HashMap::new();
+    let mut res = HashMap::default();
     for s in symbol_table.iter_symbols(symbol) {
         if s.0.starts_with(start_filter) {
             let mut typ = SymType::VARIABLE;

--- a/server/src/core/model.rs
+++ b/server/src/core/model.rs
@@ -1,7 +1,7 @@
 use lsp_types::MessageType;
 use std::cell::RefCell;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use crate::utils::HashMap;
+use crate::utils::HashSet;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
@@ -62,7 +62,7 @@ impl ModelData {
             parent_store: false,
             data_name: String::from("date"),
             fold_name: String::from("fold"),
-            computes: HashMap::new(),
+            computes: HashMap::default(),
         }
     }
 }
@@ -151,8 +151,8 @@ impl Model {
 
     pub fn get_full_model_symbols(model_rc: Rc<RefCell<Model>>, session: &SessionInfo, from_module: ModuleKey) -> HashSet<ClassKey> {
         let st = &session.sync_odoo.symbol_table;
-        let mut symbol_set  = HashSet::new();
-        let mut already_in = HashSet::new();
+        let mut symbol_set  = HashSet::default();
+        let mut already_in = HashSet::default();
         let mut queue = VecDeque::from([model_rc]);
         while let Some(current_model_rc) = queue.pop_front() {
             let current_model = current_model_rc.borrow();
@@ -176,7 +176,7 @@ impl Model {
     pub fn get_inherits_models(&self, session: &mut SessionInfo, from_module: ModuleKey) -> Vec<Rc<RefCell<Model>>> {
         let st = &session.sync_odoo.symbol_table;
         let mut res = vec![];
-        let mut already_in = HashSet::new();
+        let mut already_in = HashSet::default();
         let symbols = self.get_symbols(st, Some(from_module));
         for symbol_key in symbols {
             let Some(model_data) = &st[symbol_key]._model else {
@@ -204,7 +204,7 @@ impl Model {
         if with_inheritance is true, it will also return symbols from inherited models (NOT Base classes).
     */
     pub fn all_symbols(&self, session: &SessionInfo, from_module: Option<ModuleKey>, with_inheritance: bool) -> Vec<(ClassKey, Option<OYarn>)> {
-        self.all_symbols_helper(session, from_module, with_inheritance, &mut HashSet::new())
+        self.all_symbols_helper(session, from_module, with_inheritance, &mut HashSet::default())
     }
 
     fn all_symbols_helper(&self, session: &SessionInfo, from_module: Option<ModuleKey>, with_inheritance: bool, seen_inherited_models: &mut HashSet<OYarn>) -> Vec<(ClassKey, Option<OYarn>)> {
@@ -243,7 +243,7 @@ impl Model {
     }
 
     pub fn all_symbols_inherits(&self, session: &SessionInfo, from_module: Option<ModuleKey>) -> (Vec<(ClassKey, Option<OYarn>)>, Vec<(ClassKey, Option<OYarn>)>) {
-        let mut visited_models = HashSet::new();
+        let mut visited_models = HashSet::default();
         self.all_inherits_helper(session, from_module, &mut visited_models)
     }
 
@@ -332,6 +332,6 @@ impl Model {
             }
             false
         }
-        inner(self, session, base, &mut HashSet::new())
+        inner(self, session, base, &mut HashSet::default())
     }
 }

--- a/server/src/core/module_load_order.rs
+++ b/server/src/core/module_load_order.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 pub struct SortResult<'a> {
     pub sorted: Vec<&'a str>,
@@ -66,9 +66,9 @@ impl<'a> Graph<'a> {
     fn from(nodes: Vec<(&'a str, Vec<&'a str>)>) -> Self {
         let mut graph = Self {
             modules_to_dependencies: nodes.into_iter().collect(),
-            validation_cache: HashMap::new(),
-            depth_cache: HashMap::new(),
-            order_name_cache: HashMap::new(),
+            validation_cache: HashMap::default(),
+            depth_cache: HashMap::default(),
+            order_name_cache: HashMap::default(),
             errors: Vec::new(),
         };
         graph.add_base_dependency();

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -19,7 +19,7 @@ use crate::features::definition::DefinitionFeature;
 use crate::features::hover::HoverFeature;
 use crate::threads::SessionInfo;
 use crate::weak_collections::{WeakMap, WeakSet};
-use std::collections::HashMap;
+use crate::utils::HashMap;
 use std::cell::RefCell;
 use std::rc::{Rc};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -34,7 +34,7 @@ use ruff_source_file::PositionEncoding;
 use serde_json::Value;
 use tracing::{error, warn, info, trace};
 
-use std::collections::HashSet;
+use crate::utils::HashSet;
 use std::process::Command;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -174,8 +174,8 @@ impl SyncOdoo {
             file_mgr: Rc::new(RefCell::new(FileMgr::new())),
             stubs_dirs: SyncOdoo::default_stubs(),
             stdlib_dir: SyncOdoo::default_stdlib(),
-            modules: HashMap::new(),
-            models: HashMap::new(),
+            modules: HashMap::default(),
+            models: HashMap::default(),
             interrupt_rebuild: Arc::new(AtomicBool::new(false)),
             terminate_rebuild: Arc::new(AtomicBool::new(false)),
             current_request_id: None,
@@ -215,8 +215,8 @@ impl SyncOdoo {
         FileMgr::clear(session);//only reset files, as workspace folders didn't change
         session.sync_odoo.stubs_dirs = SyncOdoo::default_stubs();
         session.sync_odoo.stdlib_dir = SyncOdoo::default_stdlib();
-        session.sync_odoo.modules = HashMap::new();
-        session.sync_odoo.models = HashMap::new();
+        session.sync_odoo.modules = HashMap::default();
+        session.sync_odoo.models = HashMap::default();
         session.sync_odoo.rebuild_arch = FifoWeakHashSet::new();
         session.sync_odoo.rebuild_arch_eval = FifoWeakHashSet::new();
         session.sync_odoo.rebuild_validation = FifoWeakHashSet::new();
@@ -735,9 +735,9 @@ impl SyncOdoo {
             return false;
         }
         SyncOdoo::add_from_self_reload(session);
-        session.sync_odoo.import_cache = Some(ImportCache{ modules: HashMap::new(), main_modules: HashMap::new() });
-        let mut already_arch_rebuilt: HashSet<Tree> = HashSet::new();
-        let mut already_arch_eval_rebuilt: HashSet<Tree> = HashSet::new();
+        session.sync_odoo.import_cache = Some(ImportCache{ modules: HashMap::default(), main_modules: HashMap::default() });
+        let mut already_arch_rebuilt: HashSet<Tree> = HashSet::default();
+        let mut already_arch_eval_rebuilt: HashSet<Tree> = HashSet::default();
 
         //workdone progress
         let mut last_update_status = Instant::now() - Duration::from_secs(10);
@@ -902,7 +902,7 @@ impl SyncOdoo {
      */
     pub fn build_now(session: &mut SessionInfo, symbol: impl Into<SymbolKey>, step: BuildSteps) {
         // prevents dependency cycles
-        let mut visited = HashSet::new();
+        let mut visited = HashSet::default();
         Self::build_now_impl(session, symbol.into(), step, &mut visited)
     }
 

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use crate::utils::{HashMap, HashSet};
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::{u32, vec};
@@ -830,7 +830,7 @@ impl PythonArchEval {
                                 let eval_iter = evals[0].clone();
                                 if for_stmt.target.is_name_expr() { //only handle simple variable for now
                                     let variable = session.st().get_positioned_symbol(*self.sym_stack.last().unwrap(), &for_stmt.target.as_name_expr().unwrap().id, &for_stmt.target.range());
-                                    let symbol = eval_iter.symbol.get_symbol_as_weak(session, &mut Some(HashMap::from([(S!("parent_for"), ContextValue::SYMBOL(symbol_type.into()))])), &mut vec![], None);
+                                    let symbol = eval_iter.symbol.get_symbol_as_weak(session, &mut Some(HashMap::from_iter([(S!("parent_for"), ContextValue::SYMBOL(symbol_type.into()))])), &mut vec![], None);
                                     let v = variable.unwrap().unwrap_variable_key();
                                     session.st_mut()[v].evaluations = vec![Evaluation::eval_from_symbol(session.st(), symbol.weak, symbol.instance)];
                                 }

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use crate::utils::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
 use lsp_types::Diagnostic;
@@ -65,7 +65,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
             return;
         };
         let env = &mut odoo.symbol_table[symbol.unwrap_variable_key()];
-        let context = HashMap::new();
+        let context = HashMap::default();
         env.evaluations = vec![Evaluation {
             symbol: EvaluationSymbol::new_with_symbol(
                 env_class.into(),
@@ -161,7 +161,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 symbol: EvaluationSymbol::new_with_symbol(
                     (*registry_sym.last().unwrap()).into(),
                     Some(true),
-                    HashMap::new(),
+                    HashMap::default(),
                     None
                 ),
                 value: None,
@@ -511,7 +511,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
        odoo.symbol_table[symbol].evaluations = vec![Evaluation {
             symbol: EvaluationSymbol::new_with_symbol(Wk::null(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_get_item, name: S!("eval_env_get_item")})
             ),
             value: None,
@@ -526,7 +526,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
         odoo.symbol_table[symbol].evaluations = vec![Evaluation {
             symbol: EvaluationSymbol::new_with_symbol(Wk::null(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_registry_get_item, name: S!("eval_registry_get_item")})
             ),
             value: None,
@@ -689,7 +689,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
             symbol: EvaluationSymbol::new_with_symbol(
                 fields_class_sym.into(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_init, name: S!("eval_init")})
             ),
             value: None,
@@ -970,7 +970,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 return_sym.into(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: S!("eval_get")})
             ),
             value: None,
@@ -994,7 +994,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 return_sym.into(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: S!("eval_get")})
             ),
             value: None,
@@ -1021,7 +1021,7 @@ impl PythonArchEvalHooks {
         let from_module = session.st().find_module(class_sym);
         let syms = PythonArchEval::get_nested_sub_field(session, related_field_name, class_sym, from_module);
         if let Some(&symbol) = syms.first() {
-            return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: symbol.into(), context: HashMap::new(), instance: Some(true), is_super: false}))
+            return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: symbol.into(), context: HashMap::default(), instance: Some(true), is_super: false}))
         }
         None
     }
@@ -1043,10 +1043,10 @@ impl PythonArchEvalHooks {
             }
             let main_symbol = comodel_sym.borrow().get_main_symbols(session, from_module);
             if main_symbol.len() == 1 {
-                return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: main_symbol[0].into(), context: HashMap::new(), instance: Some(true), is_super: false}))
+                return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: main_symbol[0].into(), context: HashMap::default(), instance: Some(true), is_super: false}))
             }
         }
-        Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::new(), instance: Some(true), is_super: false}))
+        Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::default(), instance: Some(true), is_super: false}))
     }
 
     fn eval_relational(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
@@ -1072,7 +1072,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 Wk::null(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: S!("eval_relational")})
             ),
             value: None,
@@ -1085,7 +1085,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 Wk::null(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: S!("eval_relational")})
             ),
             value: None,
@@ -1112,9 +1112,9 @@ impl PythonArchEvalHooks {
             context.get("range").unwrap().as_text_range().start().to_u32(),
             false
         );
-        let mut result_context = HashMap::new();
+        let mut result_context = HashMap::default();
 
-        let mut contexts_to_add = HashMap::new();
+        let mut contexts_to_add = HashMap::default();
         if relational {
             if let Some(first_param) = parameters.args.get(0) {
                 contexts_to_add.insert("comodel_name", (first_param, first_param.range(), "str"));
@@ -1201,7 +1201,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 Wk::from(symbol), //use the weak to keep reference to the class for the hook.
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(match relational {
                     Some(oyarn) if oyarn == oyarn!("One2many") => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational_one2many, name: S!("eval_init_relational_one2many")},
                     Some(_) => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational, name: S!("eval_init_relational")},
@@ -1379,7 +1379,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 func_sym.into(),
                 Some(true),
-                HashMap::new(),
+                HashMap::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_ref, name: S!("eval_env_ref")})
             ),
             value: None,

--- a/server/src/core/symbols/module_load.rs
+++ b/server/src/core/symbols/module_load.rs
@@ -15,7 +15,7 @@ use crate::{constants::*, oyarn, Sy};
 use lsp_types::{Diagnostic, DiagnosticTag, Position, Range};
 use ruff_python_ast::{Expr, ExprStringLiteral, Stmt};
 use ruff_text_size::Ranged;
-use std::collections::HashSet;
+use crate::utils::HashSet;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use tracing::{error, info};
@@ -77,7 +77,7 @@ impl ModuleSymbol {
             }
             return res;
         }
-        let mut visited_keys = HashSet::new();
+        let mut visited_keys = HashSet::default();
         let dict = &ast[0].as_expr_stmt().unwrap().value.clone().dict_expr().unwrap();
         for (index, key) in dict.iter_keys().enumerate() {
             match key {

--- a/server/src/core/symbols/storage/class_symbol.rs
+++ b/server/src/core/symbols/storage/class_symbol.rs
@@ -8,7 +8,6 @@ use crate::core::model::ModelData;
 use crate::oyarn;
 use crate::core::symbols::symbol_keys::{ClassKey, SymbolKey, Wk};
 use crate::threads::SessionInfo;
-use crate::utils::NoHashBuilder;
 
 use super::symbol_mgr::{SectionRange, SymbolMgr};
 
@@ -31,7 +30,7 @@ pub struct ClassSymbol {
     // parent / child symbols
     parent: SymbolKey,
     //--- Body symbols
-    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
 }
 
 impl ClassSymbol {

--- a/server/src/core/symbols/storage/class_symbol.rs
+++ b/server/src/core/symbols/storage/class_symbol.rs
@@ -1,5 +1,5 @@
 use ruff_text_size::{TextRange, TextSize};
-use std::collections::{HashMap, HashSet};
+use crate::utils::{HashMap, HashSet};
 use std::cell::RefCell;
 
 use crate::constants::OYarn;
@@ -31,7 +31,7 @@ pub struct ClassSymbol {
     // parent / child symbols
     parent: SymbolKey,
     //--- Body symbols
-    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
 }
 
 impl ClassSymbol {
@@ -45,7 +45,7 @@ impl ClassSymbol {
             body_range: TextRange::new(body_start, range.end()),
             doc_string: None,
             sections: vec![],
-            symbols: HashMap::new(),
+            symbols: HashMap::default(),
             bases: vec![],
             _model: None,
             noqas: NoqaInfo::None,
@@ -57,7 +57,7 @@ impl ClassSymbol {
 
     pub fn inherits(session: &mut SessionInfo, class_key: ClassKey, base: ClassKey, checked: &mut Option<HashSet<ClassKey>>) -> bool {
         if checked.is_none() {
-            *checked = Some(HashSet::new());
+            *checked = Some(HashSet::default());
         }
         let bases: Vec<_> = session.st()[class_key].bases.iter().filter_map(|w| w.upgrade(session.st())).collect();
         for b in bases {

--- a/server/src/core/symbols/storage/compiled_symbol.rs
+++ b/server/src/core/symbols/storage/compiled_symbol.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 
 use crate::{constants::OYarn, oyarn};
@@ -22,7 +22,7 @@ impl CompiledSymbol {
             name: oyarn!("{}", name),
             is_external,
             path: path.to_string(),
-            module_symbols: HashMap::new(),
+            module_symbols: HashMap::default(),
             parent,
         }
     }

--- a/server/src/core/symbols/storage/csv_file_symbol.rs
+++ b/server/src/core/symbols/storage/csv_file_symbol.rs
@@ -4,7 +4,7 @@ use crate::core::symbols::Buildable;
 use crate::core::symbols::storage::dependency_mgr::{DependenciesTable, DependentsTable};
 use crate::core::symbols::symbol_keys::{ModuleKey, XmlDataKey};
 use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::symbol_keys::SymbolKey}, oyarn};
-use std::collections::HashSet;
+use crate::utils::HashSet;
 use std::{cell::RefCell, rc::Weak};
 
 #[derive(Debug)]
@@ -44,7 +44,7 @@ impl CsvFileSymbol {
             in_workspace: false,
             model_name: OYarn::default(),
             headers: Vec::new(),
-            symbols: HashSet::new(),
+            symbols: HashSet::default(),
             self_import: false,
             model_dependencies: PtrWeakHashSet::new(),
             dependencies: DependenciesTable::default(),

--- a/server/src/core/symbols/storage/disk_dir_symbol.rs
+++ b/server/src/core/symbols/storage/disk_dir_symbol.rs
@@ -1,5 +1,6 @@
 
-use std::{collections::HashMap, path::PathBuf};
+use std::{path::PathBuf};
+use crate::utils::HashMap;
 
 use crate::{constants::OYarn, core::symbols::symbol_keys::SymbolKey, oyarn, utils::PathSanitizer};
 
@@ -28,7 +29,7 @@ impl DiskDirSymbol {
             is_external,
             parent,
             in_workspace: false,
-            module_symbols: HashMap::new()
+            module_symbols: HashMap::default()
         }
     }
 

--- a/server/src/core/symbols/storage/ext_symbol_store.rs
+++ b/server/src/core/symbols/storage/ext_symbol_store.rs
@@ -3,7 +3,7 @@ use crate::oyarn;
 use crate::{
     constants::OYarn, core::symbols::storage::SymbolTable, weak_collections::WeakSet,
 };
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 /// section index → [variable keys] (Strong keys stored here)
 type SectionSymbols = HashMap<u32, Vec<VariableKey>>;
@@ -27,8 +27,8 @@ pub struct ExtSymbolStore {
 impl ExtSymbolStore {
     pub fn new() -> Self {
         Self {
-            owners_by_target: HashMap::new(),
-            symbols_by_owner: HashMap::new(),
+            owners_by_target: HashMap::default(),
+            symbols_by_owner: HashMap::default(),
         }
     }
 

--- a/server/src/core/symbols/storage/file_symbol.rs
+++ b/server/src/core/symbols/storage/file_symbol.rs
@@ -1,6 +1,6 @@
 use weak_table::PtrWeakHashSet;
 
-use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn, utils::NoHashBuilder};
+use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn};
 use std::{cell::RefCell, rc::Weak};
 use crate::utils::HashMap;
 
@@ -29,7 +29,7 @@ pub struct FileSymbol {
 
     // parent / child symbols
     parent: SymbolKey,
-    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
 }
 
 impl FileSymbol {

--- a/server/src/core/symbols/storage/file_symbol.rs
+++ b/server/src/core/symbols/storage/file_symbol.rs
@@ -1,7 +1,8 @@
 use weak_table::PtrWeakHashSet;
 
 use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn, utils::NoHashBuilder};
-use std::{cell::RefCell, collections::HashMap, rc::Weak};
+use std::{cell::RefCell, rc::Weak};
+use crate::utils::HashMap;
 
 use super::symbol_mgr::{SectionRange, SymbolMgr};
 
@@ -28,7 +29,7 @@ pub struct FileSymbol {
 
     // parent / child symbols
     parent: SymbolKey,
-    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
 }
 
 impl FileSymbol {
@@ -46,12 +47,12 @@ impl FileSymbol {
             in_workspace: false,
             self_import: false,
             sections: vec![],
-            symbols: HashMap::new(),
+            symbols: HashMap::default(),
             model_dependencies: PtrWeakHashSet::new(),
             dependencies: DependenciesTable::default(),
             dependents: DependentsTable::default(),
             processed_text_hash: 0,
-            not_found_models: HashMap::new(),
+            not_found_models: HashMap::default(),
             noqas: NoqaInfo::None,
         };
         res._init_symbol_mgr();

--- a/server/src/core/symbols/storage/function_symbol.rs
+++ b/server/src/core/symbols/storage/function_symbol.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 use lsp_types::Diagnostic;
 use ruff_python_ast::{AtomicNodeIndex, Expr, ExprCall};
@@ -54,7 +54,7 @@ pub struct FunctionSymbol {
     // parent / child symbols
     parent: SymbolKey,
     //--- Body content
-    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
 }
 
 impl FunctionSymbol {
@@ -68,7 +68,7 @@ impl FunctionSymbol {
             body_range: TextRange::new(body_start, range.end()),
             is_static: false,
             is_property: false,
-            diagnostics: HashMap::new(),
+            diagnostics: HashMap::default(),
             node_index: AtomicNodeIndex::default(),
             doc_string: None,
             evaluations: vec![],
@@ -76,7 +76,7 @@ impl FunctionSymbol {
             arch_eval_status: BuildStatus::PENDING,
             validation_status: BuildStatus::PENDING,
             sections: vec![],
-            symbols: HashMap::new(),
+            symbols: HashMap::default(),
             args: vec![],
             is_overloaded: false,
             is_class_method: false,

--- a/server/src/core/symbols/storage/function_symbol.rs
+++ b/server/src/core/symbols/storage/function_symbol.rs
@@ -4,7 +4,7 @@ use lsp_types::Diagnostic;
 use ruff_python_ast::{AtomicNodeIndex, Expr, ExprCall};
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{evaluation::{Context, Evaluation}, file_mgr::NoqaInfo, symbols::{SymbolTable, symbol_keys::{FunctionKey, SymbolKey, VariableKey, Wk}}}, oyarn, threads::SessionInfo, utils::NoHashBuilder};
+use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{evaluation::{Context, Evaluation}, file_mgr::NoqaInfo, symbols::{SymbolTable, symbol_keys::{FunctionKey, SymbolKey, VariableKey, Wk}}}, oyarn, threads::SessionInfo};
 
 use super::{symbol_mgr::{SectionRange, SymbolMgr}};
 
@@ -54,7 +54,7 @@ pub struct FunctionSymbol {
     // parent / child symbols
     parent: SymbolKey,
     //--- Body content
-    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
 }
 
 impl FunctionSymbol {

--- a/server/src/core/symbols/storage/module_symbol.rs
+++ b/server/src/core/symbols/storage/module_symbol.rs
@@ -5,7 +5,7 @@ use crate::core::symbols::storage::dependency_mgr::{DependenciesTable, Dependent
 use crate::core::symbols::symbol_keys::{NamespaceKey, SourceFileKey, SymbolKey, XmlId};
 use super::symbol_mgr::SymbolMgr;
 use crate::threads::SessionInfo;
-use crate::utils::{NoHashBuilder, PathSanitizer};
+use crate::utils::{PathSanitizer};
 use crate::weak_collections::WeakSet;
 use crate::{constants::*, oyarn};
 use ruff_text_size::TextRange;
@@ -48,7 +48,7 @@ pub struct ModuleSymbol {
 
     // parent / child symbols
     parent: NamespaceKey,
-    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
     pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
     pub(super) data_symbols: HashMap<String, SourceFileKey>,
 }

--- a/server/src/core/symbols/storage/module_symbol.rs
+++ b/server/src/core/symbols/storage/module_symbol.rs
@@ -10,7 +10,7 @@ use crate::weak_collections::WeakSet;
 use crate::{constants::*, oyarn};
 use ruff_text_size::TextRange;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use crate::utils::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Weak;
 use weak_table::PtrWeakHashSet;
@@ -48,7 +48,7 @@ pub struct ModuleSymbol {
 
     // parent / child symbols
     parent: NamespaceKey,
-    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
     pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
     pub(super) data_symbols: HashMap<String, SourceFileKey>,
 }
@@ -69,31 +69,31 @@ impl ModuleSymbol {
             init_path: dir_path.join("__init__.py").sanitize(),
             is_external,
             not_found_paths: vec![],
-            not_found_data: HashMap::new(),
-            not_found_models: HashMap::new(),
+            not_found_data: HashMap::default(),
+            not_found_models: HashMap::default(),
             in_workspace: false,
             root_path: path,
             loaded: false,
             module_name: OYarn::from(""),
-            xml_ids: HashMap::new(),
+            xml_ids: HashMap::default(),
             dir_name,
             depends,
-            all_depends: HashSet::new(),
+            all_depends: HashSet::default(),
             data: Vec::new(),
             assets: Vec::new(),
             parent,
-            module_symbols: HashMap::new(),
+            module_symbols: HashMap::default(),
             arch_status: BuildStatus::PENDING,
             arch_eval_status: BuildStatus::PENDING,
             validation_status: BuildStatus::PENDING,
             sections: vec![],
-            symbols: HashMap::new(),
+            symbols: HashMap::default(),
             model_dependencies: PtrWeakHashSet::new(),
             dependencies: DependenciesTable::default(),
             dependents: DependentsTable::default(),
             processed_text_hash: 0,
             noqas: NoqaInfo::None,
-            data_symbols: HashMap::new(),
+            data_symbols: HashMap::default(),
         };
         module._init_symbol_mgr();
         module.load(session, dir_path)

--- a/server/src/core/symbols/storage/namespace_symbol.rs
+++ b/server/src/core/symbols/storage/namespace_symbol.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::utils::HashMap;
 use crate::{constants::OYarn, core::symbols::symbol_keys::SymbolKey, oyarn};
 
 #[derive(Debug)]
@@ -29,7 +29,7 @@ impl NamespaceSymbol {
     pub fn new(name: &str, paths: Vec<String>, parent: SymbolKey, is_external: bool) -> Self {
         let directories = paths.into_iter().map(|p| NamespaceDirectory {
             path: p,
-            module_symbols: HashMap::new(),
+            module_symbols: HashMap::default(),
         }).collect();
         Self {
             name: oyarn!("{}", name),
@@ -45,7 +45,7 @@ impl NamespaceSymbol {
     }
 
     pub fn add_path(&mut self, path: String) {
-        self.directories.push(NamespaceDirectory { path: path, module_symbols: HashMap::new() });
+        self.directories.push(NamespaceDirectory { path: path, module_symbols: HashMap::default() });
     }
 
     pub fn directories(&self) -> &[NamespaceDirectory] {

--- a/server/src/core/symbols/storage/package_symbol.rs
+++ b/server/src/core/symbols/storage/package_symbol.rs
@@ -1,6 +1,6 @@
 use weak_table::PtrWeakHashSet;
 
-use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn, utils::{NoHashBuilder, PathSanitizer}};
+use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn, utils::PathSanitizer};
 use std::{cell::RefCell, path::PathBuf, rc::Weak};
 use crate::utils::HashMap;
 
@@ -30,7 +30,7 @@ pub struct PythonPackageSymbol {
 
     // parent / child symbols
     parent: SymbolKey,
-    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
     pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
 }
 

--- a/server/src/core/symbols/storage/package_symbol.rs
+++ b/server/src/core/symbols/storage/package_symbol.rs
@@ -1,7 +1,8 @@
 use weak_table::PtrWeakHashSet;
 
 use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn, utils::{NoHashBuilder, PathSanitizer}};
-use std::{cell::RefCell, collections::HashMap, path::PathBuf, rc::Weak};
+use std::{cell::RefCell, path::PathBuf, rc::Weak};
+use crate::utils::HashMap;
 
 use super::symbol_mgr::{SectionRange, SymbolMgr};
 
@@ -29,7 +30,7 @@ pub struct PythonPackageSymbol {
 
     // parent / child symbols
     parent: SymbolKey,
-    pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
+    pub(super) symbols: HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>,
     pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
 }
 
@@ -49,9 +50,9 @@ impl PythonPackageSymbol {
             not_found_paths: vec![],
             in_workspace: false,
             self_import: false, //indicates that if unloaded, the symbol should be added in the rebuild automatically as nothing depends on it (used for root packages)
-            module_symbols: HashMap::new(),
+            module_symbols: HashMap::default(),
             sections: vec![],
-            symbols: HashMap::new(),
+            symbols: HashMap::default(),
             model_dependencies: PtrWeakHashSet::new(),
             dependencies: DependenciesTable::default(),
             dependents: DependentsTable::default(),

--- a/server/src/core/symbols/storage/root_symbol.rs
+++ b/server/src/core/symbols/storage/root_symbol.rs
@@ -1,5 +1,6 @@
 use crate::{constants::OYarn, core::{entry_point::EntryPoint, symbols::symbol_keys::SymbolKey}, oyarn};
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
+use crate::utils::HashMap;
 
 #[derive(Debug)]
 pub struct RootSymbol {
@@ -16,7 +17,7 @@ impl RootSymbol {
         Self {
             name: oyarn!("Root"),
             entry_point,
-            module_symbols: HashMap::new(),
+            module_symbols: HashMap::default(),
         }
     }
 

--- a/server/src/core/symbols/storage/symbol_mgr.rs
+++ b/server/src/core/symbols/storage/symbol_mgr.rs
@@ -3,7 +3,6 @@ use crate::utils::HashMap;
 use ruff_text_size::TextSize;
 
 use crate::{constants::OYarn, core::symbols::symbol_keys::SymbolKey};
-use crate::utils::NoHashBuilder;
 
 use super::{class_symbol::ClassSymbol, file_symbol::FileSymbol, function_symbol::FunctionSymbol, module_symbol::ModuleSymbol, package_symbol::PythonPackageSymbol};
 
@@ -30,7 +29,7 @@ pub struct SectionRange {
 
 pub trait SymbolMgr {
     fn get_sections(&self) -> &[SectionRange];
-    fn symbols(&self) -> &HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>;
+    fn symbols(&self) -> &HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>;
     fn get_section_for(&self, position: u32) -> SectionRange;
     fn get_last_index(&self) -> u32;
     fn add_section(&mut self, range_start: TextSize, maybe_previous_indexes: Option<SectionIndex>) -> SectionRange;
@@ -76,7 +75,7 @@ macro_rules! impl_section_mgr_for {
             &self.sections
         }
 
-        fn symbols(&self) -> &HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>> {
+        fn symbols(&self) -> &HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>> {
             &self.symbols
         }
 

--- a/server/src/core/symbols/storage/symbol_mgr.rs
+++ b/server/src/core/symbols/storage/symbol_mgr.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 use ruff_text_size::TextSize;
 
@@ -30,7 +30,7 @@ pub struct SectionRange {
 
 pub trait SymbolMgr {
     fn get_sections(&self) -> &[SectionRange];
-    fn symbols(&self) -> &HashMap<OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>;
+    fn symbols(&self) -> &HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>>;
     fn get_section_for(&self, position: u32) -> SectionRange;
     fn get_last_index(&self) -> u32;
     fn add_section(&mut self, range_start: TextSize, maybe_previous_indexes: Option<SectionIndex>) -> SectionRange;
@@ -76,7 +76,7 @@ macro_rules! impl_section_mgr_for {
             &self.sections
         }
 
-        fn symbols(&self) -> &HashMap<OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>> {
+        fn symbols(&self) -> &HashMap<OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>> {
             &self.symbols
         }
 

--- a/server/src/core/symbols/storage/variable_symbol.rs
+++ b/server/src/core/symbols/storage/variable_symbol.rs
@@ -2,7 +2,7 @@ use ruff_text_size::TextRange;
 
 use crate::{S, constants::OYarn, core::{evaluation::{ContextValue, Evaluation}, symbols::storage::SymbolTable}, threads::SessionInfo};
 use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SymbolKey, VariableKey};
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 #[derive(Debug)]
 pub struct VariableSymbol {
@@ -64,7 +64,7 @@ impl VariableSymbol {
             let parent = session.st()[target].parent();
             // To be able to follow related fields, we need to have the base_attr set in order to find the __get__ hook in next_refs
             // we update the context here for the case where we are coming from a decorator for example.
-            let mut context = Some(HashMap::new());
+            let mut context = Some(HashMap::default());
             context.as_mut().unwrap().insert(S!("base_attr"), ContextValue::SYMBOL(parent.into()));
             let eval_weaks = SymbolTable::follow_ref(&symbol, session, &mut context, false, false, None, None);
             for eval_weak in eval_weaks.iter() {

--- a/server/src/core/symbols/storage/xml/xml_asset_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_asset_symbol.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 use ruff_text_size::TextRange;
 
@@ -16,7 +16,7 @@ pub struct XmlAssetSymbol {
 
 impl XmlAssetSymbol {
     pub fn new(xml_id: Option<OYarn>, range: TextRange, parent: SymbolKey, is_external: bool) -> Self {
-        Self { xml_id, range, parent, is_external, fields: HashMap::new() }
+        Self { xml_id, range, parent, is_external, fields: HashMap::default() }
     }
 
     pub fn parent(&self) -> SymbolKey {

--- a/server/src/core/symbols/storage/xml/xml_file_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_file_symbol.rs
@@ -7,8 +7,9 @@ use crate::core::symbols::symbol_keys::{ModuleKey, SymbolKey, XmlDataKey};
 use crate::core::symbols::Buildable;
 use crate::{core::diagnostics::DiagnosticCode, threads::SessionInfo};
 use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::{FileInfo, NoqaInfo}, model::Model}, oyarn};
-use std::collections::HashSet;
-use std::{cell::RefCell, collections::HashMap, rc::Weak};
+use crate::utils::HashSet;
+use std::{cell::RefCell, rc::Weak};
+use crate::utils::HashMap;
 
 #[derive(Debug)]
 pub struct XmlFileSymbol {
@@ -43,8 +44,8 @@ impl XmlFileSymbol {
             arch_status: BuildStatus::PENDING,
             validation_status: BuildStatus::PENDING,
             not_found_paths: vec![],
-            not_found_models: HashMap::new(),
-            symbols: HashSet::new(),
+            not_found_models: HashMap::default(),
+            symbols: HashSet::default(),
             in_workspace: false,
             self_import: false,
             model_dependencies: PtrWeakHashSet::new(),

--- a/server/src/core/symbols/storage/xml/xml_record_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_record_symbol.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, ops::Range};
+use std::{ops::Range};
+use crate::utils::HashMap;
 
 use ruff_text_size::TextRange;
 
@@ -26,7 +27,7 @@ impl XmlRecordSymbol {
         Self {
             model,
             xml_id,
-            fields: HashMap::new(),
+            fields: HashMap::default(),
             range,
             parent,
             is_external,

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -1,10 +1,11 @@
 use std::{
     cell::RefCell,
     cmp::Ordering,
-    collections::{hash_map, HashMap, HashSet, VecDeque},
+    collections::{hash_map, VecDeque},
     path::PathBuf,
     rc::Rc,
 };
+use crate::utils::{HashMap, HashSet};
 
 use lsp_types::{Diagnostic, DiagnosticTag, Range, SymbolKind};
 use ruff_text_size::TextRange;
@@ -398,7 +399,7 @@ impl SymbolTable {
         }
     }
 
-    pub fn iter_symbols(&self, target: SymbolKey) -> hash_map::Iter<'_, OYarn, HashMap<u32, Vec<SymbolKey>, NoHashBuilder>> {
+    pub fn iter_symbols(&self, target: SymbolKey) -> hash_map::Iter<'_, OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>> {
         match target {
             SymbolKey::File(f) => {
                 self[f].symbols().iter()
@@ -727,7 +728,7 @@ impl SymbolTable {
         let sections = target_sym_mgr.symbols().get(name);
         let mut content = if let Some(sections) = sections {
             let section: SectionRange = target_sym_mgr.get_section_for(position);
-            self.get_loc_symbol(target_sym_mgr, sections, position, &SectionIndex::INDEX(section.index), &mut HashSet::new())
+            self.get_loc_symbol(target_sym_mgr, sections, position, &SectionIndex::INDEX(section.index), &mut HashSet::default())
         } else {
             ContentSymbols::default()
         };
@@ -742,9 +743,9 @@ impl SymbolTable {
     /// Return all symbols before the given position that are visible in the body of this symbol.
     pub fn get_all_visible_symbols(&self, target: SymbolKey, name_prefix: &String, position: u32) -> HashMap<OYarn, Vec<SymbolKey>> {
         let Some(target_sym_mgr) = self.try_as_symbol_mgr(target) else {
-            return HashMap::new();
+            return HashMap::default();
         };
-        let mut result = HashMap::new();
+        let mut result = HashMap::default();
         let current_section = target_sym_mgr.get_section_for(position);
         let current_index = SectionIndex::INDEX(current_section.index);
 
@@ -752,7 +753,7 @@ impl SymbolTable {
             if !name.starts_with(name_prefix) {
                 continue;
             }
-            let mut seen = HashSet::new();
+            let mut seen = HashSet::default();
             let content = self.get_loc_symbol(target_sym_mgr, section_map, position, &current_index, &mut seen);
 
             if !content.symbols.is_empty() {
@@ -780,7 +781,7 @@ impl SymbolTable {
     }
 
     ///given all the sections of a symbol and a position, return all the Symbols that can represent the symbol
-    pub fn get_loc_symbol(&self, target: &dyn SymbolMgr, map: &HashMap<u32, Vec<SymbolKey>, NoHashBuilder>, position: u32, index: &SectionIndex, acc: &mut HashSet<u32>) -> ContentSymbols {
+    pub fn get_loc_symbol(&self, target: &dyn SymbolMgr, map: &std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>, position: u32, index: &SectionIndex, acc: &mut HashSet<u32>) -> ContentSymbols {
         let mut res = ContentSymbols::default();
         match index {
                 SectionIndex::NONE => { return res; },
@@ -1184,7 +1185,7 @@ impl SymbolTable {
         SyncOdoo::ensure_func_evaluations(session, get_method);
         let evaluations = session.st()[get_method].evaluations.clone();
         if context.is_none() {
-            *context = Some(HashMap::new());
+            *context = Some(HashMap::default());
         }
         for get_method_eval in evaluations.iter() {
             context.as_mut().unwrap().extend(symbol_context.clone().into_iter());
@@ -1214,7 +1215,7 @@ impl SymbolTable {
         let var_symbol = &session.sync_odoo.symbol_table[key];
         let evaluations = var_symbol.evaluations.clone();
         for eval in evaluations.iter() {
-            let ctx = &mut Some(symbol_context.clone().into_iter().chain(context.clone().unwrap_or(HashMap::new()).into_iter()).collect::<HashMap<_, _>>());
+            let ctx = &mut Some(symbol_context.clone().into_iter().chain(context.clone().unwrap_or(HashMap::default()).into_iter()).collect::<HashMap<_, _>>());
             let mut sym = eval.symbol.get_symbol(session, ctx, &mut vec![], None);
             if let EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) = &mut sym {
                 if let Some(base_attr) = symbol_context.get("base_attr") {
@@ -1302,7 +1303,7 @@ impl SymbolTable {
             }).collect();
         }
         let mut results = Vec::new();
-        let mut visited = HashSet::new();
+        let mut visited = HashSet::default();
         while let Some(current_eval) = work_queue.pop_front() {
             let next_ref_weak = match &current_eval {
                 EvaluationSymbolPtr::WEAK(weak)
@@ -1467,8 +1468,8 @@ impl SymbolTable {
         from_module: Option<ModuleKey>,
         is_super: bool
     ) -> HashMap<OYarn, Vec<(SymbolKey, Option<OYarn>)>> {
-        let mut result: HashMap<OYarn, Vec<(SymbolKey, Option<OYarn>)>> = HashMap::new();
-        let mut acc: HashSet<Tree> = HashSet::new();
+        let mut result: HashMap<OYarn, Vec<(SymbolKey, Option<OYarn>)>> = HashMap::default();
+        let mut acc: HashSet<Tree> = HashSet::default();
         Self::_all_members(symbol, session, &mut result, with_co_models, only_fields, only_methods, from_module, &mut acc, is_super);
         return  result;
     }
@@ -1614,7 +1615,7 @@ impl SymbolTable {
                 }
             }
         }
-        let mut results = HashMap::new();
+        let mut results = HashMap::default();
         helper(self, on_symbol, name, position, &mut results);
         results
     }
@@ -1840,7 +1841,7 @@ impl SymbolTable {
         all: bool,
         is_super: bool
     ) -> (Vec<SymbolKey>, Vec<Diagnostic>) {
-        let mut visited_classes: HashSet<ClassKey> = HashSet::new();
+        let mut visited_classes: HashSet<ClassKey> = HashSet::default();
         return Self::_get_member_symbol_helper(session, target, name, from_module, prevent_comodel, only_fields, only_methods, all, is_super, &mut visited_classes);
     }
 
@@ -1857,7 +1858,7 @@ impl SymbolTable {
         visited_classes: &mut HashSet<ClassKey>
     ) -> (Vec<SymbolKey>, Vec<Diagnostic>) {
         let mut result: Vec<SymbolKey> = vec![];
-        let mut visited_symbols: HashSet<SymbolKey> = HashSet::new();
+        let mut visited_symbols: HashSet<SymbolKey> = HashSet::default();
         let extend_result = |syms: Vec<SymbolKey>, result: &mut Vec<SymbolKey>, visited_symbols: &mut HashSet<SymbolKey>| {
             syms.iter().for_each(|&sym|{
                 if !visited_symbols.contains(&sym){

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -24,7 +24,7 @@ use crate::{
                 ClassKey, FunctionKey, KeyValidator, ModuleKey, NamespaceKey, RootKey, SourceFileKey, SymbolKey, VariableKey, XmlDataKey
             }, symbol_mgr::{ContentSymbols, SectionIndex, SectionRange, SymbolMgr, iter_symbol_keys}
         },
-    }, threads::SessionInfo, utils::{NoHashBuilder, PathSanitizer, compare_semver}, weak_collections::WeakSet
+    }, threads::SessionInfo, utils::{PathSanitizer, compare_semver}, weak_collections::WeakSet
 };
 
 impl SymbolTable {
@@ -399,7 +399,7 @@ impl SymbolTable {
         }
     }
 
-    pub fn iter_symbols(&self, target: SymbolKey) -> hash_map::Iter<'_, OYarn, std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>> {
+    pub fn iter_symbols(&self, target: SymbolKey) -> hash_map::Iter<'_, OYarn, HashMap<u32, Vec<SymbolKey>>> {
         match target {
             SymbolKey::File(f) => {
                 self[f].symbols().iter()
@@ -781,7 +781,7 @@ impl SymbolTable {
     }
 
     ///given all the sections of a symbol and a position, return all the Symbols that can represent the symbol
-    pub fn get_loc_symbol(&self, target: &dyn SymbolMgr, map: &std::collections::HashMap<u32, Vec<SymbolKey>, NoHashBuilder>, position: u32, index: &SectionIndex, acc: &mut HashSet<u32>) -> ContentSymbols {
+    pub fn get_loc_symbol(&self, target: &dyn SymbolMgr, map: &HashMap<u32, Vec<SymbolKey>>, position: u32, index: &SectionIndex, acc: &mut HashSet<u32>) -> ContentSymbols {
         let mut res = ContentSymbols::default();
         match index {
                 SectionIndex::NONE => { return res; },

--- a/server/src/core/xml_validation.rs
+++ b/server/src/core/xml_validation.rs
@@ -1,9 +1,9 @@
 use std::{
     cell::RefCell,
     cmp::Ordering,
-    collections::{HashMap, HashSet},
     rc::Rc,
 };
+use crate::utils::{HashMap, HashSet};
 
 use lsp_types::{Diagnostic, Position, Range};
 use tracing::{info, trace};
@@ -39,7 +39,7 @@ impl XmlValidator {
             xml_symbol: symbol,
             is_in_main_ep,
             module,
-            fields_cache: HashMap::new(),
+            fields_cache: HashMap::default(),
         }
     }
 
@@ -56,7 +56,7 @@ impl XmlValidator {
         }
         let mut dependencies = vec![];
         let mut model_dependencies = vec![];
-        let mut missing_model_dependencies = HashSet::new();
+        let mut missing_model_dependencies = HashSet::default();
         let mut diagnostics = vec![];
         for data_key in session.st()[self.xml_symbol].symbols().iter().cloned().collect::<Vec<_>>() {
             self.validate_data(session, data_key, &mut diagnostics, &mut dependencies, &mut model_dependencies, &mut missing_model_dependencies);

--- a/server/src/features/ast_utils.rs
+++ b/server/src/features/ast_utils.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::utils::HashMap;
 use crate::constants::{BuildStatus, BuildSteps, SymType};
 use crate::core::evaluation::{AnalyzeAstResult, Context, ContextValue, Evaluation, ExprOrIdent};
 use crate::core::odoo::SyncOdoo;
@@ -48,7 +48,7 @@ impl AstUtils {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from([
+        let mut context: Option<Context> = Some(HashMap::from_iter([
             (S!("module"), from_module),
             (S!("range"), ContextValue::RANGE(expr.range()))
         ]));

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -26,7 +26,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextSize};
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use crate::utils::{HashMap, HashSet};
 use std::{cell::RefCell, rc::Rc};
 
 
@@ -935,7 +935,7 @@ fn complete_name(session: &mut SessionInfo, file: SourceFileKey, offset: usize, 
     Some(CompletionResponse::List(CompletionList {
         is_incomplete: false,
         items: symbols.into_iter().map(|(_symbol_name, symbols)| {
-            build_completion_item_from_symbol(session, symbols, HashMap::new())
+            build_completion_item_from_symbol(session, symbols, HashMap::default())
         }).collect::<Vec<_>>(),
     }))
 }
@@ -1080,7 +1080,7 @@ fn add_nested_field_names(
                         let mut found_one = false;
                         for (final_sym, dep) in symbols.iter() { //search for at least one that is a field
                             if dep.is_none() && (specific_field_type.is_none() || SymbolTable::is_specific_field(session, *final_sym, &["Many2one", "One2many", "Many2many", specific_field_type.as_ref().unwrap().as_str()])){
-                                items.push(build_completion_item_from_symbol(session, vec![*final_sym], HashMap::new()));
+                                items.push(build_completion_item_from_symbol(session, vec![*final_sym], HashMap::default()));
                                 found_one = true;
                                 continue;
                             }
@@ -1146,7 +1146,7 @@ fn add_model_attributes(
             }
         }
         if symbol_name.starts_with(attribute_name) {
-            let context_of_symbol = HashMap::from([(S!("base_attr"), ContextValue::SYMBOL(parent_sym.into()))]);
+            let context_of_symbol = HashMap::from_iter([(S!("base_attr"), ContextValue::SYMBOL(parent_sym.into()))]);
             items.push(build_completion_item_from_symbol(session, vec![*final_sym], context_of_symbol));
         }
     }

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -9,7 +9,7 @@ use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::{FunctionSymbol, VariableSymbol};
 use crate::utils::compare_semver;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use crate::utils::HashMap;
 
 use crate::constants::SymType;
 use crate::constants::OYarn;
@@ -436,7 +436,7 @@ impl FeaturesUtils {
         }
 
         let mut blocks = vec![];
-        let mut aggregator: HashMap<SymbolGroupKey, Vec<SymbolInfo>> = HashMap::new();
+        let mut aggregator: HashMap<SymbolGroupKey, Vec<SymbolInfo>> = HashMap::default();
         for (index, eval) in evals.iter().enumerate() {
             //search for a constant evaluation like a model name or domain field
             if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(expr))) = eval.value.as_ref() {

--- a/server/src/features/references.rs
+++ b/server/src/features/references.rs
@@ -22,7 +22,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use tracing::error;
-use std::collections::HashSet;
+use crate::utils::HashSet;
 use std::{cell::RefCell, path::PathBuf, rc::Rc};
 
 #[derive(Debug, Clone)]
@@ -91,7 +91,7 @@ impl ReferenceFeature {
                     }
                 },
                 SymType::CLASS | SymType::FUNCTION | SymType::VARIABLE | SymType::FILE => {
-                    let mut files_to_check = HashSet::new();
+                    let mut files_to_check = HashSet::default();
 
                     files_to_check.insert(file_symbol);
 
@@ -181,7 +181,7 @@ impl ReferenceFeature {
                     let xml_id_file = session.st().get_file(definition.source).unwrap();
                     let current_module = session.st().find_module(xml_id_file).unwrap();
                     let data_module_name = session.st()[current_module].dir_name.clone();
-                    let mut files_to_process = HashSet::new();
+                    let mut files_to_process = HashSet::default();
                     //TODO do not process all modules in the dep tree, but use dependencies on XML files when we will have them
                     let modules: Vec<_> = session.sync_odoo.modules.values().copied().collect();
                     for module in modules {

--- a/server/src/features/references_xml.rs
+++ b/server/src/features/references_xml.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 use lsp_types::Location;
 use roxmltree::Node;
-use std::{collections::HashMap, ops::Range};
+use std::{ops::Range};
+use crate::utils::HashMap;
 
 pub enum XmlAstReferenceVisitor {
 
@@ -20,7 +21,7 @@ impl XmlAstReferenceVisitor {
     pub fn search_target(session: &mut SessionInfo, file_symbol: XmlFileKey, root: roxmltree::Node, target: &ReferenceTarget) -> Vec<Location> {
         let mut results = vec![];
         let from_module = session.st().find_module(file_symbol);
-        let mut context_xml = HashMap::new();
+        let mut context_xml = HashMap::default();
         for node in root.children() {
             XmlAstReferenceVisitor::visit_node(session, &node, from_module, &mut context_xml, &mut results, target);
         }

--- a/server/src/features/xml_ast_utils.rs
+++ b/server/src/features/xml_ast_utils.rs
@@ -8,7 +8,8 @@ use crate::{
     }, threads::SessionInfo
 };
 use roxmltree::Node;
-use std::{collections::HashMap, ops::Range};
+use std::{ops::Range};
+use crate::utils::HashMap;
 
 pub struct XmlAstUtils {}
 
@@ -17,7 +18,7 @@ impl XmlAstUtils {
     pub fn get_symbols(session: &mut SessionInfo, file_symbol: SourceFileKey, root: roxmltree::Node, offset: usize, on_dep_only: bool) -> (Vec<SymbolKey>, Option<Range<usize>>) {
         let mut results = (vec![], None);
         let from_module = session.sync_odoo.symbol_table.find_module(file_symbol);
-        let mut context_xml = HashMap::new();
+        let mut context_xml = HashMap::default();
         for node in root.children() {
             XmlAstUtils::visit_node(session, &node, offset, from_module, &mut context_xml, &mut results, on_dep_only);
         }

--- a/server/src/fifo_ptr_weak_hash_set.rs
+++ b/server/src/fifo_ptr_weak_hash_set.rs
@@ -11,7 +11,7 @@ pub struct FifoWeakHashSet<T: Copy + Eq + Hash> {
 impl<T: Copy + Eq + Hash> FifoWeakHashSet<T> {
     pub fn new() -> Self {
         Self {
-            set: HashSet::new(),
+            set: HashSet::default(),
             queue: VecDeque::new(),
         }
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -15,7 +15,20 @@ use odoo_ls_server::allocator::TrackingAllocator;
 #[global_allocator]
 static GLOBAL: TrackingAllocator = TrackingAllocator;
 
+// jemalloc isn't supported on Windows (MSVC); release builds there fall back to the system allocator.
+#[cfg(all(not(debug_assertions), any(target_os = "linux", target_os = "macos")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() {
+    // Move jemalloc's purging (madivise) off the worker threads
+    #[cfg(all(not(debug_assertions), any(target_os = "linux", target_os = "macos")))]
+    {
+        if let Err(e) = tikv_jemalloc_ctl::background_thread::write(true) {
+            tracing::warn!("failed to enable jemalloc background_thread: {e}");
+        }
+    }
+
     // TODO: Audit that the environment access only happens in single-threaded code.
     unsafe { env::set_var("RUST_BACKTRACE", "full") };
     crash_buffer::init_crash_buffer();

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextSize;
 use std::ffi::OsStr;
 use std::process::Command;
 use std::sync::atomic::Ordering;
-use std::{collections::HashMap, fs::{self, DirEntry}, path::{Path, PathBuf}, str::FromStr, sync::LazyLock};
+use std::{fs::{self, DirEntry}, path::{Path, PathBuf}, str::FromStr, sync::LazyLock};
 
 use crate::{constants::Tree, oyarn};
 
@@ -290,7 +290,7 @@ pub fn fill_template(template: &str, vars: &HashMap<String, String>) -> Result<S
 
 pub fn build_pattern_map(unique_ws_folders: &HashMap<String, String>) -> HashMap<String, String> {
     // TODO: Maybe cache this
-    let mut pattern_map = HashMap::new();
+    let mut pattern_map = HashMap::default();
     if let Some(home_dir) = HOME_DIR.as_ref() {
         pattern_map.insert(S!("userHome"), home_dir.clone());
     }
@@ -436,3 +436,12 @@ impl Hasher for U32IdentityHasher {
 	}
 }
 pub type NoHashBuilder = BuildHasherDefault<U32IdentityHasher>;
+
+/// Drop-in replacements for `std::collections::HashMap`/`HashSet` that use
+/// `rustc_hash::FxBuildHasher` (a fast, non-cryptographic hasher). OdooLS only ever
+/// hashes its own internal keys, so the HashDoS resistance of the std SipHash default
+/// is dead weight. The hasher is baked in (no third type parameter) so that
+/// `HashMap::default()` infers a concrete type; maps that need a different hasher
+/// (e.g. `NoHashBuilder`) must spell out `std::collections::HashMap` explicitly.
+pub type HashMap<K, V> = std::collections::HashMap<K, V, rustc_hash::FxBuildHasher>;
+pub type HashSet<T> = std::collections::HashSet<T, rustc_hash::FxBuildHasher>;

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -413,35 +413,10 @@ macro_rules! warn_or_panic {
     }
 }
 
-use std::hash::{BuildHasherDefault, Hasher};
-#[derive(Default)]
-pub struct U32IdentityHasher(u64);
-
-impl Hasher for U32IdentityHasher {
-	fn write(&mut self, bytes: &[u8]) {
-		// fallback lent (rare si on n'utilise que u32)
-		let mut v = 0u64;
-		for (i, b) in bytes.iter().enumerate().take(8) {
-			v |= (*b as u64) << (i * 8);
-		}
-		self.0 = v;
-	}
-
-	fn write_u32(&mut self, i: u32) {
-		self.0 = i as u64;
-	}
-
-	fn finish(&self) -> u64 {
-		self.0
-	}
-}
-pub type NoHashBuilder = BuildHasherDefault<U32IdentityHasher>;
-
 /// Drop-in replacements for `std::collections::HashMap`/`HashSet` that use
 /// `rustc_hash::FxBuildHasher` (a fast, non-cryptographic hasher). OdooLS only ever
 /// hashes its own internal keys, so the HashDoS resistance of the std SipHash default
 /// is dead weight. The hasher is baked in (no third type parameter) so that
-/// `HashMap::default()` infers a concrete type; maps that need a different hasher
-/// (e.g. `NoHashBuilder`) must spell out `std::collections::HashMap` explicitly.
+/// `HashMap::default()` infers a concrete type.
 pub type HashMap<K, V> = std::collections::HashMap<K, V, rustc_hash::FxBuildHasher>;
 pub type HashSet<T> = std::collections::HashSet<T, rustc_hash::FxBuildHasher>;

--- a/server/src/weak_collections.rs
+++ b/server/src/weak_collections.rs
@@ -1,6 +1,6 @@
-use std::{cell::RefCell, collections::{HashMap, HashSet, hash_map}, hash::Hash, vec::IntoIter};
+use std::{cell::RefCell, collections::{hash_map}, hash::Hash, vec::IntoIter};
 
-use crate::core::symbols::symbol_keys::KeyValidator;
+use crate::{core::symbols::symbol_keys::KeyValidator, utils::{HashMap, HashSet}};
 
 #[derive(Debug, Clone)]
 pub struct WeakSet<K: Eq + Hash + Copy> {
@@ -16,7 +16,7 @@ impl<K: Eq + Hash + Copy> Default for WeakSet<K> {
 impl<K: Eq + Hash + Copy> WeakSet<K> {
     pub fn new() -> Self {
         Self {
-            set: RefCell::new(HashSet::new()),
+            set: RefCell::new(HashSet::default()),
         }
     }
 
@@ -68,7 +68,7 @@ pub struct WeakMap<K: Eq + Hash + Copy, V> {
 impl<K: Eq + Hash + Copy, V> WeakMap<K, V> {
     pub fn new() -> Self {
         Self {
-            map: HashMap::new(),
+            map: HashMap::default(),
         }
     }
 

--- a/server/tests/config_tests.rs
+++ b/server/tests/config_tests.rs
@@ -6,7 +6,7 @@ use odoo_ls_server::core::config::get_configuration;
 use odoo_ls_server::core::odoo::SyncOdoo;
 use odoo_ls_server::threads::SessionInfo;
 use odoo_ls_server::utils::PathSanitizer;
-use std::collections::HashSet;
+use odoo_ls_server::utils::HashSet;
 use std::str::FromStr;
 
 
@@ -1919,7 +1919,7 @@ fn test_additional_languages_merge_and_base_expansion() {
     "#;
     ws_folder.child("odools.toml").write_str(ws_toml).unwrap();
 
-    // let mut ws_folders = HashMap::new();
+    // let mut ws_folders = HashMap::default();
     // ws_folders.insert(S!("ws1"), ws_folder.path().sanitize().to_string());
     let ws_folders = [(S!("ws1"), ws_folder.path().sanitize().to_string())]; 
     let mut session = mock_session_with_workspaces(&ws_folders);

--- a/server/tests/setup/setup.rs
+++ b/server/tests/setup/setup.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use core::str;
-use std::collections::HashMap;
+use odoo_ls_server::utils::HashMap;
 use std::{env, fs};
 
 use std::path::PathBuf;
@@ -103,7 +103,7 @@ pub fn get_diagnostics_for_path(session: &mut SessionInfo, path: &str) -> Vec<Di
 }
 
 pub fn get_diagnostics_for_paths(session: &mut SessionInfo, paths: &Vec<String>) -> HashMap<String, Vec<Diagnostic>> {
-    let mut res = HashMap::new();
+    let mut res = HashMap::default();
     while let Some(msg) = session._consume_message() {
         match msg {
             Message::Notification(n) => {

--- a/server/tests/test_basics.rs
+++ b/server/tests/test_basics.rs
@@ -1,6 +1,6 @@
 
 
-use std::collections::HashSet;
+use odoo_ls_server::utils::HashSet;
 use std::env;
 use odoo_ls_server::{core::evaluation::EvaluationValue, oyarn};
 use odoo_ls_server::constants::OYarn;
@@ -174,34 +174,34 @@ fn test_sections() {
         .collect::<HashSet<_>>(), values); // Check evaluation values
     };
     // If statement sections
-    assert_get_int_eval_values("a", HashSet::from([5, 6]));
-    assert_get_int_eval_values("b", HashSet::from([7]));
-    assert_get_int_eval_values("c", HashSet::from([5, 6]));
-    assert_get_int_eval_values("d", HashSet::from([4, 5]));
-    assert_get_int_eval_values("e", HashSet::from([1, 2 ,3]));
+    assert_get_int_eval_values("a", HashSet::from_iter([5, 6]));
+    assert_get_int_eval_values("b", HashSet::from_iter([7]));
+    assert_get_int_eval_values("c", HashSet::from_iter([5, 6]));
+    assert_get_int_eval_values("d", HashSet::from_iter([4, 5]));
+    assert_get_int_eval_values("e", HashSet::from_iter([1, 2 ,3]));
     // For statement sections
-    assert_get_int_eval_values("f", HashSet::from([32, 33, 34, 35]));
-    assert_get_int_eval_values("g", HashSet::from([98, 99]));
-    assert_get_int_eval_values("h", HashSet::from([98, 5]));
+    assert_get_int_eval_values("f", HashSet::from_iter([32, 33, 34, 35]));
+    assert_get_int_eval_values("g", HashSet::from_iter([98, 99]));
+    assert_get_int_eval_values("h", HashSet::from_iter([98, 5]));
     // While statement sections
-    assert_get_int_eval_values("i", HashSet::from([67, 76]));
-    assert_get_int_eval_values("j", HashSet::from([37, 27]));
+    assert_get_int_eval_values("i", HashSet::from_iter([67, 76]));
+    assert_get_int_eval_values("j", HashSet::from_iter([37, 27]));
     // Try statement sections
-    assert_get_int_eval_values("k", HashSet::from([2, 3]));
-    assert_get_int_eval_values("l", HashSet::from([30, 40]));
-    assert_get_int_eval_values("m", HashSet::from([80]));
-    assert_get_int_eval_values("o", HashSet::from([120]));
-    assert_get_int_eval_values("p", HashSet::from([20, 30, 40]));
+    assert_get_int_eval_values("k", HashSet::from_iter([2, 3]));
+    assert_get_int_eval_values("l", HashSet::from_iter([30, 40]));
+    assert_get_int_eval_values("m", HashSet::from_iter([80]));
+    assert_get_int_eval_values("o", HashSet::from_iter([120]));
+    assert_get_int_eval_values("p", HashSet::from_iter([20, 30, 40]));
     // Match statement sections
-    assert_get_int_eval_values("q", HashSet::from([33, 34, 43]));
-    assert_get_int_eval_values("r", HashSet::from([34, 43]));
+    assert_get_int_eval_values("q", HashSet::from_iter([33, 34, 43]));
+    assert_get_int_eval_values("r", HashSet::from_iter([34, 43]));
     // Named expression
-    assert_get_int_eval_values("s", HashSet::from([2]));
-    assert_get_int_eval_values("t", HashSet::from([3]));
+    assert_get_int_eval_values("s", HashSet::from_iter([2]));
+    assert_get_int_eval_values("t", HashSet::from_iter([3]));
     // If stmt with walrus
-    assert_get_int_eval_values("u", HashSet::from([91, 92]));
-    assert_get_int_eval_values("v", HashSet::from([72, 73, 74]));
-    assert_get_int_eval_values("w", HashSet::from([71, 72, 74]));
+    assert_get_int_eval_values("u", HashSet::from_iter([91, 92]));
+    assert_get_int_eval_values("v", HashSet::from_iter([72, 73, 74]));
+    assert_get_int_eval_values("w", HashSet::from_iter([71, 72, 74]));
 
 }
 

--- a/server/tests/test_csv_diagnostics.rs
+++ b/server/tests/test_csv_diagnostics.rs
@@ -3,7 +3,7 @@
 use lsp_types::Diagnostic;
 use odoo_ls_server::threads::SessionInfo;
 use odoo_ls_server::utils::PathSanitizer;
-use std::collections::HashMap;
+use odoo_ls_server::utils::HashMap;
 use std::env;
 use std::path::PathBuf;
 

--- a/server/tests/test_language_updates.rs
+++ b/server/tests/test_language_updates.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use odoo_ls_server::utils::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use lsp_types::{NumberOrString, TextDocumentContentChangeEvent, VersionedTextDocumentIdentifier};
@@ -222,7 +222,7 @@ fn test_language_validation() {
 #[test]
 fn test_additional_languages_config() {
     let (mut odoo, mut config) = setup_server(false);
-    config.additional_languages = HashSet::from(["zz".to_string()]);
+    config.additional_languages = HashSet::from_iter(["zz".to_string()]);
     let session = create_init_session(&mut odoo, config);
 
     let languages = session.sync_odoo._get_languages();
@@ -282,7 +282,7 @@ fn test_config_additional_languages_updates_diagnostics() {
     let force_republish_diagnostic = |session: &mut SessionInfo| {
         let mut file_info_borrow = file_info.borrow_mut();
         // This does not rebuild validation steps. It just sets need_push to true.
-        file_info_borrow.update_validation_diagnostics(HashMap::new());
+        file_info_borrow.update_validation_diagnostics(HashMap::default());
         file_info_borrow.publish_diagnostics(session);
     };
 
@@ -296,7 +296,7 @@ fn test_config_additional_languages_updates_diagnostics() {
 
     // Add nl_WV and nl to additional_languages via config update
     let mut new_config = session.sync_odoo.config.clone();
-    new_config.additional_languages = HashSet::from(["nl_WV".to_string(), "nl".to_string()]);
+    new_config.additional_languages = HashSet::from_iter(["nl_WV".to_string(), "nl".to_string()]);
     Odoo::handle_config_update(&mut session, new_config, ConfigFile::new());
 
     // OLS05068 should be gone now
@@ -312,7 +312,7 @@ fn test_config_additional_languages_updates_diagnostics() {
 
     // Restore original config (without nl_WV) and verify diagnostic reappears
     let mut restored_config = session.sync_odoo.config.clone();
-    restored_config.additional_languages = HashSet::new();
+    restored_config.additional_languages = HashSet::default();
     Odoo::handle_config_update(&mut session, restored_config, ConfigFile::new());
 
     let diagnostics = get_diagnostics_for_path(&mut session, &items_xml_path);

--- a/server/tests/test_utils.rs
+++ b/server/tests/test_utils.rs
@@ -84,7 +84,7 @@ pub fn verify_diagnostics_against_doc(
     doc_diag: Vec<(u32, Vec<String>)>
 ) {
     // Build a map from line to set of diagnostic codes found in diagnostics
-    let mut diags: HashMap<u32, Vec<&Diagnostic>> = HashMap::new();
+    let mut diags: HashMap<u32, Vec<&Diagnostic>> = HashMap::default();
     for diag in &diagnostics {
         let line = diag.range.start.line;
         diags.entry(line).or_default().push(diag);


### PR DESCRIPTION
- Switch hasher for hashmaps and hashset
- Tune release profile (compilation/linker optimization)
- Swap allocator.

-> 25% faster, 3% less memory 

```
$ ./benchmark_commit.sh origin/alpha-1.5.0 alpha-perf_quick_wins-rcdl

 Aggregated results (5 runs each, mean ± stddev)            
════════════════════════════════════════════════════════════════
commit                  user (s)             sys (s)       total CPU (s)         peak RSS (MB)
──────────  ──────────────────  ──────────────────  ──────────────────  ────────────────────
f5d97f94         17.070 ± 0.041      2.304 ± 0.019     19.374 ± 0.043         1637.7 ± 0.3
6e3a8f4e         12.162 ± 0.055      2.306 ± 0.026     14.468 ± 0.040         1581.3 ± 0.4

Δ (after − before):
  user (s):              -4.908  (-28.75%)   z=71.0
  sys (s):               +0.002  ( +0.09%)   z=0.1
  total CPU (s):         -4.906  (-25.32%)   z=83.6
  peak RSS (MB):          -56.4  ( -3.44%)   z=123.0

z = |Δ| / sqrt(σ_before² + σ_after²) — rough significance:
  z > 3 : clearly significant   1 < z < 3 : suggestive   z < 1 : likely noise
```