### PR TITLE
[IMP] Speed up file_mgr file deletion in hot paths

### DIFF
--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -4,10 +4,9 @@ use lsp_types::{Diagnostic, DiagnosticSeverity, MessageType, NumberOrString, Pos
 use lsp_types::notification::{Notification, PublishDiagnostics};
 use ruff_source_file::{OneIndexed, PositionEncoding, SourceLocation};
 use tracing::{error, warn};
-use std::collections::hash_map::DefaultHasher;
+use std::{collections::hash_map::DefaultHasher, path::Path};
 use crate::utils::HashSet;
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{atomic::{AtomicBool, Ordering}, Arc, OnceLock};
 use std::{fs};
@@ -610,18 +609,28 @@ impl FileMgr {
 
     pub fn delete_path(session: &mut SessionInfo, uri: &str) {
         //delete all files that are the uri or in subdirectory
-        let matching_keys: Vec<String> = session.sync_odoo.get_file_mgr().borrow_mut().files.keys().filter(|k| PathBuf::from(k).starts_with(uri)).cloned().collect();
+        let matching_keys: Vec<String> = session.sync_odoo.get_file_mgr().borrow_mut().files.keys().filter(|&k| Path::new(k).starts_with(uri)).cloned().collect();
         for key in matching_keys {
-            let to_del = session.sync_odoo.get_file_mgr().borrow_mut().files.remove(&key);
-            if let Some(to_del) = to_del {
-                if SyncOdoo::is_in_workspace_or_entry(session, uri) {
-                    let mut to_del = (*to_del).borrow_mut();
-                    to_del.replace_diagnostics(BuildSteps::SYNTAX, vec![]);
-                    to_del.replace_diagnostics(BuildSteps::ARCH, vec![]);
-                    to_del.replace_diagnostics(BuildSteps::ARCH_EVAL, vec![]);
-                    to_del.replace_diagnostics(BuildSteps::VALIDATION, vec![]);
-                    to_del.publish_diagnostics(session)
-                }
+            Self::delete_entry(session, &key, uri);
+        }
+    }
+
+    /// Unlike `delete_path`, this function only deletes the file with the exact uri, and not files in subdirectories.
+    pub fn delete_file_path(session: &mut SessionInfo, uri: &str) {
+        Self::delete_entry(session, uri, uri);
+    }
+
+    /// Helper for delete_path and delete_file_path
+    fn delete_entry(session: &mut SessionInfo, key: &str, uri: &str) {
+        let to_del = session.sync_odoo.get_file_mgr().borrow_mut().files.remove(key);
+        if let Some(to_del) = to_del {
+            if SyncOdoo::is_in_workspace_or_entry(session, uri) {
+                let mut to_del = (*to_del).borrow_mut();
+                to_del.replace_diagnostics(BuildSteps::SYNTAX, vec![]);
+                to_del.replace_diagnostics(BuildSteps::ARCH, vec![]);
+                to_del.replace_diagnostics(BuildSteps::ARCH_EVAL, vec![]);
+                to_del.replace_diagnostics(BuildSteps::VALIDATION, vec![]);
+                to_del.publish_diagnostics(session)
             }
         }
     }

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -134,7 +134,7 @@ impl PythonArchEval {
         session.st_mut().set_build_status(self.sym_stack[0], BuildSteps::ARCH_EVAL, BuildStatus::DONE);
         if session.st().is_external(self.sym_stack[0]) && (!self.file_mode  || !file_info_rc.borrow().opened) {
             if self.file_mode {
-                FileMgr::delete_path(session, &session.st().file_path(self.file).to_string());
+                FileMgr::delete_file_path(session, &session.st().file_path(self.file).to_string());
             }
         } else {
             if self.file_mode {

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -188,7 +188,8 @@ impl PythonValidator {
                 if !session.st().is_external(symbol) {
                     return;
                 }
-                FileMgr::delete_path(session, &session.st().paths(symbol)[0]);
+                let file = symbol.as_source_file_key().unwrap();
+                FileMgr::delete_file_path(session, &session.st().file_path(file).to_string());
             } else {
                 self.file_info.as_ref().unwrap().borrow_mut().publish_diagnostics(session);
             }


### PR DESCRIPTION
Iterating over all keys in `files` is unnecessary when you have the exact uri of a file (and defeats the whole purpose of a map).

```
════════════════════════════════════════════════════════════════
 Aggregated results (5 runs each, mean ± stddev)
════════════════════════════════════════════════════════════════
commit                user (s)           sys (s)     total CPU (s)          wall (s)       peak RSS (MB)
──────────  ────────────────  ────────────────  ────────────────  ────────────────  ──────────────────
2f818dcd       25.732 ± 0.086    4.024 ± 0.056   29.756 ± 0.057   29.746 ± 0.052       2744.2 ± 0.3
6567048d       22.632 ± 0.047    3.928 ± 0.023   26.560 ± 0.048   26.524 ± 0.039       2744.4 ± 0.1

Δ (after − before):
  user (s):              -3.100  (-12.05%)   z=31.7
  sys (s):               -0.096  ( -2.39%)   z=1.6
  total CPU (s):         -3.196  (-10.74%)   z=42.8
  wall (s):              -3.222  (-10.83%)   z=49.7
  peak RSS (MB):           +0.2  ( +0.01%)   z=0.6

z = |Δ| / sqrt(σ_before² + σ_after²) — rough significance:
  z > 3 : clearly significant   1 < z < 3 : suggestive   z < 1 : likely noise
════════════════════════════════════════════════════════════════
```