### PR TITLE
[FIX] fix pos only wrong diagnostic

### DIFF
--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -1764,8 +1764,8 @@ impl Evaluation {
                     }
                 }
             } else {
-                // if arg is None, it means that it is a **arg, which could replace all args (except pos-only args)
-                found_pos_arg_with_kw = number_pos_arg - pos_only_args.len() as i32;
+                // if arg is None, it means that it is a **arg, which could replace all args (except pos-only args, of which some could have been set already)
+                found_pos_arg_with_kw = number_pos_arg as i32 - (pos_only_args.len() as i32 - arg_index).max(0);
                 kword_only_args.clear();
             }
         }

--- a/server/tests/data/python/diagnostics/ols01007.py
+++ b/server/tests/data/python/diagnostics/ols01007.py
@@ -111,6 +111,7 @@ n(a=1, b=2, c=3, d=4) # OLS01011
 n(1, 2) # OLS01007
 n(1, 2, 3) # OLS01010
 n(1, 2, 3, 4, d=5) # OLS01007
+n(1, 2, **{})
 
 # Functions mixing defaults and varargs + keywords
 def o(a, b=1, *args, c, d=0):


### PR DESCRIPTION
Before already set pos only args were not counted when passing a **kwargs arg, raising a wrong diagnostic, this commit fixes that