### PR TITLE
Context type

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.102"
 clap = { version = "4.6.0", features = ["derive"] }
 glob = "0.3.3"
 regex = "1.12.3"
+thin-vec = "0.2.18"
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.15.0", version = "0.0.0" }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.0", version = "0.0.0" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff", tag = "0.15.0", version = "0.0.0" }

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -16,7 +16,8 @@ use ruff_python_ast::{
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use std::cmp::{max, min};
 use crate::utils::{HashMap, HashSet};
-use std::i32;
+use std::{i32, mem};
+use thin_vec::ThinVec;
 
 use super::file_mgr::FileMgr;
 use super::symbols::function_symbol::{Argument, ArgumentType};
@@ -115,6 +116,41 @@ impl ExprOrIdent<'_> {
 
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ContextKey {
+    Args,
+    BaseAttr,
+    BaseAttrInserted,
+    BaseCall,
+    BaseIsSelf,
+    Compute,
+    ComputeArgRange,
+    ComodelName,
+    ComodelNameArgRange,
+    ConstructingClass,
+    Default,
+    Delegate,
+    FieldParent,
+    IsAttrOfInstance,
+    IsInValidation,
+    Inverse,
+    InverseArgRange,
+    InverseName,
+    InverseNameArgRange,
+    Module,
+    Parameters,
+    ParentFor,
+    ParentInstance,
+    Range,
+    Related,
+    RelatedArgRange,
+    Required,
+    Search,
+    SearchArgRange,
+    // placeholder after removal
+    EMPTY,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ContextValue {
     BOOLEAN(bool),
@@ -122,7 +158,9 @@ pub enum ContextValue {
     MODULE(Wk<ModuleKey>),
     SYMBOL(Wk<SymbolKey>),
     ARGUMENTS(Arguments),
-    RANGE(TextRange)
+    RANGE(TextRange),
+    // empty value after removal
+    EMPTY,
 }
 
 impl ContextValue {
@@ -162,12 +200,96 @@ impl ContextValue {
     }
 }
 
-/** A context can contains: (non-exhaustive)
+/** A context can contain: (non-exhaustive)
 * module: the current module the file belongs to
 * parent: in an expression, like self.test, the parent is the base attribute, so 'self' for test
 * object: the object the expression is executed on (useful if function is defined in parent object).
 */
-pub type Context = HashMap<String, ContextValue>;
+#[derive(Debug, Clone, Default)]
+pub struct Context {
+    // ThinVec is a single pointer (8 B inline, x 24 B for a Vec), with no heap
+    // allocation while empty. Most contexts are empty.
+    entries: ThinVec<(ContextKey, ContextValue)>
+}
+
+impl PartialEq for Context {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().count() == other.iter().count()
+            && self.iter().all(|(k, v)| other.get(*k) == Some(v))
+    }
+}
+
+impl Context {
+    pub fn from_iter(entries: impl IntoIterator<Item = (ContextKey, ContextValue)>) -> Self {
+        Context { entries: entries.into_iter().collect() }
+    }
+
+    pub fn insert(&mut self, key: ContextKey, value: ContextValue) {
+        let mut empty_slot = None;
+        // update value if key already exists
+        for (i, (k, v)) in self.entries.iter_mut().enumerate() {
+            if *k == key {
+                *v = value;
+                return;
+            }
+            if empty_slot.is_none() && *k == ContextKey::EMPTY {
+                empty_slot = Some(i)
+            }
+        }
+        // otherwise, insert new entry
+        // reuse empty slot if any
+        if let Some(i) = empty_slot {
+            self.entries[i] = (key, value);
+        } else {
+            self.entries.push((key, value));
+        }
+    }
+
+    /// Removing an entry that was added last is (usually) more efficient.
+    pub fn remove(&mut self, key: ContextKey) -> Option<ContextValue> {
+        while let Some((k, _)) = self.entries.last() {
+            if *k == key {
+                // key matches last entry, simply pop it
+                return self.entries.pop().map(|(_, v)| v);
+            } else if *k == ContextKey::EMPTY {
+                // last entry is empty: clean it up and keep seaching
+                self.entries.pop();
+            } else {
+                break;
+            }
+        }
+        // We keep seaching in reverse order, skip last entry (it was checked above)
+        for (k, v) in self.entries.iter_mut().rev().skip(1) {
+            if *k == key {
+                *k = ContextKey::EMPTY; // mark as empty
+                let value = mem::replace(v, ContextValue::EMPTY);
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    pub fn get(&self, key: ContextKey) -> Option<&ContextValue> {
+        self.entries.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+    }
+
+    pub fn contains_key(&self, key: &ContextKey) -> bool {
+        self.entries.iter().any(|(k, _)| k == key)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(ContextKey, ContextValue)> {
+        self.entries.iter().filter(|(k, _)| *k != ContextKey::EMPTY)
+    }
+
+    /// Merges two Contexts into a new one.
+    /// When a key is present in both, value from `b` has precedence.
+    pub fn merge(a: &Self, b: &Self) -> Self {
+        let mut result = ThinVec::with_capacity(a.entries.len() + b.entries.len());
+        result.extend(a.iter().filter(|(key, _)| !b.contains_key(key)).cloned());
+        result.extend(b.iter().cloned());
+        Self { entries: result }
+    }
+}
 
 /**
  * A hook will receive:
@@ -202,10 +324,10 @@ pub struct EvaluationSymbolWeak {
 
 impl PartialEq for EvaluationSymbolWeak {
     fn eq(&self, other: &Self) -> bool {
-        self.context == other.context
-        && self.instance == other.instance
+        self.instance == other.instance
         && self.is_super == other.is_super
         && self.weak == other.weak
+        && self.context == other.context
     }
 }
 
@@ -213,7 +335,7 @@ impl EvaluationSymbolWeak {
     pub fn new(key: impl Into<Wk<SymbolKey>>, instance: Option<bool>, is_super: bool) -> Self {
         EvaluationSymbolWeak {
             weak: key.into(),
-            context: HashMap::default(),
+            context: Context::default(),
             instance,
             is_super
         }
@@ -279,7 +401,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_list(),
-                    context: HashMap::default(),
+                    context: Context::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -295,7 +417,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_tuple(),
-                    context: HashMap::default(),
+                    context: Context::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -311,7 +433,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_dict(),
-                    context: HashMap::default(),
+                    context: Context::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -327,7 +449,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: odoo.get_ts_set(),
-                    context: HashMap::default(),
+                    context: Context::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -384,7 +506,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak {
                     weak: symbol,
-                    context: HashMap::default(),
+                    context: Context::default(),
                     instance: Some(true),
                     is_super: false,
                 }),
@@ -529,7 +651,7 @@ impl Evaluation {
             symbol: EvaluationSymbol {
                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                     weak: symbol,
-                    context: HashMap::default(),
+                    context: Context::default(),
                     instance: instance,
                     is_super: false,
                 }),
@@ -567,9 +689,9 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from_iter([
-            (S!("module"), from_module),
-            (S!("range"), ContextValue::RANGE(ast.range()))
+        let mut context: Option<Context> = Some(Context::from_iter([
+            (ContextKey::Module, from_module),
+            (ContextKey::Range, ContextValue::RANGE(ast.range()))
         ]));
         let analyze_result = Evaluation::analyze_ast(session, &ExprOrIdent::Expr(ast), parent, max_infer, &mut context, for_annotation, required_dependencies);
         return (analyze_result.evaluations, analyze_result.diagnostics)
@@ -583,9 +705,9 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from_iter([
-            (S!("module"), from_module),
-            (S!("range"), ContextValue::RANGE(ast.range()))
+        let mut context: Option<Context> = Some(Context::from_iter([
+            (ContextKey::Module, from_module),
+            (ContextKey::Range, ContextValue::RANGE(ast.range()))
         ]));
         let value = Evaluation::analyze_ast(session, &ExprOrIdent::Expr(ast), parent, max_infer, &mut context, for_annotation, &mut vec![]);
         if value.evaluations.len() == 1 { //only handle strict evaluations
@@ -616,9 +738,9 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from_iter([
-            (S!("module"), from_module),
-            (S!("range"), ContextValue::RANGE(ast.range()))
+        let mut context: Option<Context> = Some(Context::from_iter([
+            (ContextKey::Module, from_module),
+            (ContextKey::Range, ContextValue::RANGE(ast.range()))
         ]));
         let value = Evaluation::analyze_ast(session, &ExprOrIdent::Expr(ast), parent, max_infer, &mut context, for_annotation, &mut vec![]);
         if value.evaluations.len() == 1 { //only handle strict evaluations
@@ -932,7 +1054,7 @@ impl Evaluation {
                                         symbol: EvaluationSymbol {
                                             sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{
                                                 weak: super_class,
-                                                context: HashMap::default(),
+                                                context: Context::default(),
                                                 instance,
                                                 is_super: true,
                                             }),
@@ -960,8 +1082,8 @@ impl Evaluation {
                                     //init will always return an instance of the class, so we are not searching the method to check its return type, but rather to check if there is
                                     //an hook on it. Hooks, can be used to use parameters for context (see relational fields for example).
                                     if init_eval.len() == 1 && init_eval[0].symbol.get_symbol_hook.is_some() {
-                                        context.as_mut().unwrap().insert(S!("constructing_class"), ContextValue::SYMBOL(base_sym.into()));
-                                        context.as_mut().unwrap().insert(S!("parameters"), ContextValue::ARGUMENTS(expr.arguments.clone()));
+                                        context.as_mut().unwrap().insert(ContextKey::ConstructingClass, ContextValue::SYMBOL(base_sym.into()));
+                                        context.as_mut().unwrap().insert(ContextKey::Parameters, ContextValue::ARGUMENTS(expr.arguments.clone()));
                                         found_hook = true;
                                         let init_eval_sym = init_eval[0].symbol.clone();
                                         // We disable evaluation search during the get_symbol call to avoid duplicating references.
@@ -971,8 +1093,8 @@ impl Evaluation {
                                         session.sync_odoo.evaluation_search = None;
                                         let init_result = init_eval_sym.get_symbol_as_weak(session, context, &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
                                         session.sync_odoo.evaluation_search = cache_eval_search;
-                                        context.as_mut().unwrap().remove("parameters");
-                                        context.as_mut().unwrap().remove("constructing_class");
+                                        context.as_mut().unwrap().remove(ContextKey::ConstructingClass);
+                                        context.as_mut().unwrap().remove(ContextKey::Parameters);
                                         evals.push(Evaluation {
                                             symbol: EvaluationSymbol {
                                                 sym: EvaluationSymbolPtr::WEAK(init_result),
@@ -999,7 +1121,7 @@ impl Evaluation {
                                         symbol: EvaluationSymbol {
                                             sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak {
                                                 weak: base_sym_weak_eval.weak,
-                                                context: HashMap::default(),
+                                                context: Context::default(),
                                                 instance: Some(true),
                                                 is_super: false,
                                             }),
@@ -1026,8 +1148,8 @@ impl Evaluation {
                             required_dependencies[2].push(base_sym_file);
                         }
                         let (call_parent, base_is_self) = match (
-                            base_sym_weak_eval.context.get("base_attr"),
-                            base_sym_weak_eval.context.get("base_is_self"),
+                            base_sym_weak_eval.context.get(ContextKey::BaseAttr),
+                            base_sym_weak_eval.context.get(ContextKey::BaseIsSelf),
                         )
                         {
                             (
@@ -1040,7 +1162,7 @@ impl Evaluation {
                             Evaluation::search_reference_in_arg(session, expr, parent);
                         }
                         if is_in_validation {
-                            let on_instance = base_sym_weak_eval.context.get("is_attr_of_instance").map(|v| v.as_bool());
+                            let on_instance = base_sym_weak_eval.context.get(ContextKey::IsAttrOfInstance).map(|v| v.as_bool());
                             call_argument_diagnostics.last_mut().unwrap().extend(Evaluation::validate_call_arguments(session,
                                 f,
                                 expr,
@@ -1049,10 +1171,10 @@ impl Evaluation {
                                 on_instance,
                             ));
                         }
-                        context.as_mut().unwrap().insert(S!("base_call"), ContextValue::SYMBOL(call_parent));
-                        context.as_mut().unwrap().insert(S!("base_is_self"), ContextValue::BOOLEAN(base_is_self));
-                        context.as_mut().unwrap().insert(S!("parameters"), ContextValue::ARGUMENTS(expr.arguments.clone()));
-                        context.as_mut().unwrap().insert(S!("is_in_validation"), ContextValue::BOOLEAN(is_in_validation));
+                        context.as_mut().unwrap().insert(ContextKey::BaseCall, ContextValue::SYMBOL(call_parent));
+                        context.as_mut().unwrap().insert(ContextKey::BaseIsSelf, ContextValue::BOOLEAN(base_is_self));
+                        context.as_mut().unwrap().insert(ContextKey::Parameters, ContextValue::ARGUMENTS(expr.arguments.clone()));
+                        context.as_mut().unwrap().insert(ContextKey::IsInValidation, ContextValue::BOOLEAN(is_in_validation));
                         let evaluations = &session.st()[f].evaluations;
                         for eval in evaluations.clone() {
                             let eval_ptr = eval.symbol.get_symbol_weak_transformed(session, context, &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
@@ -1065,10 +1187,11 @@ impl Evaluation {
                                 range: Some(expr.range)
                             });
                         }
-                        context.as_mut().unwrap().remove("base_call");
-                        context.as_mut().unwrap().remove("base_is_self");
-                        context.as_mut().unwrap().remove("parameters");
-                        context.as_mut().unwrap().remove("is_in_validation");
+                        // removing in reverse order is more efficient
+                        context.as_mut().unwrap().remove(ContextKey::IsInValidation);
+                        context.as_mut().unwrap().remove(ContextKey::Parameters);
+                        context.as_mut().unwrap().remove(ContextKey::BaseIsSelf);
+                        context.as_mut().unwrap().remove(ContextKey::BaseCall);
                     }
                 }
                 diagnostics.extend(Evaluation::process_argument_diagnostics(&session, expr, call_argument_diagnostics, base_eval_ptrs.len()));
@@ -1125,9 +1248,9 @@ impl Evaluation {
                                     let mut eval = Evaluation::eval_from_symbol(session.st(), attribute, instance);
                                     match eval.symbol.sym {
                                         EvaluationSymbolPtr::WEAK(ref mut weak) => {
-                                            weak.context.insert(S!("base_attr"), ContextValue::SYMBOL(base_loc.into()));
-                                            weak.context.insert(S!("base_is_self"), ContextValue::BOOLEAN(base_is_self));
-                                            weak.context.insert(S!("is_attr_of_instance"), ContextValue::BOOLEAN(is_instance));
+                                            weak.context.insert(ContextKey::BaseAttr, ContextValue::SYMBOL(base_loc.into()));
+                                            weak.context.insert(ContextKey::BaseIsSelf, ContextValue::BOOLEAN(base_is_self));
+                                            weak.context.insert(ContextKey::IsAttrOfInstance, ContextValue::BOOLEAN(is_instance));
                                         },
                                         _ => {}
                                     }
@@ -1255,11 +1378,11 @@ impl Evaluation {
                         for get_item_eval in evaluations.clone() {
                             if let Some(hook) = get_item_eval.symbol.get_symbol_hook.as_ref() {
                                 if let Some(value) = &value.0 {
-                                    context.as_mut().unwrap().insert(S!("args"), ContextValue::STRING(value.clone()));
+                                    context.as_mut().unwrap().insert(ContextKey::Args, ContextValue::STRING(value.clone()));
                                 }
-                                let old_range = context.as_mut().unwrap().remove("range");
-                                context.as_mut().unwrap().insert(S!("range"), ContextValue::RANGE(sub.slice.range()));
-                                context.as_mut().unwrap().insert(S!("is_in_validation"), ContextValue::BOOLEAN(is_in_validation));
+                                let old_range = context.as_mut().unwrap().remove(ContextKey::Range);
+                                context.as_mut().unwrap().insert(ContextKey::Range, ContextValue::RANGE(sub.slice.range()));
+                                context.as_mut().unwrap().insert(ContextKey::IsInValidation, ContextValue::BOOLEAN(is_in_validation));
                                 let hook_result = (hook.callable)(session, &get_item_eval.symbol, context, &mut diagnostics, Some(parent));
                                 if let Some(hook_result) = hook_result {
                                     match hook_result {
@@ -1273,16 +1396,16 @@ impl Evaluation {
                                         }
                                     }
                                 }
-                                context.as_mut().unwrap().remove("args");
-                                context.as_mut().unwrap().remove("is_in_validation");
-                                context.as_mut().unwrap().insert(S!("range"), old_range.unwrap());
+                                context.as_mut().unwrap().remove(ContextKey::Args);
+                                context.as_mut().unwrap().remove(ContextKey::IsInValidation);
+                                context.as_mut().unwrap().insert(ContextKey::Range, old_range.unwrap());
                             }
                             if let EvaluationSymbolPtr::SELF(_) = get_item_eval.symbol.get_symbol_ptr() {
                                 // Evaluate to the base itself
                                 // For example for models, since you get the same type of recordset when subscripted
                                 evals.push(Evaluation{
                                     symbol: EvaluationSymbol {
-                                        sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: base.into(), context: HashMap::default(), instance: Some(true), is_super: false}),
+                                        sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: base.into(), context: Context::default(), instance: Some(true), is_super: false}),
                                         get_symbol_hook: None,
                                     },
                                     value: None,
@@ -1321,7 +1444,7 @@ impl Evaluation {
                             symbol: EvaluationSymbol {
                                 sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                                     weak: odoo.get_ts_boolean(),
-                                    context: HashMap::default(),
+                                    context: Context::default(),
                                     instance: Some(true),
                                     is_super: false,
                                 }),
@@ -1371,7 +1494,7 @@ impl Evaluation {
                         symbol: EvaluationSymbol {
                             sym: EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{
                                 weak: odoo.get_ts_string(),
-                                context: HashMap::default(),
+                                context: Context::default(),
                                 instance: Some(true),
                                 is_super: false,
                             }),
@@ -2013,7 +2136,7 @@ impl EvaluationSymbol {
 
     pub fn new_self(get_symbol_hook: Option<GetSymbolHook>, base: Wk<SymbolKey>, instance: Option<bool>) -> EvaluationSymbol {
         Self {
-            sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{weak: base, context: HashMap::default(), instance, is_super: false}),
+            sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{weak: base, context: Context::default(), instance, is_super: false}),
             get_symbol_hook,
         }
     }
@@ -2054,14 +2177,14 @@ impl EvaluationSymbol {
             | EvaluationSymbolPtr::ARG(_)
             | EvaluationSymbolPtr::NONE
             | EvaluationSymbolPtr::UNBOUND(_)
-            | EvaluationSymbolPtr::DOMAIN => EvaluationSymbolWeak{ weak: Wk::null(), context: HashMap::default(), instance: Some(false), is_super: false },
+            | EvaluationSymbolPtr::DOMAIN => EvaluationSymbolWeak{ weak: Wk::null(), context: Context::default(), instance: Some(false), is_super: false },
             EvaluationSymbolPtr::SELF(_) => {
                 let class = context.as_ref().
-                and_then(|context| context.get("parent_for").or(context.get("base_attr")))
+                and_then(|context| context.get(ContextKey::ParentFor).or(context.get(ContextKey::BaseAttr)))
                 .unwrap_or(&ContextValue::BOOLEAN(false));
                 match class {
-                    ContextValue::SYMBOL(s) => EvaluationSymbolWeak{weak: *s, context: HashMap::default(), instance: Some(true), is_super: false},
-                    _ => EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::default(), instance: Some(false), is_super: false}
+                    ContextValue::SYMBOL(s) => EvaluationSymbolWeak{weak: *s, context: Context::default(), instance: Some(true), is_super: false},
+                    _ => EvaluationSymbolWeak{weak: Wk::null(), context: Context::default(), instance: Some(false), is_super: false}
                 }
             }
         }
@@ -2080,8 +2203,8 @@ impl EvaluationSymbol {
             EvaluationSymbolPtr::UNBOUND(_) => eval,
             EvaluationSymbolPtr::DOMAIN => eval,
             EvaluationSymbolPtr::SELF(_) => {
-                let default = EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::default(), instance: Some(false), is_super: false});
-                let class = context.as_ref().and_then(|context| context.get("base_call")).unwrap_or(&ContextValue::BOOLEAN(false));
+                let default = EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: Context::default(), instance: Some(false), is_super: false});
+                let class = context.as_ref().and_then(|context| context.get(ContextKey::BaseCall)).unwrap_or(&ContextValue::BOOLEAN(false));
                 let class_sym = match class {
                     ContextValue::SYMBOL(s) => match s.upgrade(&session.sync_odoo.symbol_table) {
                         Some(sym) => sym,
@@ -2089,10 +2212,10 @@ impl EvaluationSymbol {
                     },
                     _ => {return default;}
                 };
-                let eval_symbol_weak = EvaluationSymbolWeak{weak: class_sym.into(), context: HashMap::default(), instance: Some(true), is_super: false};
+                let eval_symbol_weak = EvaluationSymbolWeak{weak: class_sym.into(), context: Context::default(), instance: Some(true), is_super: false};
                 let base_is_self = context
                     .as_ref()
-                    .and_then(|context| context.get("base_is_self"))
+                    .and_then(|context| context.get(ContextKey::BaseIsSelf))
                     .unwrap_or(&ContextValue::BOOLEAN(false))
                     .as_bool();
                 if base_is_self {

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -5,7 +5,6 @@ use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::{FunctionSymbol, VariableSymbol};
 use crate::features::references::ReferenceTarget;
 use crate::threads::SessionInfo;
-use crate::S;
 use crate::{constants::*, Sy};
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
@@ -1109,7 +1108,7 @@ impl Evaluation {
                                     }
                                 }
                                 //1: find __init__ method
-                                let init = SymbolTable::get_member_symbol(session, base_sym, &S!("__init__"), module, true, false, false, false, false);
+                                let init = SymbolTable::get_member_symbol(session, base_sym, "__init__", module, true, false, false, false, false);
                                 let mut found_hook = false;
                                 if let Some(&SymbolKey::Function(init)) = init.0.first() {
                                     SyncOdoo::ensure_func_evaluations(session, init);
@@ -1398,7 +1397,7 @@ impl Evaluation {
                     let get_item_symbols = SymbolTable::get_member_symbol(
                         session,
                         base,
-                        &S!("__getitem__"),
+                        "__getitem__",
                         session.st().find_module(parent),
                         false,
                         false,
@@ -1505,7 +1504,7 @@ impl Evaluation {
                     for base_eval_ptr in base_eval_ptrs.iter() {
                         let EvaluationSymbolPtr::WEAK(base_sym_weak_eval) = base_eval_ptr else {continue};
                         let Some(base_sym) = base_sym_weak_eval.weak.upgrade(session.st()) else {continue};
-                        let (operator_functions, diags) = SymbolTable::get_member_symbol(session, base_sym, &S!(method), module, true, false, true, false, false);
+                        let (operator_functions, diags) = SymbolTable::get_member_symbol(session, base_sym, method, module, true, false, true, false, false);
                         diagnostics.extend(diags);
                         for operator_function in operator_functions.into_iter() {
                             for eval in session.st().evaluations(operator_function).unwrap_or(&vec![]).clone() {

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -1,4 +1,5 @@
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
+use crate::core::evaluation_context::{Context, ContextKey, ContextValue};
 use crate::core::odoo::SyncOdoo;
 use crate::core::symbols::symbol_keys::{FunctionKey, KeyValidator, ModuleKey, SourceFileKey, SymbolKey, Wk};
 use crate::core::symbols::storage::SymbolTable;
@@ -10,13 +11,12 @@ use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
 use lsp_types::{Diagnostic, Location, Position, Range};
 use ruff_python_ast::{
-    Arguments, Expr, ExprCall, FStringPart, Identifier, Number, Parameter, UnaryOp,
+    Expr, ExprCall, FStringPart, Identifier, Number, Parameter, UnaryOp,
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use std::cmp::{max, min};
 use crate::utils::{HashMap, HashSet};
-use std::{i32, mem};
-use thin_vec::ThinVec;
+use std::i32;
 
 use super::file_mgr::FileMgr;
 use super::symbols::function_symbol::{Argument, ArgumentType};
@@ -135,181 +135,6 @@ impl ExprOrIdent<'_> {
         }
     }
 
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ContextKey {
-    Args,
-    BaseAttr,
-    BaseAttrInserted,
-    BaseCall,
-    BaseIsSelf,
-    Compute,
-    ComputeArgRange,
-    ComodelName,
-    ComodelNameArgRange,
-    ConstructingClass,
-    Default,
-    Delegate,
-    FieldParent,
-    IsAttrOfInstance,
-    IsInValidation,
-    Inverse,
-    InverseArgRange,
-    InverseName,
-    InverseNameArgRange,
-    Module,
-    Parameters,
-    ParentFor,
-    ParentInstance,
-    Range,
-    Related,
-    RelatedArgRange,
-    Required,
-    Search,
-    SearchArgRange,
-    // placeholder after removal
-    EMPTY,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum ContextValue {
-    BOOLEAN(bool),
-    STRING(String),
-    MODULE(Wk<ModuleKey>),
-    SYMBOL(Wk<SymbolKey>),
-    ARGUMENTS(Arguments),
-    RANGE(TextRange),
-    // empty value after removal
-    EMPTY,
-}
-
-impl ContextValue {
-    pub fn as_bool(&self) -> bool {
-        match self {
-            ContextValue::BOOLEAN(b) => *b,
-            _ => panic!("Not a boolean")
-        }
-    }
-
-    pub fn as_str(&self) -> &str {
-        match self {
-            ContextValue::STRING(s) => s,
-            _ => panic!("Not a string")
-        }
-    }
-
-    pub fn as_symbol(&self) -> Wk<SymbolKey> {
-        match self {
-            ContextValue::SYMBOL(s) => *s,
-            _ => panic!("Not a symbol")
-        }
-    }
-
-    pub fn as_text_range(&self) -> TextRange {
-        match self {
-            ContextValue::RANGE(r) => r.clone(),
-            _ => panic!("Not a TextRange")
-        }
-    }
-
-    pub fn as_arguments(&self) -> Arguments {
-        match self {
-            ContextValue::ARGUMENTS(a) => a.clone(),
-            _ => panic!("Not an arguments")
-        }
-    }
-}
-
-/** A context can contain: (non-exhaustive)
-* module: the current module the file belongs to
-* parent: in an expression, like self.test, the parent is the base attribute, so 'self' for test
-* object: the object the expression is executed on (useful if function is defined in parent object).
-*/
-#[derive(Debug, Clone, Default)]
-pub struct Context {
-    // ThinVec is a single pointer (8 B inline, x 24 B for a Vec), with no heap
-    // allocation while empty. Most contexts are empty.
-    entries: ThinVec<(ContextKey, ContextValue)>
-}
-
-impl PartialEq for Context {
-    fn eq(&self, other: &Self) -> bool {
-        self.iter().count() == other.iter().count()
-            && self.iter().all(|(k, v)| other.get(*k) == Some(v))
-    }
-}
-
-impl Context {
-    pub fn from_iter(entries: impl IntoIterator<Item = (ContextKey, ContextValue)>) -> Self {
-        Context { entries: entries.into_iter().collect() }
-    }
-
-    pub fn insert(&mut self, key: ContextKey, value: ContextValue) {
-        let mut empty_slot = None;
-        // update value if key already exists
-        for (i, (k, v)) in self.entries.iter_mut().enumerate() {
-            if *k == key {
-                *v = value;
-                return;
-            }
-            if empty_slot.is_none() && *k == ContextKey::EMPTY {
-                empty_slot = Some(i)
-            }
-        }
-        // otherwise, insert new entry
-        // reuse empty slot if any
-        if let Some(i) = empty_slot {
-            self.entries[i] = (key, value);
-        } else {
-            self.entries.push((key, value));
-        }
-    }
-
-    /// Removing an entry that was added last is (usually) more efficient.
-    pub fn remove(&mut self, key: ContextKey) -> Option<ContextValue> {
-        while let Some((k, _)) = self.entries.last() {
-            if *k == key {
-                // key matches last entry, simply pop it
-                return self.entries.pop().map(|(_, v)| v);
-            } else if *k == ContextKey::EMPTY {
-                // last entry is empty: clean it up and keep seaching
-                self.entries.pop();
-            } else {
-                break;
-            }
-        }
-        // We keep seaching in reverse order, skip last entry (it was checked above)
-        for (k, v) in self.entries.iter_mut().rev().skip(1) {
-            if *k == key {
-                *k = ContextKey::EMPTY; // mark as empty
-                let value = mem::replace(v, ContextValue::EMPTY);
-                return Some(value);
-            }
-        }
-        None
-    }
-
-    pub fn get(&self, key: ContextKey) -> Option<&ContextValue> {
-        self.entries.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
-    }
-
-    pub fn contains_key(&self, key: &ContextKey) -> bool {
-        self.entries.iter().any(|(k, _)| k == key)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &(ContextKey, ContextValue)> {
-        self.entries.iter().filter(|(k, _)| *k != ContextKey::EMPTY)
-    }
-
-    /// Merges two Contexts into a new one.
-    /// When a key is present in both, value from `b` has precedence.
-    pub fn merge(a: &Self, b: &Self) -> Self {
-        let mut result = ThinVec::with_capacity(a.entries.len() + b.entries.len());
-        result.extend(a.iter().filter(|(key, _)| !b.contains_key(key)).cloned());
-        result.extend(b.iter().cloned());
-        Self { entries: result }
-    }
 }
 
 /**

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -26,7 +26,7 @@ use super::symbols::symbol_mgr::SectionIndex;
 #[derive(Debug, Clone, PartialEq)]
 pub enum EvaluationValue {
     ANY(), //we don't know what it is, so it can be everything !
-    CONSTANT(ruff_python_ast::Expr), //expr is a literal
+    CONSTANT(Box<ruff_python_ast::Expr>), //expr is a literal
     DICT(Vec<(ruff_python_ast::Expr, ruff_python_ast::Expr)>), //expr is a literal
     LIST(Vec<ruff_python_ast::Expr>), //expr is a literal
     TUPLE(Vec<ruff_python_ast::Expr>) //expr is a literal
@@ -44,6 +44,28 @@ impl EvaluationValue {
         match self {
             EvaluationValue::CONSTANT(e) => e,
             _ => panic!("Not a constant")
+        }
+    }
+
+    /// Returns the inner string literal if this is a `CONSTANT(Expr::StringLiteral(_))`.
+    pub fn as_string_literal(&self) -> Option<&ruff_python_ast::ExprStringLiteral> {
+        match self {
+            EvaluationValue::CONSTANT(e) => match e.as_ref() {
+                Expr::StringLiteral(s) => Some(s),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Returns the boolean value if this is a `CONSTANT(Expr::BooleanLiteral(_))`.
+    pub fn as_bool_literal(&self) -> Option<bool> {
+        match self {
+            EvaluationValue::CONSTANT(e) => match e.as_ref() {
+                Expr::BooleanLiteral(b) => Some(b.value),
+                _ => None,
+            },
+            _ => None,
         }
     }
 
@@ -495,7 +517,7 @@ impl Evaluation {
             Expr::NoneLiteral(_n) => {
                 let mut eval = Evaluation::new_none();
                 eval.range = Some(range);
-                eval.value = Some(EvaluationValue::CONSTANT(values));
+                eval.value = Some(EvaluationValue::CONSTANT(Box::new(values)));
                 return eval
             }
             _ => {
@@ -512,7 +534,7 @@ impl Evaluation {
                 }),
                 get_symbol_hook: None
             },
-            value: Some(EvaluationValue::CONSTANT(values)),
+            value: Some(EvaluationValue::CONSTANT(Box::new(values))),
             range: Some(range)
         }
     }
@@ -716,7 +738,7 @@ impl Evaluation {
             if let Some(v) = v {
                 match v {
                     EvaluationValue::CONSTANT(v) => {
-                        match v {
+                        match *v {
                             Expr::StringLiteral(s) => {
                                 return (Some(s.value.to_string()), value.diagnostics);
                             },
@@ -749,7 +771,7 @@ impl Evaluation {
             if let Some(v) = v {
                 match v {
                     EvaluationValue::CONSTANT(v) => {
-                        match v {
+                        match *v {
                             Expr::BooleanLiteral(s) => {
                                 return (Some(s.value), value.diagnostics);
                             },
@@ -1673,8 +1695,8 @@ impl Evaluation {
                     }
                 }
                 if let Some(value) = eval.value.as_ref() {
-                    match value {
-                        EvaluationValue::CONSTANT(Expr::StringLiteral(constant)) => {
+                    if let EvaluationValue::CONSTANT(c) = value {
+                        if let Expr::StringLiteral(constant) = c.as_ref() {
                             match evaluation_search {
                                 ReferenceTarget::String(evaluation_search_string) => {
                                     if constant.value.to_str() == evaluation_search_string {
@@ -1691,8 +1713,7 @@ impl Evaluation {
                                     }
                                 }
                             }
-                        },
-                        _ => {}
+                        }
                     }
                 }
             }

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -326,8 +326,21 @@ type GetSymbolHookCallable = fn (session: &mut SessionInfo, eval: &EvaluationSym
 #[derive(Debug, Clone)]
 pub struct GetSymbolHook {
     pub callable: GetSymbolHookCallable,
-    pub name: String
+    pub name: HookName,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum HookName {
+    EvalEnvGetItem,
+    EvalRegistryGetItem,
+    EvalInit,
+    EvalGet,
+    EvalRelational,
+    EvalInitRelational,
+    EvalInitRelationalOne2many,
+    EvalEnvRef,
+}
+
 
 impl PartialEq for GetSymbolHook {
     fn eq(&self, other: &Self) -> bool {

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -320,7 +320,7 @@ impl Context {
  * diagnostics: a vec the hook can fill to add diagnostics
  * file_symbol: if provided, can be used to add dependencies
  */
-type GetSymbolHookCallable = fn (session: &mut SessionInfo, eval: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>;
+type GetSymbolHookCallable = fn (session: &mut SessionInfo, eval: &EvaluationSymbol, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>;
 
 #[derive(Debug, Clone)]
 pub struct GetSymbolHook {
@@ -597,8 +597,8 @@ impl Evaluation {
         match self.symbol.sym {
             EvaluationSymbolPtr::WEAK(_) => {
                 //take the weak by get_symbol instead of the match
-                let symbol_eval = self.symbol.get_symbol(session, &mut None, &mut vec![], Some(function.into()));
-                let out_of_scope = SymbolTable::follow_ref(&symbol_eval, session, &mut None, false, false, None, Some(function.into()));
+                let symbol_eval = self.symbol.get_symbol(session, None, &mut vec![], Some(function.into()));
+                let out_of_scope = SymbolTable::follow_ref(&symbol_eval, session, None, false, false, None, Some(function.into()));
                 for sym in out_of_scope {
                     if !sym.is_expired_if_weak(&session.sync_odoo.symbol_table) {
                         res.push(Evaluation {
@@ -619,11 +619,11 @@ impl Evaluation {
         res
     }
 
-    pub fn follow_ref_and_get_value(&self, session: &mut SessionInfo, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>) -> Option<EvaluationValue> {
+    pub fn follow_ref_and_get_value(&self, session: &mut SessionInfo, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>) -> Option<EvaluationValue> {
         if self.value.is_some() {
             return Some(self.value.as_ref().unwrap().clone())
         }
-        let eval_symbol = self.symbol.get_symbol(session, &mut None, diagnostics, None);
+        let eval_symbol = self.symbol.get_symbol(session, None, diagnostics, None);
         if eval_symbol.is_expired_if_weak(session.st()) {
             return None;
         }
@@ -723,10 +723,10 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(Context::from_iter([
+        let mut context = Context::from_iter([
             (ContextKey::Module, from_module),
             (ContextKey::Range, ContextValue::RANGE(ast.range()))
-        ]));
+        ]);
         let analyze_result = Evaluation::analyze_ast(session, &ExprOrIdent::Expr(ast), parent, max_infer, &mut context, for_annotation, required_dependencies);
         return (analyze_result.evaluations, analyze_result.diagnostics)
     }
@@ -739,14 +739,14 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(Context::from_iter([
+        let mut context = Context::from_iter([
             (ContextKey::Module, from_module),
             (ContextKey::Range, ContextValue::RANGE(ast.range()))
-        ]));
+        ]);
         let value = Evaluation::analyze_ast(session, &ExprOrIdent::Expr(ast), parent, max_infer, &mut context, for_annotation, &mut vec![]);
         if value.evaluations.len() == 1 { //only handle strict evaluations
             let eval = &value.evaluations[0];
-            let v = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
+            let v = eval.follow_ref_and_get_value(session, None, diagnostics);
             if let Some(v) = v {
                 match v {
                     EvaluationValue::CONSTANT(v) => {
@@ -772,14 +772,14 @@ impl Evaluation {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(Context::from_iter([
+        let mut context = Context::from_iter([
             (ContextKey::Module, from_module),
             (ContextKey::Range, ContextValue::RANGE(ast.range()))
-        ]));
+        ]);
         let value = Evaluation::analyze_ast(session, &ExprOrIdent::Expr(ast), parent, max_infer, &mut context, for_annotation, &mut vec![]);
         if value.evaluations.len() == 1 { //only handle strict evaluations
             let eval = &value.evaluations[0];
-            let v = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
+            let v = eval.follow_ref_and_get_value(session, None, diagnostics);
             if let Some(v) = v {
                 match v {
                     EvaluationValue::CONSTANT(v) => {
@@ -821,7 +821,7 @@ impl Evaluation {
         context: {}
         diagnostics: vec![]
      */
-    pub fn analyze_ast(session: &mut SessionInfo, ast: &ExprOrIdent, parent: SymbolKey, max_infer: &TextSize, context: &mut Option<Context>, for_annotation: bool, required_dependencies: &mut Vec<Vec<SourceFileKey>>) -> AnalyzeAstResult {
+    pub fn analyze_ast(session: &mut SessionInfo, ast: &ExprOrIdent, parent: SymbolKey, max_infer: &TextSize, context: &mut Context, for_annotation: bool, required_dependencies: &mut Vec<Vec<SourceFileKey>>) -> AnalyzeAstResult {
         let mut evals = vec![];
         let mut diagnostics = vec![];
         let module = session.st().find_module(parent);
@@ -990,8 +990,8 @@ impl Evaluation {
                     return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                 }
                 let base_eval_ptrs: Vec<EvaluationSymbolPtr> = base_evals.iter().map(|base_eval| {
-                    let base_sym_weak_eval_base = base_eval.symbol.get_symbol(session, context, &mut diagnostics, None);
-                    SymbolTable::follow_ref(&base_sym_weak_eval_base, session, context, true, false, None, None)
+                    let base_sym_weak_eval_base = base_eval.symbol.get_symbol(session, Some(context), &mut diagnostics, None);
+                    SymbolTable::follow_ref(&base_sym_weak_eval_base, session, Some(context), true, false, None, None)
                 }).flatten().collect();
 
                 let mut call_argument_diagnostics = Vec::new();
@@ -1011,11 +1011,11 @@ impl Evaluation {
                                     if class_eval.len() != 1 {
                                         return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                                     }
-                                    let class_sym_weak_eval= class_eval[0].symbol.get_symbol_as_weak(session, context, &mut diagnostics, None);
+                                    let class_sym_weak_eval= class_eval[0].symbol.get_symbol_as_weak(session, Some(context), &mut diagnostics, None);
                                     let res = class_sym_weak_eval.weak.upgrade(session.st()).and_then(|class_sym|{
                                         let class_sym_weak_eval = &SymbolTable::follow_ref(&EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(
                                             class_sym, None, false
-                                        )), session, &mut None, false, false, None, None)[0];
+                                        )), session, None, false, false, None, None)[0];
                                         if !matches!(class_sym_weak_eval.upgrade_weak(session.st()).unwrap(), SymbolKey::Class(_)) {
                                             return None;
                                         }
@@ -1043,8 +1043,8 @@ impl Evaluation {
                                                 }
                                                 let object_or_type_weak_eval = &SymbolTable::follow_ref(
                                                     &object_or_type_eval[0].symbol.get_symbol(
-                                                        session, context, &mut diagnostics, Some(parent)),
-                                                        session, &mut None, false, false, None, None)[0];
+                                                        session, Some(context), &mut diagnostics, Some(parent)),
+                                                        session, None, false, false, None, None)[0];
                                                 if object_or_type_weak_eval.has_weak() {
                                                     is_instance = Some(object_or_type_weak_eval.get_weak().instance.unwrap_or(default_instance));
                                                 } else {
@@ -1116,8 +1116,8 @@ impl Evaluation {
                                     //init will always return an instance of the class, so we are not searching the method to check its return type, but rather to check if there is
                                     //an hook on it. Hooks, can be used to use parameters for context (see relational fields for example).
                                     if init_eval.len() == 1 && init_eval[0].symbol.get_symbol_hook.is_some() {
-                                        context.as_mut().unwrap().insert(ContextKey::ConstructingClass, ContextValue::SYMBOL(base_sym.into()));
-                                        context.as_mut().unwrap().insert(ContextKey::Parameters, ContextValue::ARGUMENTS(expr.arguments.clone()));
+                                        context.insert(ContextKey::ConstructingClass, ContextValue::SYMBOL(base_sym.into()));
+                                        context.insert(ContextKey::Parameters, ContextValue::ARGUMENTS(expr.arguments.clone()));
                                         found_hook = true;
                                         let init_eval_sym = init_eval[0].symbol.clone();
                                         // We disable evaluation search during the get_symbol call to avoid duplicating references.
@@ -1125,10 +1125,10 @@ impl Evaluation {
                                         // So any call in the hooks that calls analyze_ast will not contaminate the evaluation search.
                                         let cache_eval_search = session.sync_odoo.evaluation_search.clone();
                                         session.sync_odoo.evaluation_search = None;
-                                        let init_result = init_eval_sym.get_symbol_as_weak(session, context, &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
+                                        let init_result = init_eval_sym.get_symbol_as_weak(session, Some(context), &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
                                         session.sync_odoo.evaluation_search = cache_eval_search;
-                                        context.as_mut().unwrap().remove(ContextKey::ConstructingClass);
-                                        context.as_mut().unwrap().remove(ContextKey::Parameters);
+                                        context.remove(ContextKey::ConstructingClass);
+                                        context.remove(ContextKey::Parameters);
                                         evals.push(Evaluation {
                                             symbol: EvaluationSymbol {
                                                 sym: EvaluationSymbolPtr::WEAK(init_result),
@@ -1205,13 +1205,13 @@ impl Evaluation {
                                 on_instance,
                             ));
                         }
-                        context.as_mut().unwrap().insert(ContextKey::BaseCall, ContextValue::SYMBOL(call_parent));
-                        context.as_mut().unwrap().insert(ContextKey::BaseIsSelf, ContextValue::BOOLEAN(base_is_self));
-                        context.as_mut().unwrap().insert(ContextKey::Parameters, ContextValue::ARGUMENTS(expr.arguments.clone()));
-                        context.as_mut().unwrap().insert(ContextKey::IsInValidation, ContextValue::BOOLEAN(is_in_validation));
+                        context.insert(ContextKey::BaseCall, ContextValue::SYMBOL(call_parent));
+                        context.insert(ContextKey::BaseIsSelf, ContextValue::BOOLEAN(base_is_self));
+                        context.insert(ContextKey::Parameters, ContextValue::ARGUMENTS(expr.arguments.clone()));
+                        context.insert(ContextKey::IsInValidation, ContextValue::BOOLEAN(is_in_validation));
                         let evaluations = &session.st()[f].evaluations;
                         for eval in evaluations.clone() {
-                            let eval_ptr = eval.symbol.get_symbol_weak_transformed(session, context, &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
+                            let eval_ptr = eval.symbol.get_symbol_weak_transformed(session, Some(context), &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
                             evals.push(Evaluation{
                                 symbol: EvaluationSymbol {
                                     sym: eval_ptr,
@@ -1222,10 +1222,10 @@ impl Evaluation {
                             });
                         }
                         // removing in reverse order is more efficient
-                        context.as_mut().unwrap().remove(ContextKey::IsInValidation);
-                        context.as_mut().unwrap().remove(ContextKey::Parameters);
-                        context.as_mut().unwrap().remove(ContextKey::BaseIsSelf);
-                        context.as_mut().unwrap().remove(ContextKey::BaseCall);
+                        context.remove(ContextKey::IsInValidation);
+                        context.remove(ContextKey::Parameters);
+                        context.remove(ContextKey::BaseIsSelf);
+                        context.remove(ContextKey::BaseCall);
                     }
                 }
                 diagnostics.extend(Evaluation::process_argument_diagnostics(&session, expr, call_argument_diagnostics, base_eval_ptrs.len()));
@@ -1237,11 +1237,11 @@ impl Evaluation {
                     return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                 }
                 for base_eval in base_evals.iter() {
-                    let base_ref = base_eval.symbol.get_symbol(session, context, &mut diagnostics, Some(parent));
+                    let base_ref = base_eval.symbol.get_symbol(session, Some(context), &mut diagnostics, Some(parent));
                     if base_ref.is_expired_if_weak(session.st()) {
                         return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                     }
-                    let bases = SymbolTable::follow_ref(&base_ref, session, context, false, false, None, None);
+                    let bases = SymbolTable::follow_ref(&base_ref, session, Some(context), false, false, None, None);
                     for ibase in bases.iter() {
                         let base_is_self = matches!(ibase, EvaluationSymbolPtr::SELF(_));
                         let base_loc = ibase.upgrade_weak(session.st());
@@ -1360,11 +1360,11 @@ impl Evaluation {
                 if eval_left.is_empty() {
                     return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                 }
-                let base = &eval_left[0].symbol.get_symbol(session, context, &mut diagnostics, Some(parent));
+                let base = &eval_left[0].symbol.get_symbol(session, Some(context), &mut diagnostics, Some(parent));
                 if base.is_expired_if_weak(session.st()) {
                     return AnalyzeAstResult::from_only_diagnostics(diagnostics);
                 }
-                let bases = SymbolTable::follow_ref(&base, session, &mut None, false, false, None, None);
+                let bases = SymbolTable::follow_ref(&base, session, None, false, false, None, None);
                 let value = Evaluation::expr_to_str(session, &sub.slice, parent, max_infer, false, &mut diagnostics);
                 diagnostics.extend(value.1);
                 for base in bases.iter() {
@@ -1412,12 +1412,12 @@ impl Evaluation {
                         for get_item_eval in evaluations.clone() {
                             if let Some(hook) = get_item_eval.symbol.get_symbol_hook.as_ref() {
                                 if let Some(value) = &value.0 {
-                                    context.as_mut().unwrap().insert(ContextKey::Args, ContextValue::STRING(value.clone()));
+                                    context.insert(ContextKey::Args, ContextValue::STRING(value.clone()));
                                 }
-                                let old_range = context.as_mut().unwrap().remove(ContextKey::Range);
-                                context.as_mut().unwrap().insert(ContextKey::Range, ContextValue::RANGE(sub.slice.range()));
-                                context.as_mut().unwrap().insert(ContextKey::IsInValidation, ContextValue::BOOLEAN(is_in_validation));
-                                let hook_result = (hook.callable)(session, &get_item_eval.symbol, context, &mut diagnostics, Some(parent));
+                                let old_range = context.remove(ContextKey::Range);
+                                context.insert(ContextKey::Range, ContextValue::RANGE(sub.slice.range()));
+                                context.insert(ContextKey::IsInValidation, ContextValue::BOOLEAN(is_in_validation));
+                                let hook_result = (hook.callable)(session, &get_item_eval.symbol, Some(context), &mut diagnostics, Some(parent));
                                 if let Some(hook_result) = hook_result {
                                     match hook_result {
                                         EvaluationSymbolPtr::WEAK(ref weak) => {
@@ -1430,9 +1430,9 @@ impl Evaluation {
                                         }
                                     }
                                 }
-                                context.as_mut().unwrap().remove(ContextKey::Args);
-                                context.as_mut().unwrap().remove(ContextKey::IsInValidation);
-                                context.as_mut().unwrap().insert(ContextKey::Range, old_range.unwrap());
+                                context.remove(ContextKey::Args);
+                                context.remove(ContextKey::IsInValidation);
+                                context.insert(ContextKey::Range, old_range.unwrap());
                             }
                             if let EvaluationSymbolPtr::SELF(_) = get_item_eval.symbol.get_symbol_ptr() {
                                 // Evaluate to the base itself
@@ -1499,8 +1499,8 @@ impl Evaluation {
                 let (bases, diags) = Evaluation::eval_from_ast(session, &unary_operator.operand, parent, max_infer, false, required_dependencies);
                 diagnostics.extend(diags);
                 for base in bases.into_iter(){
-                    let base_sym_weak_eval= base.symbol.get_symbol_weak_transformed(session, context, &mut diagnostics, None);
-                    let base_eval_ptrs = SymbolTable::follow_ref(&base_sym_weak_eval, session, context, true, false, None, None);
+                    let base_sym_weak_eval= base.symbol.get_symbol_weak_transformed(session, Some(context), &mut diagnostics, None);
+                    let base_eval_ptrs = SymbolTable::follow_ref(&base_sym_weak_eval, session, Some(context), true, false, None, None);
                     for base_eval_ptr in base_eval_ptrs.iter() {
                         let EvaluationSymbolPtr::WEAK(base_sym_weak_eval) = base_eval_ptr else {continue};
                         let Some(base_sym) = base_sym_weak_eval.weak.upgrade(session.st()) else {continue};
@@ -1508,7 +1508,7 @@ impl Evaluation {
                         diagnostics.extend(diags);
                         for operator_function in operator_functions.into_iter() {
                             for eval in session.st().evaluations(operator_function).unwrap_or(&vec![]).clone() {
-                                let eval_ptr = eval.symbol.get_symbol_weak_transformed(session, context, &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
+                                let eval_ptr = eval.symbol.get_symbol_weak_transformed(session, Some(context), &mut diagnostics, Some(session.st().get_file(parent).unwrap().into()));
                                 evals.push(Evaluation {
                                     symbol: EvaluationSymbol {
                                         sym: eval_ptr,
@@ -2200,7 +2200,7 @@ impl EvaluationSymbol {
     }
 
     /* Execute the hook, then use context to return an EvaluationSymbolWeak if possible, else return an empty one */
-    pub fn get_symbol_as_weak(&self, session: &mut SessionInfo, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> EvaluationSymbolWeak {
+    pub fn get_symbol_as_weak(&self, session: &mut SessionInfo, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> EvaluationSymbolWeak {
         let eval = self.get_symbol(session, context, diagnostics, scope);
         match eval {
             EvaluationSymbolPtr::WEAK(w) => {
@@ -2212,7 +2212,7 @@ impl EvaluationSymbol {
             | EvaluationSymbolPtr::UNBOUND(_)
             | EvaluationSymbolPtr::DOMAIN => EvaluationSymbolWeak{ weak: Wk::null(), context: Context::default(), instance: Some(false), is_super: false },
             EvaluationSymbolPtr::SELF(_) => {
-                let class = context.as_ref().
+                let class = context.
                 and_then(|context| context.get(ContextKey::ParentFor).or(context.get(ContextKey::BaseAttr)))
                 .unwrap_or(&ContextValue::BOOLEAN(false));
                 match class {
@@ -2224,7 +2224,7 @@ impl EvaluationSymbol {
     }
 
     /* Execute Hook, then return the effective EvaluationSymbolPtr, but transformed as EvaluationSmbolWeak if possible */
-    pub fn get_symbol_weak_transformed(&self, session: &mut SessionInfo, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> EvaluationSymbolPtr {
+    pub fn get_symbol_weak_transformed(&self, session: &mut SessionInfo, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> EvaluationSymbolPtr {
         let eval = self.get_symbol(session, context, diagnostics, scope);
         match eval {
             EvaluationSymbolPtr::WEAK(_) => {
@@ -2261,7 +2261,7 @@ impl EvaluationSymbol {
     }
 
     /* Execute Hook, then return the effective EvaluationSymbolPtr */
-    pub fn get_symbol(&self, session: &mut SessionInfo, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> EvaluationSymbolPtr {
+    pub fn get_symbol(&self, session: &mut SessionInfo, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> EvaluationSymbolPtr {
         let mut custom_eval = None;
         if let Some(hook) = self.get_symbol_hook.as_ref() {
             custom_eval = (hook.callable)(session, self, context, diagnostics, file_symbol);

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -320,7 +320,7 @@ impl Context {
  * diagnostics: a vec the hook can fill to add diagnostics
  * file_symbol: if provided, can be used to add dependencies
  */
-type GetSymbolHookCallable = fn (session: &mut SessionInfo, eval: &EvaluationSymbol, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>;
+type GetSymbolHookCallable = fn (session: &mut SessionInfo, eval: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>;
 
 #[derive(Debug, Clone)]
 pub struct GetSymbolHook {
@@ -2200,7 +2200,7 @@ impl EvaluationSymbol {
     }
 
     /* Execute the hook, then use context to return an EvaluationSymbolWeak if possible, else return an empty one */
-    pub fn get_symbol_as_weak(&self, session: &mut SessionInfo, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> EvaluationSymbolWeak {
+    pub fn get_symbol_as_weak(&self, session: &mut SessionInfo, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> EvaluationSymbolWeak {
         let eval = self.get_symbol(session, context, diagnostics, scope);
         match eval {
             EvaluationSymbolPtr::WEAK(w) => {
@@ -2261,7 +2261,7 @@ impl EvaluationSymbol {
     }
 
     /* Execute Hook, then return the effective EvaluationSymbolPtr */
-    pub fn get_symbol(&self, session: &mut SessionInfo, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> EvaluationSymbolPtr {
+    pub fn get_symbol(&self, session: &mut SessionInfo, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> EvaluationSymbolPtr {
         let mut custom_eval = None;
         if let Some(hook) = self.get_symbol_hook.as_ref() {
             custom_eval = (hook.callable)(session, self, context, diagnostics, file_symbol);

--- a/server/src/core/evaluation_context.rs
+++ b/server/src/core/evaluation_context.rs
@@ -1,0 +1,182 @@
+use ruff_python_ast::Arguments;
+use ruff_text_size::TextRange;
+use thin_vec::ThinVec;
+
+use crate::core::symbols::symbol_keys::{ModuleKey, SymbolKey, Wk};
+
+
+/** A context can contain: (non-exhaustive)
+* module: the current module the file belongs to
+* parent: in an expression, like self.test, the parent is the base attribute, so 'self' for test
+* object: the object the expression is executed on (useful if function is defined in parent object).
+*/
+#[derive(Debug, Clone, Default)]
+pub struct Context {
+    // ThinVec is a single pointer (8 B inline, x 24 B for a Vec), with no heap
+    // allocation while empty. Most contexts are empty.
+    entries: ThinVec<(ContextKey, ContextValue)>
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ContextKey {
+    Args,
+    BaseAttr,
+    BaseAttrInserted,
+    BaseCall,
+    BaseIsSelf,
+    Compute,
+    ComputeArgRange,
+    ComodelName,
+    ComodelNameArgRange,
+    ConstructingClass,
+    Default,
+    Delegate,
+    FieldParent,
+    IsAttrOfInstance,
+    IsInValidation,
+    Inverse,
+    InverseArgRange,
+    InverseName,
+    InverseNameArgRange,
+    Module,
+    Parameters,
+    ParentFor,
+    ParentInstance,
+    Range,
+    Related,
+    RelatedArgRange,
+    Required,
+    Search,
+    SearchArgRange,
+    // placeholder after removal
+    EMPTY,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContextValue {
+    BOOLEAN(bool),
+    STRING(String),
+    MODULE(Wk<ModuleKey>),
+    SYMBOL(Wk<SymbolKey>),
+    ARGUMENTS(Arguments),
+    RANGE(TextRange),
+    // empty value after removal
+    EMPTY,
+}
+
+
+impl Context {
+    pub fn from_iter(entries: impl IntoIterator<Item = (ContextKey, ContextValue)>) -> Self {
+        Context { entries: entries.into_iter().collect() }
+    }
+
+    pub fn insert(&mut self, key: ContextKey, value: ContextValue) {
+        let mut empty_slot = None;
+        // update value if key already exists
+        for (i, (k, v)) in self.entries.iter_mut().enumerate() {
+            if *k == key {
+                *v = value;
+                return;
+            }
+            if empty_slot.is_none() && *k == ContextKey::EMPTY {
+                empty_slot = Some(i)
+            }
+        }
+        // otherwise, insert new entry
+        // reuse empty slot if any
+        if let Some(i) = empty_slot {
+            self.entries[i] = (key, value);
+        } else {
+            self.entries.push((key, value));
+        }
+    }
+
+    /// Removing an entry that was added last is (usually) more efficient.
+    pub fn remove(&mut self, key: ContextKey) -> Option<ContextValue> {
+        while let Some((k, _)) = self.entries.last() {
+            if *k == key {
+                // key matches last entry, simply pop it
+                return self.entries.pop().map(|(_, v)| v);
+            } else if *k == ContextKey::EMPTY {
+                // last entry is empty: clean it up and keep seaching
+                self.entries.pop();
+            } else {
+                break;
+            }
+        }
+        // We keep seaching in reverse order, skip last entry (it was checked above)
+        for (k, v) in self.entries.iter_mut().rev().skip(1) {
+            if *k == key {
+                *k = ContextKey::EMPTY; // mark as empty
+                let value = std::mem::replace(v, ContextValue::EMPTY);
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    pub fn get(&self, key: ContextKey) -> Option<&ContextValue> {
+        self.entries.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+    }
+
+    pub fn contains_key(&self, key: &ContextKey) -> bool {
+        self.entries.iter().any(|(k, _)| k == key)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(ContextKey, ContextValue)> {
+        self.entries.iter().filter(|(k, _)| *k != ContextKey::EMPTY)
+    }
+
+    /// Merges two Contexts into a new one.
+    /// When a key is present in both, value from `b` has precedence.
+    pub fn merge(a: &Self, b: &Self) -> Self {
+        let mut result = ThinVec::with_capacity(a.entries.len() + b.entries.len());
+        result.extend(a.iter().filter(|(key, _)| !b.contains_key(key)).cloned());
+        result.extend(b.iter().cloned());
+        Self { entries: result }
+    }
+}
+
+impl ContextValue {
+    pub fn as_bool(&self) -> bool {
+        match self {
+            ContextValue::BOOLEAN(b) => *b,
+            _ => panic!("Not a boolean")
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            ContextValue::STRING(s) => s,
+            _ => panic!("Not a string")
+        }
+    }
+
+    pub fn as_symbol(&self) -> Wk<SymbolKey> {
+        match self {
+            ContextValue::SYMBOL(s) => *s,
+            _ => panic!("Not a symbol")
+        }
+    }
+
+    pub fn as_text_range(&self) -> TextRange {
+        match self {
+            ContextValue::RANGE(r) => r.clone(),
+            _ => panic!("Not a TextRange")
+        }
+    }
+
+    pub fn as_arguments(&self) -> Arguments {
+        match self {
+            ContextValue::ARGUMENTS(a) => a.clone(),
+            _ => panic!("Not an arguments")
+        }
+    }
+}
+
+impl PartialEq for Context {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().count() == other.iter().count()
+            && self.iter().all(|(k, v)| other.get(*k) == Some(v))
+    }
+}

--- a/server/src/core/evaluation_context.rs
+++ b/server/src/core/evaluation_context.rs
@@ -48,7 +48,7 @@ pub enum ContextKey {
     Required,
     Search,
     SearchArgRange,
-    // placeholder after removal
+    // placeholder after removal (tombstone) - should not be used as key
     EMPTY,
 }
 
@@ -60,14 +60,25 @@ pub enum ContextValue {
     SYMBOL(Wk<SymbolKey>),
     ARGUMENTS(Arguments),
     RANGE(TextRange),
-    // empty value after removal
+    // empty value after removal - should not be used as value
     EMPTY,
 }
 
 
 impl Context {
+    /// Builds a Context from an iterable of key-value pairs. Keys must be unique.
     pub fn from_iter(entries: impl IntoIterator<Item = (ContextKey, ContextValue)>) -> Self {
-        Context { entries: entries.into_iter().collect() }
+        let entries: ThinVec<_> = entries.into_iter().collect();
+        debug_assert!({
+            let unique_keys = entries.iter().map(|(k, _)| *k).collect::<crate::utils::HashSet<_>>();
+            unique_keys.len() == entries.len()
+            }, "Context::from_iter requires unique keys"
+        );
+        debug_assert!(
+            entries.iter().all(|(k, _)| *k != ContextKey::EMPTY),
+            "Context::from_iter must not receive EMPTY keys"
+        );
+        Context { entries }
     }
 
     pub fn insert(&mut self, key: ContextKey, value: ContextValue) {
@@ -178,5 +189,285 @@ impl PartialEq for Context {
     fn eq(&self, other: &Self) -> bool {
         self.iter().count() == other.iter().count()
             && self.iter().all(|(k, v)| other.get(*k) == Some(v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_returns_inserted_value() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        assert_eq!(ctx.get(ContextKey::Required), Some(&ContextValue::BOOLEAN(true)));
+    }
+
+    #[test]
+    fn get_missing_key_returns_none() {
+        let ctx = Context::default();
+        assert_eq!(ctx.get(ContextKey::Required), None);
+    }
+
+    #[test]
+    fn insert_updates_existing_key() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Default, ContextValue::STRING("a".to_string()));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("b".to_string()));
+        assert_eq!(ctx.get(ContextKey::Default), Some(&ContextValue::STRING("b".to_string())));
+        // update must not create a second entry
+        assert_eq!(ctx.iter().count(), 1);
+    }
+
+    #[test]
+    fn contains_key_reflects_presence() {
+        let mut ctx = Context::default();
+        assert!(!ctx.contains_key(&ContextKey::Search));
+        ctx.insert(ContextKey::Search, ContextValue::BOOLEAN(false));
+        assert!(ctx.contains_key(&ContextKey::Search));
+    }
+
+    #[test]
+    fn remove_returns_value_and_clears_key() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Inverse, ContextValue::STRING("x".to_string()));
+        assert_eq!(ctx.remove(ContextKey::Inverse), Some(ContextValue::STRING("x".to_string())));
+        assert!(!ctx.contains_key(&ContextKey::Inverse));
+        assert_eq!(ctx.get(ContextKey::Inverse), None);
+    }
+
+    #[test]
+    fn remove_missing_key_returns_none() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        assert_eq!(ctx.remove(ContextKey::Search), None);
+        // unrelated entry is untouched
+        assert!(ctx.contains_key(&ContextKey::Required));
+    }
+
+    #[test]
+    fn remove_non_last_entry_keeps_others() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        ctx.insert(ContextKey::Search, ContextValue::BOOLEAN(false));
+        // remove a middle (non-last) entry
+        assert_eq!(ctx.remove(ContextKey::Default), Some(ContextValue::STRING("d".to_string())));
+        assert!(!ctx.contains_key(&ContextKey::Default));
+        assert!(ctx.contains_key(&ContextKey::Required));
+        assert!(ctx.contains_key(&ContextKey::Search));
+        assert_eq!(ctx.iter().count(), 2);
+    }
+
+    #[test]
+    fn iter_skips_tombstones() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        // non-last removal leaves an EMPTY tombstone in raw storage
+        ctx.remove(ContextKey::Required);
+        assert_eq!(ctx.entries.len(), 2);
+        // iter must hide the tombstone and only yield the live entry
+        let yielded: Vec<_> = ctx.iter().collect();
+        assert_eq!(yielded, vec![&(ContextKey::Default, ContextValue::STRING("d".to_string()))]);
+    }
+
+    #[test]
+    fn insert_reuses_emptied_slot() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        // removing the non-last entry leaves an EMPTY slot to be reused
+        ctx.remove(ContextKey::Required);
+        ctx.insert(ContextKey::Search, ContextValue::BOOLEAN(false));
+        assert_eq!(ctx.entries.len(), 2);
+        assert_eq!(ctx.iter().count(), 2);
+        assert!(ctx.contains_key(&ContextKey::Search));
+    }
+
+    #[test]
+    fn remove_then_reinsert_same_key() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        // non-last removal tombstones Required
+        ctx.remove(ContextKey::Required);
+        // putting it back reuses the freed slot rather than growing storage
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(false));
+        assert_eq!(ctx.entries.len(), 2);
+        assert_eq!(ctx.iter().count(), 2);
+        assert_eq!(ctx.get(ContextKey::Required), Some(&ContextValue::BOOLEAN(false)));
+    }
+
+    #[test]
+    fn insert_reuses_first_of_multiple_tombstones() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        ctx.insert(ContextKey::Search, ContextValue::BOOLEAN(false));
+        // tombstone the two non-last entries -> two EMPTY slots in storage
+        ctx.remove(ContextKey::Required);
+        ctx.remove(ContextKey::Default);
+        assert_eq!(ctx.entries.len(), 3);
+        // one insert fills one tombstone; storage must not grow
+        ctx.insert(ContextKey::Inverse, ContextValue::BOOLEAN(true));
+        assert_eq!(ctx.entries.len(), 3);
+        // it reused the first tombstone (Required's slot, index 0)
+        assert_eq!(ctx.entries[0].0, ContextKey::Inverse);
+        assert_eq!(ctx.iter().count(), 2);
+    }
+
+    #[test]
+    fn double_remove_returns_none_second_time() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Inverse, ContextValue::STRING("x".to_string()));
+        assert!(ctx.remove(ContextKey::Inverse).is_some());
+        assert_eq!(ctx.remove(ContextKey::Inverse), None);
+    }
+
+    #[test]
+    fn pop_last_leaves_no_tombstone() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        // removing the only (last) entry pops it outright, no tombstone left behind
+        ctx.remove(ContextKey::Required);
+        assert_eq!(ctx.entries.len(), 0);
+    }
+
+    #[test]
+    fn lifo_removal_clears_all_entries() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        ctx.insert(ContextKey::Search, ContextValue::BOOLEAN(false));
+        // pop in reverse insertion order: each removal hits the last entry
+        ctx.remove(ContextKey::Search);
+        assert_eq!(ctx.entries.len(), 2);
+        ctx.remove(ContextKey::Default);
+        assert_eq!(ctx.entries.len(), 1);
+        ctx.remove(ContextKey::Required);
+        // fully drained, raw storage reclaimed (no tombstones)
+        assert_eq!(ctx.entries.len(), 0);
+    }
+
+    #[test]
+    fn next_remove_sweeps_trailing_tombstone() {
+        let mut ctx = Context::default();
+        ctx.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        ctx.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        ctx.insert(ContextKey::Search, ContextValue::BOOLEAN(false));
+        // remove a middle entry: leaves a tombstone, raw storage unchanged
+        ctx.remove(ContextKey::Default);
+        assert_eq!(ctx.entries.len(), 3);
+        // remove the last entry: it pops & returns immediately, so the middle
+        // tombstone is now trailing but still occupies storage
+        ctx.remove(ContextKey::Search);
+        assert_eq!(ctx.entries.len(), 2);
+        // the next removal sweeps that trailing tombstone before popping its target
+        ctx.remove(ContextKey::Required);
+        assert_eq!(ctx.entries.len(), 0);
+    }
+
+    #[test]
+    fn from_iter_builds_context_with_entries() {
+        let ctx = Context::from_iter([
+            (ContextKey::Required, ContextValue::BOOLEAN(true)),
+            (ContextKey::Default, ContextValue::STRING("d".to_string())),
+        ]);
+        assert_eq!(ctx.iter().count(), 2);
+        assert_eq!(ctx.get(ContextKey::Required), Some(&ContextValue::BOOLEAN(true)));
+        assert_eq!(ctx.get(ContextKey::Default), Some(&ContextValue::STRING("d".to_string())));
+    }
+
+    #[test]
+    fn from_iter_empty_yields_empty_context() {
+        let ctx = Context::from_iter([]);
+        assert_eq!(ctx.iter().count(), 0);
+        assert_eq!(ctx, Context::default());
+    }
+
+    #[test]
+    fn merge_unions_disjoint_keys() {
+        let a = Context::from_iter([(ContextKey::Required, ContextValue::BOOLEAN(true))]);
+        let b = Context::from_iter([(ContextKey::Search, ContextValue::BOOLEAN(false))]);
+        let merged = Context::merge(&a, &b);
+        assert_eq!(merged.iter().count(), 2);
+        assert_eq!(merged.get(ContextKey::Required), Some(&ContextValue::BOOLEAN(true)));
+        assert_eq!(merged.get(ContextKey::Search), Some(&ContextValue::BOOLEAN(false)));
+    }
+
+    #[test]
+    fn merge_b_takes_precedence_on_conflict() {
+        let a = Context::from_iter([(ContextKey::Default, ContextValue::STRING("a".to_string()))]);
+        let b = Context::from_iter([(ContextKey::Default, ContextValue::STRING("b".to_string()))]);
+        let merged = Context::merge(&a, &b);
+        // conflicting key keeps b's value, with no duplicate entry
+        assert_eq!(merged.iter().count(), 1);
+        assert_eq!(merged.get(ContextKey::Default), Some(&ContextValue::STRING("b".to_string())));
+    }
+
+    #[test]
+    fn merge_with_empty_is_identity() {
+        let ctx = Context::from_iter([
+            (ContextKey::Required, ContextValue::BOOLEAN(true)),
+            (ContextKey::Default, ContextValue::STRING("d".to_string())),
+        ]);
+        let empty = Context::default();
+        // empty is the identity element on both sides
+        assert_eq!(Context::merge(&ctx, &empty), ctx);
+        assert_eq!(Context::merge(&empty, &ctx), ctx);
+        // merging two empties stays empty
+        assert_eq!(Context::merge(&empty, &empty), empty);
+    }
+
+    #[test]
+    fn merge_skips_emptied_slots() {
+        let mut a = Context::default();
+        a.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        a.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        a.remove(ContextKey::Required); // leaves an EMPTY slot in a
+        let b = Context::from_iter([(ContextKey::Search, ContextValue::BOOLEAN(false))]);
+        let merged = Context::merge(&a, &b);
+        // EMPTY slot must not leak into the merged result
+        assert_eq!(merged.iter().count(), 2);
+        assert!(!merged.contains_key(&ContextKey::Required));
+        assert!(merged.contains_key(&ContextKey::Default));
+        assert!(merged.contains_key(&ContextKey::Search));
+    }
+
+    #[test]
+    fn eq_ignores_entry_order() {
+        let a = Context::from_iter([
+            (ContextKey::Required, ContextValue::BOOLEAN(true)),
+            (ContextKey::Search, ContextValue::BOOLEAN(false)),
+        ]);
+        let b = Context::from_iter([
+            (ContextKey::Search, ContextValue::BOOLEAN(false)),
+            (ContextKey::Required, ContextValue::BOOLEAN(true)),
+        ]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn eq_distinguishes_values_and_counts() {
+        let base = Context::from_iter([(ContextKey::Default, ContextValue::STRING("a".to_string()))]);
+        let diff_value = Context::from_iter([(ContextKey::Default, ContextValue::STRING("b".to_string()))]);
+        let extra_key = Context::from_iter([
+            (ContextKey::Default, ContextValue::STRING("a".to_string())),
+            (ContextKey::Required, ContextValue::BOOLEAN(true)),
+        ]);
+        assert_ne!(base, diff_value);
+        assert_ne!(base, extra_key);
+    }
+
+    #[test]
+    fn eq_ignores_emptied_slots() {
+        // A context that had an entry removed should equal a fresh-built equivalent.
+        let mut with_empty = Context::default();
+        with_empty.insert(ContextKey::Required, ContextValue::BOOLEAN(true));
+        with_empty.insert(ContextKey::Default, ContextValue::STRING("d".to_string()));
+        with_empty.remove(ContextKey::Required);
+        let clean = Context::from_iter([(ContextKey::Default, ContextValue::STRING("d".to_string()))]);
+        assert_eq!(with_empty, clean);
     }
 }

--- a/server/src/core/mod.rs
+++ b/server/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod csv_validation;
 pub mod data_hooks;
 pub mod diagnostics;
 pub mod evaluation;
+pub mod evaluation_context;
 pub mod entry_point;
 pub mod file_mgr;
 pub mod import_resolver;

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -191,7 +191,7 @@ impl PythonArchBuilder {
                     if let Some(all) = session.st().get_content_symbol(import_symbol, "__all__", u32::MAX).symbols.first().copied() {
                         let all_value = SymbolTable::follow_ref(&EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(
                             all, None, false
-                        )), session, &mut None, false, true, None, None);
+                        )), session, None, false, true, None, None);
                         if let Some(all_value_first) = all_value.get(0) {
                             if !all_value_first.is_expired_if_weak(session.st()) {
                                 let all_upgraded = all_value_first.upgrade_weak(session.st());
@@ -236,7 +236,7 @@ impl PythonArchBuilder {
                         }
                         for (name, evaluations) in import_variables_to_create {
                             let evaluated_type = &evaluations[0].symbol;
-                            let evaluated_type = evaluated_type.get_symbol_as_weak(session, &mut None, &mut self.diagnostics, None).weak;
+                            let evaluated_type = evaluated_type.get_symbol_as_weak(session, None, &mut self.diagnostics, None).weak;
                             if let Some(evaluated_type) = evaluated_type.upgrade(session.st()) {
                                 let evaluated_type_file = session.st().get_file(evaluated_type).unwrap();
                                 if !(self.file == evaluated_type_file) {

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -492,7 +492,7 @@ impl PythonArchBuilder {
                         vec![]
                     }
                     EvaluationValue::CONSTANT(c) => {
-                        match c {
+                        match &**c {
                             Expr::StringLiteral(s) => {
                                 vec![oyarn!("{}", s.value)]
                             },

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -366,7 +366,7 @@ impl PythonArchEval {
     fn check_for_cyclic_evaluation(&mut self, session: &mut SessionInfo, sym_ref: SymbolKey, from_sym: VariableKey) -> bool {
         let syms_followed = SymbolTable::follow_ref(&EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(
             sym_ref, None, false
-        )), session, &mut None, false, false, None, None);
+        )), session, None, false, false, None, None);
         for sym in syms_followed {
             let Some(sym) = sym.upgrade_weak(session.st()) else { continue };
             if sym == from_sym {
@@ -479,7 +479,7 @@ impl PythonArchEval {
                         if let Some((ref val_eval, ref _diags)) = value_evaluations {
                             if val_eval.len() == 1 {
                                 let evaluation = &val_eval[0];
-                                let sym_weak = evaluation.symbol.get_symbol_as_weak(session, &mut None, &mut vec![], Some(parent));
+                                let sym_weak = evaluation.symbol.get_symbol_as_weak(session, None, &mut vec![], Some(parent));
                                 if let Some(sym_key) = sym_weak.weak.upgrade(session.st()) {
                                     if SymbolTable::is_field_class(session, sym_key) {
                                         take_value = true;
@@ -506,7 +506,7 @@ impl PythonArchEval {
                         let mut dep_to_add = vec![];
                         let mut to_remove = vec![];
                         for (ix, evaluation) in evaluations.iter().enumerate() {
-                            if let Some(sym) = evaluation.symbol.get_symbol_as_weak(session, &mut None, &mut self.diagnostics, None).weak.upgrade(session.st()) {
+                            if let Some(sym) = evaluation.symbol.get_symbol_as_weak(session, None, &mut self.diagnostics, None).weak.upgrade(session.st()) {
                                 if sym == variable_key {
                                     // TODO: investigate deps, and fix cyclic evals
                                     let file_path = session.st().get_file(parent).map(|file| session.st().path(file));
@@ -567,7 +567,7 @@ impl PythonArchEval {
                     'while_block: while matches!(expr, Expr::Attribute(_)){
                         let assignee = Evaluation::eval_from_ast(session, &expr, *self.sym_stack.last().unwrap(), &attr_expr.range.start(), false, &mut vec![]);
                         for evaluation in assignee.0 {
-                            let evaluation_symbol_ptr = evaluation.symbol.get_symbol_weak_transformed(session, &mut None, &mut vec![], None);
+                            let evaluation_symbol_ptr = evaluation.symbol.get_symbol_weak_transformed(session, None, &mut vec![], None);
                             let Some(sym_key) = evaluation_symbol_ptr.upgrade_weak(session.st()) else {
                                 continue;
                             };
@@ -643,8 +643,8 @@ impl PythonArchEval {
                 continue;
             }
             let eval_base = &eval_base[0];
-            let eval_symbol = eval_base.symbol.get_symbol(session, &mut None, &mut vec![], None);
-            let ref_sym = SymbolTable::follow_ref(&eval_symbol, session, &mut None, false, true, None, None);
+            let eval_symbol = eval_base.symbol.get_symbol(session, None, &mut vec![], None);
+            let ref_sym = SymbolTable::follow_ref(&eval_symbol, session, None, false, true, None, None);
             if ref_sym.len() > 1 {
                 if let Some(diagnostic) = create_diagnostic(&session, DiagnosticCode::OLS01003, &[&AstUtils::flatten_expr(base)]) {
                     self.diagnostics.push(Diagnostic {
@@ -819,9 +819,9 @@ impl PythonArchEval {
         self.diagnostics.extend(diags);
         if eval_iter_node.len() == 1 { //Only handle values that we are sure about
             let eval = &eval_iter_node[0];
-            let eval_symbol = eval.symbol.get_symbol(session, &mut None, &mut vec![], None);
+            let eval_symbol = eval.symbol.get_symbol(session, None, &mut vec![], None);
             if !eval_symbol.is_expired_if_weak(session.st()) {
-                let symbol_eval = SymbolTable::follow_ref(&eval_symbol, session, &mut None, false, false, None, None);
+                let symbol_eval = SymbolTable::follow_ref(&eval_symbol, session, None, false, false, None, None);
                 if symbol_eval.len() == 1 && let Some(symbol_type) = symbol_eval[0].upgrade_weak(session.st()) {
                     if matches!(symbol_type, SymbolKey::Class(_)) {
                         let (iters, _) = SymbolTable::get_member_symbol(session, symbol_type, "__iter__", None, true, false, false, false, false);
@@ -833,7 +833,7 @@ impl PythonArchEval {
                                 if for_stmt.target.is_name_expr() { //only handle simple variable for now
                                     let variable = session.st().get_positioned_symbol(*self.sym_stack.last().unwrap(), &for_stmt.target.as_name_expr().unwrap().id, &for_stmt.target.range());
 
-                                    let symbol = eval_iter.symbol.get_symbol_as_weak(session, &mut Some(Context::from_iter([(ContextKey::ParentFor, ContextValue::SYMBOL(symbol_type.into()))])), &mut vec![], None);
+                                    let symbol = eval_iter.symbol.get_symbol_as_weak(session, Some(&Context::from_iter([(ContextKey::ParentFor, ContextValue::SYMBOL(symbol_type.into()))])), &mut vec![], None);
                                     let v = variable.unwrap().unwrap_variable_key();
                                     session.st_mut()[v].evaluations = vec![Evaluation::eval_from_symbol(session.st(), symbol.weak, symbol.instance)];
                                 }
@@ -921,7 +921,7 @@ impl PythonArchEval {
                             // The expression name in with <> [as <name>], is the result of __enter__.
                             let mut enter_evals = vec![];
                             for context_mgr_eval in context_mgr_evals.iter() {
-                                let symbol = context_mgr_eval.symbol.get_symbol_as_weak(session, &mut None, &mut self.diagnostics, Some(session.st().parent_file_or_function(variable_key.into()).unwrap()));
+                                let symbol = context_mgr_eval.symbol.get_symbol_as_weak(session, None, &mut self.diagnostics, Some(session.st().parent_file_or_function(variable_key.into()).unwrap()));
                                 if let Some(symbol) = symbol.weak.upgrade(session.st()) {
                                     let _enter_ = session.st().get_symbol(symbol, (&[], &["__enter__"]), u32::MAX);
                                     if let Some(&SymbolKey::Function(_enter_)) = _enter_.last() {
@@ -982,9 +982,9 @@ impl PythonArchEval {
             // And give it priority over other evaluations
             if evaluations.iter().any(|evaluation|
                 SymbolTable::follow_ref(
-                    &evaluation.symbol.get_symbol(session, &mut None, diagnostics, None),
+                    &evaluation.symbol.get_symbol(session, None, diagnostics, None),
                     session,
-                    &mut None,
+                    None,
                     false,
                     false,
                     Some((&["typing"], &["Self"])),

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -1,4 +1,4 @@
-use crate::utils::{HashMap, HashSet};
+use crate::utils::HashSet;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::{u32, vec};
@@ -17,7 +17,7 @@ use crate::core::symbols::VariableSymbol;
 use crate::{constants::*, oyarn};
 use crate::core::import_resolver::resolve_import_stmt;
 use crate::core::odoo::SyncOdoo;
-use crate::core::evaluation::Evaluation;
+use crate::core::evaluation::{Context, ContextKey, Evaluation};
 use crate::core::python_utils;
 use crate::features::ast_utils::AstUtils;
 use crate::threads::SessionInfo;
@@ -833,7 +833,8 @@ impl PythonArchEval {
                                 let eval_iter = evals[0].clone();
                                 if for_stmt.target.is_name_expr() { //only handle simple variable for now
                                     let variable = session.st().get_positioned_symbol(*self.sym_stack.last().unwrap(), &for_stmt.target.as_name_expr().unwrap().id, &for_stmt.target.range());
-                                    let symbol = eval_iter.symbol.get_symbol_as_weak(session, &mut Some(HashMap::from_iter([(S!("parent_for"), ContextValue::SYMBOL(symbol_type.into()))])), &mut vec![], None);
+
+                                    let symbol = eval_iter.symbol.get_symbol_as_weak(session, &mut Some(Context::from_iter([(ContextKey::ParentFor, ContextValue::SYMBOL(symbol_type.into()))])), &mut vec![], None);
                                     let v = variable.unwrap().unwrap_variable_key();
                                     session.st_mut()[v].evaluations = vec![Evaluation::eval_from_symbol(session.st(), symbol.weak, symbol.instance)];
                                 }

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -21,7 +21,6 @@ use crate::core::evaluation::{Context, ContextKey, Evaluation};
 use crate::core::python_utils;
 use crate::features::ast_utils::AstUtils;
 use crate::threads::SessionInfo;
-use crate::S;
 
 use super::config::DiagMissingImportsMode;
 use super::entry_point::EntryPoint;
@@ -825,7 +824,7 @@ impl PythonArchEval {
                 let symbol_eval = SymbolTable::follow_ref(&eval_symbol, session, &mut None, false, false, None, None);
                 if symbol_eval.len() == 1 && let Some(symbol_type) = symbol_eval[0].upgrade_weak(session.st()) {
                     if matches!(symbol_type, SymbolKey::Class(_)) {
-                        let (iters, _) = SymbolTable::get_member_symbol(session, symbol_type, &S!("__iter__"), None, true, false, false, false, false);
+                        let (iters, _) = SymbolTable::get_member_symbol(session, symbol_type, "__iter__", None, true, false, false, false, false);
                         if let Some(&SymbolKey::Function(iter)) = iters.first() && iters.len() == 1 {
                             SyncOdoo::ensure_func_evaluations(session, iter);
                             let evals = &session.st()[iter].evaluations;
@@ -1047,8 +1046,8 @@ impl PythonArchEval {
     ) -> Vec<SymbolKey>{
         let mut parent_object = Some(class_sym);
         let mut syms = vec![];
-        let split_expr: Vec<String> = field_name.split(".").map(|x| x.to_string()).collect();
-        for (ix, name) in split_expr.iter().enumerate() {
+        let split_expr: Vec<_> = field_name.split(".").collect();
+        for (ix, &name) in split_expr.iter().enumerate() {
             if parent_object.is_none() {
                 break;
             }

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -17,14 +17,15 @@ use crate::core::symbols::VariableSymbol;
 use crate::{constants::*, oyarn};
 use crate::core::import_resolver::resolve_import_stmt;
 use crate::core::odoo::SyncOdoo;
-use crate::core::evaluation::{Context, ContextKey, Evaluation};
+use crate::core::evaluation::{Evaluation};
+use crate::core::evaluation_context::{Context, ContextKey, ContextValue};
 use crate::core::python_utils;
 use crate::features::ast_utils::AstUtils;
 use crate::threads::SessionInfo;
 
 use super::config::DiagMissingImportsMode;
 use super::entry_point::EntryPoint;
-use super::evaluation::{ContextValue, EvaluationSymbolPtr, EvaluationSymbolWeak};
+use super::evaluation::{EvaluationSymbolPtr, EvaluationSymbolWeak};
 use super::file_mgr::FileMgr;
 use super::import_resolver::ImportResult;
 use super::python_arch_eval_hooks::PythonArchEvalHooks;

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -1,3 +1,4 @@
+use crate::core::evaluation::ContextKey;
 use crate::utils::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -67,7 +68,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
             return;
         };
         let env = &mut odoo.symbol_table[symbol.unwrap_variable_key()];
-        let context = HashMap::default();
+        let context = Context::default();
         env.evaluations = vec![Evaluation {
             symbol: EvaluationSymbol::new_with_symbol(
                 env_class.into(),
@@ -163,7 +164,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
                 symbol: EvaluationSymbol::new_with_symbol(
                     (*registry_sym.last().unwrap()).into(),
                     Some(true),
-                    HashMap::default(),
+                    Context::default(),
                     None
                 ),
                 value: None,
@@ -372,7 +373,7 @@ static arch_eval_file_hooks: Lazy<Vec<PythonArchEvalFileHook>> = Lazy::new(|| {v
         if let Some(&boolean) = boolean_field.first() {
             let mut eval = Evaluation::eval_from_symbol(&odoo.symbol_table, boolean, Some(true));
             let weak = eval.symbol.get_mut_symbol_ptr().get_mut_weak();
-            weak.context.insert(S!("compute"), ContextValue::STRING(S!("_compute_global")));
+            weak.context.insert(ContextKey::Compute, ContextValue::STRING(S!("_compute_global")));
             odoo.symbol_table.set_evaluations(symbol, vec![eval]);
         }
     }},
@@ -513,7 +514,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
        odoo.symbol_table[symbol].evaluations = vec![Evaluation {
             symbol: EvaluationSymbol::new_with_symbol(Wk::null(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_get_item, name: S!("eval_env_get_item")})
             ),
             value: None,
@@ -528,7 +529,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
         odoo.symbol_table[symbol].evaluations = vec![Evaluation {
             symbol: EvaluationSymbol::new_with_symbol(Wk::null(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_registry_get_item, name: S!("eval_registry_get_item")})
             ),
             value: None,
@@ -691,7 +692,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
             symbol: EvaluationSymbol::new_with_symbol(
                 fields_class_sym.into(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_init, name: S!("eval_init")})
             ),
             value: None,
@@ -865,15 +866,15 @@ impl PythonArchEvalHooks {
         let Some(context) = context else {
             return res
         };
-        let in_validation = context.get("is_in_validation").unwrap_or(&ContextValue::BOOLEAN(false)).as_bool();
-        let Some(ContextValue::STRING(s)) = context.get("args") else {
+        let in_validation = context.get(ContextKey::IsInValidation).unwrap_or(&ContextValue::BOOLEAN(false)).as_bool();
+        let Some(ContextValue::STRING(s)) = context.get(ContextKey::Args) else {
             return res
         };
         let maybe_model = session.sync_odoo.models.get(s.as_str()).cloned();
         let has_class_in_parents = scope.as_ref().map(|&scope| session.st().get_in_parents(scope, &[SymType::CLASS], true).is_some()).unwrap_or(false);
         if maybe_model.as_ref().map(|m| m.borrow_mut().has_symbols(session.st())).unwrap_or(false) {
             let Some(model) = maybe_model else {unreachable!()};
-            let module = context.get("module");
+            let module = context.get(ContextKey::Module);
             let from_module = if let Some(ContextValue::MODULE(m)) = module {
                 m.upgrade(session.st())
             } else {
@@ -908,7 +909,7 @@ impl PythonArchEvalHooks {
                         // Model exists, but has no main symbols
                         if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03005, &[]) { // Is this error code correct?
                             diagnostics.push(Diagnostic {
-                                range: FileMgr::textRange_to_temporary_Range(&context.get("range").unwrap().as_text_range()),
+                                range: FileMgr::textRange_to_temporary_Range(&context.get(ContextKey::Range).unwrap().as_text_range()),
                                 ..diagnostic_base.clone()
                             });
                         }
@@ -920,7 +921,7 @@ impl PythonArchEvalHooks {
                         }).collect();
                         if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03001, &[&format!("{:?}", valid_modules)]) {
                             diagnostics.push(Diagnostic {
-                                range: FileMgr::textRange_to_temporary_Range(&context.get("range").unwrap().as_text_range()),
+                                range: FileMgr::textRange_to_temporary_Range(&context.get(ContextKey::Range).unwrap().as_text_range()),
                                 ..diagnostic_base.clone()
                             });
                         }
@@ -929,7 +930,7 @@ impl PythonArchEvalHooks {
                     // Model exists, but has no main symbols
                     if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03005, &[]) {
                             diagnostics.push(Diagnostic {
-                                range: FileMgr::textRange_to_temporary_Range(&context.get("range").unwrap().as_text_range()),
+                                range: FileMgr::textRange_to_temporary_Range(&context.get(ContextKey::Range).unwrap().as_text_range()),
                                 ..diagnostic_base
                             });
                     }
@@ -939,7 +940,7 @@ impl PythonArchEvalHooks {
             // Model Unknown
             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03002, &[]) {
                 diagnostics.push(Diagnostic {
-                    range: FileMgr::textRange_to_temporary_Range(&context.get("range").unwrap().as_text_range()),
+                    range: FileMgr::textRange_to_temporary_Range(&context.get(ContextKey::Range).unwrap().as_text_range()),
                     ..diagnostic_base
                 });
             }
@@ -968,7 +969,7 @@ impl PythonArchEvalHooks {
     fn eval_get(_session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, _diagnostics: &mut Vec<Diagnostic>, _scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         if context.is_some() {
-            let parent_instance = context.as_ref().unwrap().get("parent_instance");
+            let parent_instance = context.as_ref().unwrap().get(ContextKey::ParentInstance);
             if parent_instance.is_some() {
                 match parent_instance.unwrap() {
                     ContextValue::BOOLEAN(b) => {
@@ -995,7 +996,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 return_sym.into(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: S!("eval_get")})
             ),
             value: None,
@@ -1019,7 +1020,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 return_sym.into(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: S!("eval_get")})
             ),
             value: None,
@@ -1040,13 +1041,13 @@ impl PythonArchEvalHooks {
     }
 
     fn eval_relational_with_related(session: &mut SessionInfo, related_field: &ContextValue, context: &Context) -> Option<EvaluationSymbolPtr>{
-        let Some(ContextValue::SYMBOL(class_sym_weak)) = context.get("field_parent") else {return None};
+        let Some(ContextValue::SYMBOL(class_sym_weak)) = context.get(ContextKey::FieldParent) else {return None};
         let Some(SymbolKey::Class(class_sym)) = class_sym_weak.upgrade(session.st()) else {return None};
         let related_field_name = related_field.as_str();
         let from_module = session.st().find_module(class_sym);
         let syms = PythonArchEval::get_nested_sub_field(session, related_field_name, class_sym, from_module);
         if let Some(&symbol) = syms.first() {
-            return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: symbol.into(), context: HashMap::default(), instance: Some(true), is_super: false}))
+            return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: symbol.into(), context: Context::default(), instance: Some(true), is_super: false}))
         }
         None
     }
@@ -1059,7 +1060,7 @@ impl PythonArchEvalHooks {
             if let Some(scope) = scope.and_then(|s| session.st().get_file(s)) {
                 session.st_mut().add_model_dependencies(scope, &comodel_sym);
             }
-            let module = context.get("module");
+            let module = context.get(ContextKey::Module);
             let mut from_module = None;
             if let Some(ContextValue::MODULE(m)) = module {
                 if let Some(m) = m.upgrade(session.st()) {
@@ -1068,10 +1069,10 @@ impl PythonArchEvalHooks {
             }
             let main_symbol = comodel_sym.borrow().get_main_symbols(session, from_module);
             if main_symbol.len() == 1 {
-                return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: main_symbol[0].into(), context: HashMap::default(), instance: Some(true), is_super: false}))
+                return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: main_symbol[0].into(), context: Context::default(), instance: Some(true), is_super: false}))
             }
         }
-        Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: HashMap::default(), instance: Some(true), is_super: false}))
+        Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: Context::default(), instance: Some(true), is_super: false}))
     }
 
     fn eval_relational(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
@@ -1079,10 +1080,10 @@ impl PythonArchEvalHooks {
         let Some(context) = context else {
             return None;
         };
-        if let Some(comodel) = context.get("comodel_name") {
+        if let Some(comodel) = context.get(ContextKey::ComodelName) {
             return PythonArchEvalHooks::eval_relational_with_comodel(session, comodel, context, scope);
         }
-        if let Some(related_field) = context.get("related") {
+        if let Some(related_field) = context.get(ContextKey::Related) {
             return PythonArchEvalHooks::eval_relational_with_related(session, related_field, context);
         }
         None
@@ -1097,7 +1098,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 Wk::null(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: S!("eval_relational")})
             ),
             value: None,
@@ -1110,7 +1111,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 Wk::null(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: S!("eval_relational")})
             ),
             value: None,
@@ -1130,70 +1131,68 @@ impl PythonArchEvalHooks {
     {
         let Some(context) = maybe_context else {return None};
 
-        let Some(parameters) = context.get("parameters").map(|ps| ps.as_arguments()) else {return None};
+        let Some(parameters) = context.get(ContextKey::Parameters).map(|ps| ps.as_arguments()) else {return None};
 
         let parent = session.st().get_scope_symbol(
             file_symbol.unwrap(),
-            context.get("range").unwrap().as_text_range().start().to_u32(),
+            context.get(ContextKey::Range).unwrap().as_text_range().start().to_u32(),
             false
         );
-        let mut result_context = HashMap::default();
+        let mut result_context = Context::default();
 
         let mut contexts_to_add = HashMap::default();
         if relational {
             if let Some(first_param) = parameters.args.get(0) {
-                contexts_to_add.insert("comodel_name", (first_param, first_param.range(), "str"));
+                contexts_to_add.insert(ContextKey::ComodelName, (first_param, first_param.range(), "str", ContextKey::ComodelNameArgRange));
             }
             if one2many {
                 if let Some(second_param) = parameters.args.get(1) {
-                    contexts_to_add.insert("inverse_name", (second_param, second_param.range(), "str"));
+                    contexts_to_add.insert(ContextKey::InverseName, (second_param, second_param.range(), "str", ContextKey::InverseNameArgRange));
                 }
             }
         }
 
         // Keyword Arguments for fields that we would like to keep in the context
         let context_arguments = [
-            ("comodel_name", "str"),
-            ("related", "str"),
-            ("compute", "str"),
-            ("inverse", "str"),
-            ("search", "str"),
-            ("inverse_name", "str"),
-            ("delegate", "bool"),
-            ("required", "bool"),
-            ("default", "bool"),
+            ("comodel_name", "str", ContextKey::ComodelName, ContextKey::ComodelNameArgRange),
+            ("related", "str", ContextKey::Related, ContextKey::RelatedArgRange),
+            ("compute", "str", ContextKey::Compute, ContextKey::ComputeArgRange),
+            ("inverse", "str", ContextKey::Inverse, ContextKey::InverseArgRange),
+            ("search", "str", ContextKey::Search, ContextKey::SearchArgRange),
+            ("inverse_name", "str", ContextKey::InverseName, ContextKey::InverseNameArgRange),
+            ("delegate", "bool", ContextKey::Delegate, ContextKey::EMPTY), // No arg range
+            ("required", "bool", ContextKey::Required, ContextKey::EMPTY),
+            ("default", "bool", ContextKey::Default, ContextKey::EMPTY),
         ];
         contexts_to_add.extend(
             context_arguments.into_iter()
-            .filter_map(|(arg_name, only_str)|
-                PythonArchEvalHooks::find_special_arguments(&parameters, arg_name)
-                .map(|(field_name_expr, arg_range)| (arg_name, (field_name_expr, arg_range, only_str)))
+            .filter_map(|(arg_name_str, only_str, arg_name_key, arg_range_key)|
+                PythonArchEvalHooks::find_special_arguments(&parameters, arg_name_str)
+                .map(|(field_name_expr, arg_range)| (arg_name_key, (field_name_expr, arg_range, only_str, arg_range_key)))
             )
         );
 
-        for (arg_name, (field_name_expr, arg_range, bool_or_str)) in contexts_to_add {
+        for (arg_name, (field_name_expr, arg_range, bool_or_str, arg_range_key)) in contexts_to_add {
             match bool_or_str {
                 "str" => if let Some(related_string) = Evaluation::expr_to_str(session, field_name_expr, parent, &parameters.range.start(), false, &mut vec![]).0 {
-                    result_context.insert(S!(arg_name), ContextValue::STRING(related_string.to_string()));
-                    result_context.insert(format!("{arg_name}_arg_range"), ContextValue::RANGE(arg_range.clone()));
+                    result_context.insert(arg_name, ContextValue::STRING(related_string.to_string()));
+                    result_context.insert(arg_range_key, ContextValue::RANGE(arg_range));
                 },
                 "bool" => {
                     let maybe_boolean = Evaluation::expr_to_bool(session, field_name_expr, parent, &parameters.range.start(), false, &mut vec![]).0;
                     if let Some(boolean) = maybe_boolean {
-                        result_context.insert(S!(arg_name), ContextValue::BOOLEAN(boolean));
+                        result_context.insert(arg_name, ContextValue::BOOLEAN(boolean));
                     }
-                    if arg_name == "default" {
-                        result_context.insert(S!("default"), ContextValue::BOOLEAN(true)); //set to True as the value is not really useful for now, but we want the key in context if one default is set
+                    if arg_name == ContextKey::Default {
+                        result_context.insert(ContextKey::Default, ContextValue::BOOLEAN(true)); //set to True as the value is not really useful for now, but we want the key in context if one default is set
                     }
                 },
                 _ => {}
             }
         }
 
-        result_context.extend([
-            (S!("field_parent"), ContextValue::SYMBOL(parent.into())),
-        ]);
-        let weak_eval = match context.get("constructing_class") {
+        result_context.insert(ContextKey::FieldParent, ContextValue::SYMBOL(parent.into()));
+        let weak_eval = match context.get(ContextKey::ConstructingClass) {
             Some(ContextValue::SYMBOL(weak)) if !weak.is_expired(session.st()) => *weak,
             _ => evaluation_sym.get_weak().weak,
         };
@@ -1226,7 +1225,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 Wk::from(symbol), //use the weak to keep reference to the class for the hook.
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(match relational {
                     Some(oyarn) if oyarn == oyarn!("One2many") => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational_one2many, name: S!("eval_init_relational_one2many")},
                     Some(_) => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational, name: S!("eval_init_relational")},
@@ -1338,8 +1337,8 @@ impl PythonArchEvalHooks {
 
     fn eval_env_ref(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         let Some(context) = context else {return None};
-        let in_validation = context.get("is_in_validation").unwrap_or(&ContextValue::BOOLEAN(false)).as_bool();
-        let Some(parameters) = context.get("parameters").map(|ps| ps.as_arguments()) else {return None};
+        let in_validation = context.get(ContextKey::IsInValidation).unwrap_or(&ContextValue::BOOLEAN(false)).as_bool();
+        let Some(parameters) = context.get(ContextKey::Parameters).map(|ps| ps.as_arguments()) else {return None};
         if parameters.args.is_empty() {
             return None; // No arguments to process
         }
@@ -1404,7 +1403,7 @@ impl PythonArchEvalHooks {
             symbol: EvaluationSymbol::new_with_symbol(
                 func_sym.into(),
                 Some(true),
-                HashMap::default(),
+                Context::default(),
                 Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_ref, name: S!("eval_env_ref")})
             ),
             value: None,

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -833,7 +833,7 @@ impl PythonArchEvalHooks {
             diagnostics.extend(diags);
             let mut followed_evals = vec![];
             for eval in dec_evals {
-                followed_evals.extend(SymbolTable::follow_ref(&eval.symbol.get_symbol(session, &mut None, &mut vec![], None), session, &mut None, true, false, None, None));
+                followed_evals.extend(SymbolTable::follow_ref(&eval.symbol.get_symbol(session, None, &mut vec![], None), session, None, true, false, None, None));
             }
             for decorator_eval in followed_evals {
                 let EvaluationSymbolPtr::WEAK(decorator_eval_sym_weak) = decorator_eval else {
@@ -861,7 +861,7 @@ impl PythonArchEvalHooks {
         diagnostics
     }
 
-    pub fn eval_env_get_item(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    pub fn eval_env_get_item(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         let res = Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(Wk::null(), Some(true), false)));
         let Some(context) = context else {
@@ -955,7 +955,7 @@ impl PythonArchEvalHooks {
         res
     }
 
-    pub fn eval_registry_get_item(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    pub fn eval_registry_get_item(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         let mut result = PythonArchEvalHooks::eval_env_get_item(session, evaluation_sym, context, diagnostics, scope);
         match result.as_mut().unwrap() {
@@ -967,10 +967,10 @@ impl PythonArchEvalHooks {
         result
     }
 
-    fn eval_get(_session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &Option<Context>, _diagnostics: &mut Vec<Diagnostic>, _scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    fn eval_get(_session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: Option<&Context>, _diagnostics: &mut Vec<Diagnostic>, _scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         if context.is_some() {
-            let parent_instance = context.as_ref().unwrap().get(ContextKey::ParentInstance);
+            let parent_instance = context.unwrap().get(ContextKey::ParentInstance);
             if parent_instance.is_some() {
                 match parent_instance.unwrap() {
                     ContextValue::BOOLEAN(b) => {
@@ -1076,7 +1076,7 @@ impl PythonArchEvalHooks {
         Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: Context::default(), instance: Some(true), is_super: false}))
     }
 
-    fn eval_relational(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &Option<Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    fn eval_relational(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: Option<&Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         let Some(context) = context else {
             return None;
@@ -1128,7 +1128,7 @@ impl PythonArchEvalHooks {
         })
     }
 
-    fn eval_init_common(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, _diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>, relational: bool, one2many: bool) -> Option<EvaluationSymbolPtr>
+    fn eval_init_common(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: Option<&Context>, _diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>, relational: bool, one2many: bool) -> Option<EvaluationSymbolPtr>
     {
         let Some(context) = maybe_context else {return None};
 
@@ -1205,15 +1205,15 @@ impl PythonArchEvalHooks {
         }));
     }
 
-    fn eval_init(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_init(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, false, false)
     }
 
-    fn eval_init_relational(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_init_relational(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, true, false)
     }
 
-    fn eval_init_relational_one2many(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_init_relational_one2many(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, true, true)
     }
 
@@ -1336,7 +1336,7 @@ impl PythonArchEvalHooks {
         diagnostics
     }
 
-    fn eval_env_ref(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_env_ref(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         let Some(context) = context else {return None};
         let in_validation = context.get(ContextKey::IsInValidation).unwrap_or(&ContextValue::BOOLEAN(false)).as_bool();
         let Some(parameters) = context.get(ContextKey::Parameters).map(|ps| ps.as_arguments()) else {return None};

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -1,4 +1,5 @@
 use crate::core::evaluation::ContextKey;
+use crate::core::evaluation::HookName;
 use crate::utils::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -515,7 +516,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
             symbol: EvaluationSymbol::new_with_symbol(Wk::null(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_get_item, name: S!("eval_env_get_item")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_get_item, name: HookName::EvalEnvGetItem})
             ),
             value: None,
             range: None
@@ -530,7 +531,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
             symbol: EvaluationSymbol::new_with_symbol(Wk::null(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_registry_get_item, name: S!("eval_registry_get_item")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_registry_get_item, name: HookName::EvalRegistryGetItem})
             ),
             value: None,
             range: None
@@ -693,7 +694,7 @@ static arch_eval_function_hooks: Lazy<Vec<PythonArchEvalFunctionHook>> = Lazy::n
                 fields_class_sym.into(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_init, name: S!("eval_init")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_init, name: HookName::EvalInit})
             ),
             value: None,
             range: None,
@@ -997,7 +998,7 @@ impl PythonArchEvalHooks {
                 return_sym.into(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: S!("eval_get")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: HookName::EvalGet})
             ),
             value: None,
             range: None
@@ -1021,7 +1022,7 @@ impl PythonArchEvalHooks {
                 return_sym.into(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: S!("eval_get")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_get, name: HookName::EvalGet})
             ),
             value: None,
             range: None
@@ -1099,7 +1100,7 @@ impl PythonArchEvalHooks {
                 Wk::null(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: S!("eval_relational")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: HookName::EvalRelational})
             ),
             value: None,
             range: None,
@@ -1112,7 +1113,7 @@ impl PythonArchEvalHooks {
                 Wk::null(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: S!("eval_relational")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_relational, name: HookName::EvalRelational})
             ),
             value: None,
             range: None,
@@ -1227,9 +1228,9 @@ impl PythonArchEvalHooks {
                 Some(true),
                 Context::default(),
                 Some(match relational {
-                    Some(oyarn) if oyarn == oyarn!("One2many") => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational_one2many, name: S!("eval_init_relational_one2many")},
-                    Some(_) => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational, name: S!("eval_init_relational")},
-                    None => GetSymbolHook{callable: PythonArchEvalHooks::eval_init, name: S!("eval_init")},
+                    Some(oyarn) if oyarn == oyarn!("One2many") => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational_one2many, name: HookName::EvalInitRelationalOne2many},
+                    Some(_) => GetSymbolHook{callable: PythonArchEvalHooks::eval_init_relational, name: HookName::EvalInitRelational},
+                    None => GetSymbolHook{callable: PythonArchEvalHooks::eval_init, name: HookName::EvalInit},
                 })
             ),
             value: None,
@@ -1404,7 +1405,7 @@ impl PythonArchEvalHooks {
                 func_sym.into(),
                 Some(true),
                 Context::default(),
-                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_ref, name: S!("eval_env_ref")})
+                Some(GetSymbolHook{callable: PythonArchEvalHooks::eval_env_ref, name: HookName::EvalEnvRef})
             ),
             value: None,
             range: None

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -861,7 +861,7 @@ impl PythonArchEvalHooks {
         diagnostics
     }
 
-    pub fn eval_env_get_item(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    pub fn eval_env_get_item(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         let res = Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(Wk::null(), Some(true), false)));
         let Some(context) = context else {
@@ -955,7 +955,7 @@ impl PythonArchEvalHooks {
         res
     }
 
-    pub fn eval_registry_get_item(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    pub fn eval_registry_get_item(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         let mut result = PythonArchEvalHooks::eval_env_get_item(session, evaluation_sym, context, diagnostics, scope);
         match result.as_mut().unwrap() {
@@ -967,7 +967,7 @@ impl PythonArchEvalHooks {
         result
     }
 
-    fn eval_get(_session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, _diagnostics: &mut Vec<Diagnostic>, _scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    fn eval_get(_session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, context: &Option<Context>, _diagnostics: &mut Vec<Diagnostic>, _scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         if context.is_some() {
             let parent_instance = context.as_ref().unwrap().get(ContextKey::ParentInstance);
@@ -1076,7 +1076,7 @@ impl PythonArchEvalHooks {
         Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak{weak: Wk::null(), context: Context::default(), instance: Some(true), is_super: false}))
     }
 
-    fn eval_relational(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    fn eval_relational(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &Option<Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         let Some(context) = context else {
             return None;
@@ -1128,7 +1128,7 @@ impl PythonArchEvalHooks {
         })
     }
 
-    fn eval_init_common(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &mut Option<Context>, _diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>, relational: bool, one2many: bool) -> Option<EvaluationSymbolPtr>
+    fn eval_init_common(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, _diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>, relational: bool, one2many: bool) -> Option<EvaluationSymbolPtr>
     {
         let Some(context) = maybe_context else {return None};
 
@@ -1205,15 +1205,15 @@ impl PythonArchEvalHooks {
         }));
     }
 
-    fn eval_init(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_init(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, false, false)
     }
 
-    fn eval_init_relational(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_init_relational(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, true, false)
     }
 
-    fn eval_init_relational_one2many(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_init_relational_one2many(session: &mut SessionInfo, evaluation_sym: &EvaluationSymbol, maybe_context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, file_symbol: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         return PythonArchEvalHooks::eval_init_common(session, evaluation_sym, maybe_context, diagnostics, file_symbol, true, true)
     }
 
@@ -1336,7 +1336,7 @@ impl PythonArchEvalHooks {
         diagnostics
     }
 
-    fn eval_env_ref(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &mut Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
+    fn eval_env_ref(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: &Option<Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr> {
         let Some(context) = context else {return None};
         let in_validation = context.get(ContextKey::IsInValidation).unwrap_or(&ContextValue::BOOLEAN(false)).as_bool();
         let Some(parameters) = context.get(ContextKey::Parameters).map(|ps| ps.as_arguments()) else {return None};

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -1,4 +1,4 @@
-use crate::core::evaluation::ContextKey;
+use crate::core::evaluation_context::ContextKey;
 use crate::core::evaluation::HookName;
 use crate::utils::HashMap;
 use std::rc::Rc;
@@ -14,7 +14,7 @@ use tracing::warn;
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
 use crate::core::evaluation::GetSymbolHook;
 use crate::core::odoo::SyncOdoo;
-use crate::core::evaluation::Context;
+use crate::core::evaluation_context::Context;
 use crate::constants::*;
 use crate::tree::OYarnExt;
 use crate::tree::Tree;
@@ -30,7 +30,8 @@ use crate::S;
 use crate::tree::TreeStrSlice;
 
 use super::entry_point::EntryPoint;
-use super::evaluation::{ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationSymbol, EvaluationSymbolWeak};
+use super::evaluation::{Evaluation, EvaluationSymbolPtr, EvaluationSymbol, EvaluationSymbolWeak};
+use super::evaluation_context::ContextValue;
 use super::file_mgr::FileMgr;
 use super::python_arch_eval::PythonArchEval;
 

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -5,7 +5,7 @@ use lsp_types::Diagnostic;
 use tracing::error;
 
 use crate::constants::OYarn;
-use crate::core::evaluation::ContextKey;
+use crate::core::evaluation_context::ContextKey;
 use crate::core::model::{Model, ModelData};
 use crate::core::symbols::{ClassSymbol, ModuleSymbol};
 use crate::core::symbols::storage::SymbolTable;
@@ -14,7 +14,8 @@ use crate::threads::SessionInfo;
 use crate::tree::TreeStrSlice;
 use crate::{oyarn, Sy, S};
 
-use super::evaluation::{ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationValue};
+use super::evaluation::{Evaluation, EvaluationSymbolPtr, EvaluationValue};
+use super::evaluation_context::ContextValue;
 
 pub const MAGIC_FIELDS: [&str; 6] = [
     "id",

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -81,8 +81,12 @@ impl PythonOdooBuilder {
         for eval in evaluations.clone() {
             if let Some(eval) = eval.follow_ref_and_get_value(session, &mut None, diagnostics) {
                 match eval {
-                    EvaluationValue::CONSTANT(Expr::StringLiteral(s)) => {
-                        session.st_mut()[symbol]._model.as_mut().unwrap().inherit = vec![oyarn!("{}", s.value)];
+                    EvaluationValue::CONSTANT(c) => {
+                        if let Expr::StringLiteral(s) = c.as_ref() {
+                            session.st_mut()[symbol]._model.as_mut().unwrap().inherit = vec![oyarn!("{}", s.value)];
+                        } else {
+                            error!("wrong _inherit value");
+                        }
                     },
                     EvaluationValue::LIST(l) | EvaluationValue::TUPLE(l)=> {
                         for e in l {
@@ -107,7 +111,7 @@ impl PythonOdooBuilder {
         if let Some(&_name) = _name.last() {
             for eval in session.st().evaluations(_name).unwrap().clone() {
                 let eval = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
-                if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = eval {
+                if let Some(s) = eval.as_ref().and_then(EvaluationValue::as_string_literal) {
                     return oyarn!("{}", s.value);
                 }
             }
@@ -190,86 +194,86 @@ impl PythonOdooBuilder {
     fn _load_class_attributes(&mut self, session: &mut SessionInfo, diagnostics: &mut Vec<Diagnostic>) {
         let symbol = self.symbol;
         let descr = PythonOdooBuilder::_get_attribute(session, symbol, &"_description".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = descr {
+        if let Some(s) = descr.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().description = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().description = session.st()[symbol]._model.as_ref().unwrap().name.to_string();
         }
         let auto = PythonOdooBuilder::_get_attribute(session, symbol, &"_auto".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::BooleanLiteral(b))) = auto {
-            session.st_mut()[symbol]._model.as_mut().unwrap().auto = b.value;
+        if let Some(b) = auto.as_ref().and_then(EvaluationValue::as_bool_literal) {
+            session.st_mut()[symbol]._model.as_mut().unwrap().auto = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().auto = false;
         }
         let log_access = PythonOdooBuilder::_get_attribute(session, symbol, &"_log_access".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::BooleanLiteral(b))) = log_access {
-            session.st_mut()[symbol]._model.as_mut().unwrap().log_access = b.value;
+        if let Some(b) = log_access.as_ref().and_then(EvaluationValue::as_bool_literal) {
+            session.st_mut()[symbol]._model.as_mut().unwrap().log_access = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().log_access = session.st()[symbol]._model.as_ref().unwrap().auto;
         }
         let table = PythonOdooBuilder::_get_attribute(session, symbol, &"_table".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = table {
+        if let Some(s) = table.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().table = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().table = session.st()[symbol]._model.as_ref().unwrap().name.replace(".", "_");
         }
         let sequence = PythonOdooBuilder::_get_attribute(session, symbol, &"_sequence".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = sequence {
+        if let Some(s) = sequence.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().sequence = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().sequence = session.st()[symbol]._model.as_ref().unwrap().table.clone() + "_id_seq";
         }
         let is_abstract = PythonOdooBuilder::_get_attribute(session, symbol, &"_abstract".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::BooleanLiteral(b))) = is_abstract {
-            session.st_mut()[symbol]._model.as_mut().unwrap().is_abstract = b.value;
+        if let Some(b) = is_abstract.as_ref().and_then(EvaluationValue::as_bool_literal) {
+            session.st_mut()[symbol]._model.as_mut().unwrap().is_abstract = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().is_abstract = true;
         }
         let transient = PythonOdooBuilder::_get_attribute(session, symbol, &"_transient".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::BooleanLiteral(b))) = transient {
-            session.st_mut()[symbol]._model.as_mut().unwrap().transient = b.value;
+        if let Some(b) = transient.as_ref().and_then(EvaluationValue::as_bool_literal) {
+            session.st_mut()[symbol]._model.as_mut().unwrap().transient = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().transient = false;
         }
         let rec_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_rec_name".to_string(), diagnostics);
         //TODO check that rec_name is a field
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = rec_name {
+        if let Some(s) = rec_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().rec_name = Some(S!(s.value.to_str()));
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().rec_name = Some(S!("name")); //TODO if name is not on model, take 'id'
         }
         let _check_company_auto = PythonOdooBuilder::_get_attribute(session, symbol, &"_check_company_auto".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::BooleanLiteral(b))) = _check_company_auto {
-            session.st_mut()[symbol]._model.as_mut().unwrap().check_company_auto = b.value;
+        if let Some(b) = _check_company_auto.as_ref().and_then(EvaluationValue::as_bool_literal) {
+            session.st_mut()[symbol]._model.as_mut().unwrap().check_company_auto = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().check_company_auto = false;
         }
         let parent_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_parent_name".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = parent_name {
+        if let Some(s) = parent_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().parent_name = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().parent_name = S!("parent_id");
         }
         let parent_store = PythonOdooBuilder::_get_attribute(session, symbol, &"_parent_store".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::BooleanLiteral(b))) = parent_store {
-            session.st_mut()[symbol]._model.as_mut().unwrap().parent_store = b.value;
+        if let Some(b) = parent_store.as_ref().and_then(EvaluationValue::as_bool_literal) {
+            session.st_mut()[symbol]._model.as_mut().unwrap().parent_store = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().parent_store = false;
         }
         let active_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_active_name".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = active_name {
+        if let Some(s) = active_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().active_name = Some(S!(s.value.to_str()));
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().active_name = None;
         }
         let data_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_data_name".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = data_name {
+        if let Some(s) = data_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().data_name = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().data_name = S!("date");
         }
         let fold_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_fold_name".to_string(), diagnostics);
-        if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(s))) = fold_name {
+        if let Some(s) = fold_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().fold_name = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().fold_name = S!("fold");
@@ -354,10 +358,7 @@ impl PythonOdooBuilder {
             // Read all boolean values, ignore non-boolean-value evaluations, as they can be dynamic or type annotations
             let register_evals_values: Vec<_> = register_evals.iter().filter_map(
                 |eval|
-                    match eval.follow_ref_and_get_value(session, &mut None, diagnostics)? {
-                        EvaluationValue::CONSTANT(Expr::BooleanLiteral(b)) => Some(b.value),
-                        _ => None,
-                    }
+                    eval.follow_ref_and_get_value(session, &mut None, diagnostics)?.as_bool_literal()
             ).collect();
             // If we have exactly *one* False value evaluation, we consider _register = False, thus it is an abstract model
             if register_evals_values == &[false] {

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -79,7 +79,7 @@ impl PythonOdooBuilder {
             return;
         }
         for eval in evaluations.clone() {
-            if let Some(eval) = eval.follow_ref_and_get_value(session, &mut None, diagnostics) {
+            if let Some(eval) = eval.follow_ref_and_get_value(session, None, diagnostics) {
                 match eval {
                     EvaluationValue::CONSTANT(c) => {
                         if let Expr::StringLiteral(s) = c.as_ref() {
@@ -110,7 +110,7 @@ impl PythonOdooBuilder {
         let _name = session.st().get_symbol(symbol.into(), (&[], &["_name"]), u32::MAX);
         if let Some(&_name) = _name.last() {
             for eval in session.st().evaluations(_name).unwrap().clone() {
-                let eval = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
+                let eval = eval.follow_ref_and_get_value(session, None, diagnostics);
                 if let Some(s) = eval.as_ref().and_then(EvaluationValue::as_string_literal) {
                     return oyarn!("{}", s.value);
                 }
@@ -142,7 +142,7 @@ impl PythonOdooBuilder {
         let _inherits = session.st().get_symbol(symbol.into(), (&[], &["_inherits"]), u32::MAX);
         if let Some(&SymbolKey::Variable(_inherits)) = _inherits.last() {
             if let Some(eval) = session.st()[_inherits].evaluations.last().cloned() {
-                let eval = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
+                let eval = eval.follow_ref_and_get_value(session, None, diagnostics);
                 let model = session.st_mut()[symbol]._model.as_mut().unwrap();
                 model.inherits.clear();
                 if let Some(EvaluationValue::DICT(d)) = eval {
@@ -165,7 +165,7 @@ impl PythonOdooBuilder {
                 let Some(evals) = session.st().evaluations(*symbol) else { continue };
                 for eval in evals.clone() {
                     let scope = session.st().get_file(self.symbol.into()).map(SymbolKey::from);
-                    let symbol_weak = eval.symbol.get_symbol_as_weak(session, &mut None, diagnostics, scope);
+                    let symbol_weak = eval.symbol.get_symbol_as_weak(session, None, diagnostics, scope);
                     let Some(eval_symbol) = symbol_weak.weak.upgrade(session.st()) else { continue };
                     if session.st().name(eval_symbol) != &Sy!("Many2one") { continue; }
                     let context = &symbol_weak.context;
@@ -183,7 +183,7 @@ impl PythonOdooBuilder {
         let (attr_sym, _) = SymbolTable::get_member_symbol(session, loc_sym.into(), attr, None, true, false, false, false, false);
         let &attr_sym = attr_sym.first()?;
         for eval in session.st().evaluations(attr_sym).unwrap().clone() {
-            let eval = eval.follow_ref_and_get_value(session, &mut None, diagnostics);
+            let eval = eval.follow_ref_and_get_value(session, None, diagnostics);
             if eval.is_some() {
                 return eval;
             }
@@ -358,7 +358,7 @@ impl PythonOdooBuilder {
             // Read all boolean values, ignore non-boolean-value evaluations, as they can be dynamic or type annotations
             let register_evals_values: Vec<_> = register_evals.iter().filter_map(
                 |eval|
-                    eval.follow_ref_and_get_value(session, &mut None, diagnostics)?.as_bool_literal()
+                    eval.follow_ref_and_get_value(session, None, diagnostics)?.as_bool_literal()
             ).collect();
             // If we have exactly *one* False value evaluation, we consider _register = False, thus it is an abstract model
             if register_evals_values == &[false] {
@@ -374,8 +374,8 @@ impl PythonOdooBuilder {
                 continue;
             };
             for eval in evals.clone() {
-                let eval_sym_ptr = eval.symbol.get_symbol(session, &mut None,  &mut vec![], None);
-                let eval_ptrs = SymbolTable::follow_ref(&eval_sym_ptr, session, &mut None, true, false, None, None);
+                let eval_sym_ptr = eval.symbol.get_symbol(session, None,  &mut vec![], None);
+                let eval_ptrs = SymbolTable::follow_ref(&eval_sym_ptr, session, None, true, false, None, None);
                 for eval_ptr in eval_ptrs.iter() {
                     let eval_weak = match &eval_ptr {
                         EvaluationSymbolPtr::WEAK(w) => w,

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -4,7 +4,8 @@ use ruff_python_ast::Expr;
 use lsp_types::Diagnostic;
 use tracing::error;
 
-use crate::constants::{OYarn};
+use crate::constants::OYarn;
+use crate::core::evaluation::ContextKey;
 use crate::core::model::{Model, ModelData};
 use crate::core::symbols::{ClassSymbol, ModuleSymbol};
 use crate::core::symbols::storage::SymbolTable;
@@ -164,8 +165,8 @@ impl PythonOdooBuilder {
                     let Some(eval_symbol) = symbol_weak.weak.upgrade(session.st()) else { continue };
                     if session.st().name(eval_symbol) != &Sy!("Many2one") { continue; }
                     let context = &symbol_weak.context;
-                    let Some(delegate) = context.get("delegate") else { continue };
-                    if delegate.as_bool() == true && let Some(comodel) = context.get("comodel_name") {
+                    let Some(delegate) = context.get(ContextKey::Delegate) else { continue };
+                    if delegate.as_bool() == true && let Some(comodel) = context.get(ContextKey::ComodelName) {
                         let comodel_name = oyarn!("{}", comodel.as_str());
                         session.st_mut()[self.symbol]._model.as_mut().unwrap().inherits.push((comodel_name, field_name.clone()));
                     }
@@ -385,7 +386,7 @@ impl PythonOdooBuilder {
                     if !SymbolTable::is_field_class(session, member_symbol) {
                         continue;
                     }
-                    if let Some(ContextValue::STRING(compute_ctx_val)) = eval_weak.context.get("compute") {
+                    if let Some(ContextValue::STRING(compute_ctx_val)) = eval_weak.context.get(ContextKey::Compute) {
                         let name = session.st().name(field).clone();
                         session.st_mut()[symbol]._model.as_mut().unwrap().computes.entry(oyarn!("{}", compute_ctx_val)).or_default().insert(name);
                     }

--- a/server/src/core/python_odoo_builder.rs
+++ b/server/src/core/python_odoo_builder.rs
@@ -179,7 +179,7 @@ impl PythonOdooBuilder {
         }
     }
 
-    fn _get_attribute(session: &mut SessionInfo, loc_sym: ClassKey, attr: &String, diagnostics: &mut Vec<Diagnostic>) -> Option<EvaluationValue> {
+    fn _get_attribute(session: &mut SessionInfo, loc_sym: ClassKey, attr: &str, diagnostics: &mut Vec<Diagnostic>) -> Option<EvaluationValue> {
         let (attr_sym, _) = SymbolTable::get_member_symbol(session, loc_sym.into(), attr, None, true, false, false, false, false);
         let &attr_sym = attr_sym.first()?;
         for eval in session.st().evaluations(attr_sym).unwrap().clone() {
@@ -193,86 +193,86 @@ impl PythonOdooBuilder {
 
     fn _load_class_attributes(&mut self, session: &mut SessionInfo, diagnostics: &mut Vec<Diagnostic>) {
         let symbol = self.symbol;
-        let descr = PythonOdooBuilder::_get_attribute(session, symbol, &"_description".to_string(), diagnostics);
+        let descr = PythonOdooBuilder::_get_attribute(session, symbol, "_description", diagnostics);
         if let Some(s) = descr.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().description = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().description = session.st()[symbol]._model.as_ref().unwrap().name.to_string();
         }
-        let auto = PythonOdooBuilder::_get_attribute(session, symbol, &"_auto".to_string(), diagnostics);
+        let auto = PythonOdooBuilder::_get_attribute(session, symbol, "_auto", diagnostics);
         if let Some(b) = auto.as_ref().and_then(EvaluationValue::as_bool_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().auto = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().auto = false;
         }
-        let log_access = PythonOdooBuilder::_get_attribute(session, symbol, &"_log_access".to_string(), diagnostics);
+        let log_access = PythonOdooBuilder::_get_attribute(session, symbol, "_log_access", diagnostics);
         if let Some(b) = log_access.as_ref().and_then(EvaluationValue::as_bool_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().log_access = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().log_access = session.st()[symbol]._model.as_ref().unwrap().auto;
         }
-        let table = PythonOdooBuilder::_get_attribute(session, symbol, &"_table".to_string(), diagnostics);
+        let table = PythonOdooBuilder::_get_attribute(session, symbol, "_table", diagnostics);
         if let Some(s) = table.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().table = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().table = session.st()[symbol]._model.as_ref().unwrap().name.replace(".", "_");
         }
-        let sequence = PythonOdooBuilder::_get_attribute(session, symbol, &"_sequence".to_string(), diagnostics);
+        let sequence = PythonOdooBuilder::_get_attribute(session, symbol, "_sequence", diagnostics);
         if let Some(s) = sequence.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().sequence = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().sequence = session.st()[symbol]._model.as_ref().unwrap().table.clone() + "_id_seq";
         }
-        let is_abstract = PythonOdooBuilder::_get_attribute(session, symbol, &"_abstract".to_string(), diagnostics);
+        let is_abstract = PythonOdooBuilder::_get_attribute(session, symbol, "_abstract", diagnostics);
         if let Some(b) = is_abstract.as_ref().and_then(EvaluationValue::as_bool_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().is_abstract = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().is_abstract = true;
         }
-        let transient = PythonOdooBuilder::_get_attribute(session, symbol, &"_transient".to_string(), diagnostics);
+        let transient = PythonOdooBuilder::_get_attribute(session, symbol, "_transient", diagnostics);
         if let Some(b) = transient.as_ref().and_then(EvaluationValue::as_bool_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().transient = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().transient = false;
         }
-        let rec_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_rec_name".to_string(), diagnostics);
+        let rec_name = PythonOdooBuilder::_get_attribute(session, symbol, "_rec_name", diagnostics);
         //TODO check that rec_name is a field
         if let Some(s) = rec_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().rec_name = Some(S!(s.value.to_str()));
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().rec_name = Some(S!("name")); //TODO if name is not on model, take 'id'
         }
-        let _check_company_auto = PythonOdooBuilder::_get_attribute(session, symbol, &"_check_company_auto".to_string(), diagnostics);
+        let _check_company_auto = PythonOdooBuilder::_get_attribute(session, symbol, "_check_company_auto", diagnostics);
         if let Some(b) = _check_company_auto.as_ref().and_then(EvaluationValue::as_bool_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().check_company_auto = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().check_company_auto = false;
         }
-        let parent_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_parent_name".to_string(), diagnostics);
+        let parent_name = PythonOdooBuilder::_get_attribute(session, symbol, "_parent_name", diagnostics);
         if let Some(s) = parent_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().parent_name = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().parent_name = S!("parent_id");
         }
-        let parent_store = PythonOdooBuilder::_get_attribute(session, symbol, &"_parent_store".to_string(), diagnostics);
+        let parent_store = PythonOdooBuilder::_get_attribute(session, symbol, "_parent_store", diagnostics);
         if let Some(b) = parent_store.as_ref().and_then(EvaluationValue::as_bool_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().parent_store = b;
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().parent_store = false;
         }
-        let active_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_active_name".to_string(), diagnostics);
+        let active_name = PythonOdooBuilder::_get_attribute(session, symbol, "_active_name", diagnostics);
         if let Some(s) = active_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().active_name = Some(S!(s.value.to_str()));
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().active_name = None;
         }
-        let data_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_data_name".to_string(), diagnostics);
+        let data_name = PythonOdooBuilder::_get_attribute(session, symbol, "_data_name", diagnostics);
         if let Some(s) = data_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().data_name = S!(s.value.to_str());
         } else {
             session.st_mut()[symbol]._model.as_mut().unwrap().data_name = S!("date");
         }
-        let fold_name = PythonOdooBuilder::_get_attribute(session, symbol, &"_fold_name".to_string(), diagnostics);
+        let fold_name = PythonOdooBuilder::_get_attribute(session, symbol, "_fold_name", diagnostics);
         if let Some(s) = fold_name.as_ref().and_then(EvaluationValue::as_string_literal) {
             session.st_mut()[symbol]._model.as_mut().unwrap().fold_name = S!(s.value.to_str());
         } else {

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -446,7 +446,7 @@ impl PythonValidator {
                                         return false
                                     };
                                     let found =
-                                        SymbolTable::get_member_symbol(session, related_field_class_sym, &S!("type"), None, false, false, false, false, false)
+                                        SymbolTable::get_member_symbol(session, related_field_class_sym, "type", None, false, false, false, false, false)
                                         .0.first()
                                         .and_then(|field_type_var| session.st().evaluations(*field_type_var).cloned())
                                         .and_then(|evals| evals.first().cloned())

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -341,7 +341,7 @@ impl PythonValidator {
                 if let Some(variable) = variable {
                     let v = variable.unwrap_variable_key();
                     for evaluation in session.st()[v].evaluations.clone() {
-                        let eval_sym = evaluation.symbol.get_symbol(session, &mut None, &mut self.diagnostics, Some(file_symbol.into()));
+                        let eval_sym = evaluation.symbol.get_symbol(session, None, &mut self.diagnostics, Some(file_symbol.into()));
                         match eval_sym {
                             EvaluationSymbolPtr::WEAK(w) => {
                                 if let Some(symbol) = w.weak.upgrade(session.st()) {
@@ -406,8 +406,8 @@ impl PythonValidator {
             };
             let evals = session.st()[v].evaluations.clone();
             for eval in evals.iter() {
-                let symbol = eval.symbol.get_symbol(session, &mut None,  &mut vec![], None);
-                let eval_weaks = SymbolTable::follow_ref(&symbol, session, &mut None, true, false, None, None);
+                let symbol = eval.symbol.get_symbol(session, None,  &mut vec![], None);
+                let eval_weaks = SymbolTable::follow_ref(&symbol, session, None, true, false, None, None);
                 for eval_weak in eval_weaks {
                     let Some(symbol) = eval_weak.upgrade_weak(session.st()) else {continue};
                     if !SymbolTable::is_field_class(session, symbol) {
@@ -440,7 +440,7 @@ impl PythonValidator {
                                     sym,
                                     None,
                                     false,
-                                )), session, &mut None, true, true, None, None);
+                                )), session, None, true, true, None, None);
                                 related_eval_weaks.iter().any(|related_eval_weak|{
                                     let Some(related_field_class_sym) = related_eval_weak.upgrade_weak(session.st()) else {
                                         return false
@@ -579,9 +579,9 @@ impl PythonValidator {
                                 let evals = session.st().evaluations(sym).cloned().unwrap();
                                 for eval in evals {
                                     let followed = SymbolTable::follow_ref(
-                                        &eval.symbol.get_symbol(session, &mut None, &mut vec![], None),
+                                        &eval.symbol.get_symbol(session, None, &mut vec![], None),
                                         session,
-                                        &mut None,
+                                        None,
                                         true,
                                         false,
                                         None,
@@ -618,7 +618,7 @@ impl PythonValidator {
         if let Some(&inherit) = inherit.last() {
             let inherit_evals = session.st().evaluations(inherit).cloned().unwrap();
             for inherit_eval in inherit_evals {
-                let inherit_value = inherit_eval.follow_ref_and_get_value(session, &mut None, &mut vec![]);
+                let inherit_value = inherit_eval.follow_ref_and_get_value(session, None, &mut vec![]);
                 if let Some(inherit_value) = inherit_value {
                     match inherit_value {
                         EvaluationValue::CONSTANT(c) => {
@@ -664,7 +664,7 @@ impl PythonValidator {
                 let evals = session.st().evaluations(_name).cloned().unwrap();
                 // Try to get the string value range, otherwise stick to _name var range.
                 if let Some(eval_range) = evals.iter().find_map(|e|
-                    match e.follow_ref_and_get_value(session, &mut None, &mut self.diagnostics) {
+                    match e.follow_ref_and_get_value(session, None, &mut self.diagnostics) {
                         Some(v) if v.as_string_literal().is_some() => e.range,
                         _ => None,
                     }
@@ -684,7 +684,7 @@ impl PythonValidator {
         if let Some(&inherits) = inherits.last() {
             let inherits_evals = session.st().evaluations(inherits).cloned().unwrap();
             for inherits_eval in inherits_evals {
-                let inherits_value = inherits_eval.follow_ref_and_get_value(session, &mut None, &mut vec![]);
+                let inherits_value = inherits_eval.follow_ref_and_get_value(session, None, &mut vec![]);
                 if let Some(inherits_value) = inherits_value {
                     match inherits_value {
                         EvaluationValue::DICT(d) => {

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 use lsp_types::{Diagnostic, Position, Range};
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
-use crate::core::evaluation::{ContextKey, ContextValue};
+use crate::core::evaluation_context::{ContextKey, ContextValue};
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SourceFileKey, SymbolKey};
 use crate::{constants::*, oyarn};

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -432,10 +432,7 @@ impl PythonValidator {
                                 .and_then(|field_type_var| session.st().evaluations(*field_type_var).cloned())
                                 .and_then(|evals| evals.first().cloned())
                                 .and_then(|eval| eval.value.clone())
-                                .and_then(|value| match value {
-                                    EvaluationValue::CONSTANT(Expr::StringLiteral(s)) => Some(s.value.to_string()),
-                                    _ => None,
-                                }) else {
+                                .and_then(|value| value.as_string_literal().map(|s| s.value.to_string())) else {
                                 break 'related_check;
                             };
                             let found_same_type_match = syms.iter().any(|&sym| {
@@ -454,7 +451,7 @@ impl PythonValidator {
                                         .and_then(|field_type_var| session.st().evaluations(*field_type_var).cloned())
                                         .and_then(|evals| evals.first().cloned())
                                         .and_then(|eval| eval.value.clone())
-                                        .map(|value| matches!(value, EvaluationValue::CONSTANT(Expr::StringLiteral(s)) if s.value.to_str() == field_type))
+                                        .map(|value| value.as_string_literal().is_some_and(|s| s.value.to_str() == field_type))
                                         .unwrap_or(false);
                                     found
                                 })
@@ -624,8 +621,10 @@ impl PythonValidator {
                 let inherit_value = inherit_eval.follow_ref_and_get_value(session, &mut None, &mut vec![]);
                 if let Some(inherit_value) = inherit_value {
                     match inherit_value {
-                        EvaluationValue::CONSTANT(Expr::StringLiteral(s)) => {
-                            self._check_module_dependency(session, class, s.value.to_str(), &s.range());
+                        EvaluationValue::CONSTANT(c) => {
+                            if let Expr::StringLiteral(s) = c.as_ref() {
+                                self._check_module_dependency(session, class, s.value.to_str(), &s.range());
+                            }
                         },
                         EvaluationValue::LIST(l) => {
                             for e in l {
@@ -666,7 +665,7 @@ impl PythonValidator {
                 // Try to get the string value range, otherwise stick to _name var range.
                 if let Some(eval_range) = evals.iter().find_map(|e|
                     match e.follow_ref_and_get_value(session, &mut None, &mut self.diagnostics) {
-                        Some(EvaluationValue::CONSTANT(Expr::StringLiteral(_))) => e.range,
+                        Some(v) if v.as_string_literal().is_some() => e.range,
                         _ => None,
                     }
                 ) {

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 use lsp_types::{Diagnostic, Position, Range};
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
-use crate::core::evaluation::ContextValue;
+use crate::core::evaluation::{ContextKey, ContextValue};
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SourceFileKey, SymbolKey};
 use crate::{constants::*, oyarn};
@@ -414,8 +414,8 @@ impl PythonValidator {
                         continue;
                     }
                     'related_check: {
-                        if let Some(related_field_name) = eval_weak.get_weak().context.get("related").filter(|val| matches!(val, ContextValue::STRING(_))).map(ContextValue::as_str) {
-                            let Some(special_arg_range) = eval_weak.get_weak().context.get("related_arg_range").map(|ctx_val| ctx_val.as_text_range()) else {
+                        if let Some(related_field_name) = eval_weak.get_weak().context.get(ContextKey::Related).filter(|val| matches!(val, ContextValue::STRING(_))).map(ContextValue::as_str) {
+                            let Some(special_arg_range) = eval_weak.get_weak().context.get(ContextKey::RelatedArgRange).map(|ctx_val| ctx_val.as_text_range()) else {
                                 break 'related_check;
                             };
                             let syms = PythonArchEval::get_nested_sub_field(session, related_field_name, class, maybe_from_module);
@@ -471,8 +471,8 @@ impl PythonValidator {
                         }
                     }
                     'comodel_check: {
-                        if let Some(comodel_field_name) = eval_weak.get_weak().context.get("comodel_name").map(ContextValue::as_str) {
-                            let Some(special_arg_range) = eval_weak.get_weak().context.get("comodel_name_arg_range").map(|ctx_val| ctx_val.as_text_range()) else {
+                        if let Some(comodel_field_name) = eval_weak.get_weak().context.get(ContextKey::ComodelName).map(ContextValue::as_str) {
+                            let Some(special_arg_range) = eval_weak.get_weak().context.get(ContextKey::ComodelNameArgRange).map(|ctx_val| ctx_val.as_text_range()) else {
                                 break 'comodel_check;
                             };
                             let Some(file_symbol) = session.st().get_file(class.into()) else {
@@ -506,7 +506,11 @@ impl PythonValidator {
                             session.sync_odoo.get_main_entry().borrow_mut().not_found_symbols_for_models.insert(file_symbol);
                         }
                     }
-                    for special_fn_field_name in ["compute", "inverse", "search"]{
+                    for (special_fn_field_name, special_fn_field_arg_range) in [
+                        (ContextKey::Compute, ContextKey::ComputeArgRange),
+                        (ContextKey::Inverse, ContextKey::InverseArgRange),
+                        (ContextKey::Search, ContextKey::SearchArgRange),
+                    ]{
                         let Some(method_name) = eval_weak.get_weak().context.get(special_fn_field_name).map(ContextValue::as_str) else {
                             continue;
                         };
@@ -524,7 +528,7 @@ impl PythonValidator {
                         );
                         let method_found = !symbols.is_empty();
                         if !method_found{
-                            let Some(arg_range) = eval_weak.get_weak().context.get(&format!("{special_fn_field_name}_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
+                            let Some(arg_range) = eval_weak.get_weak().context.get(special_fn_field_arg_range).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };
                             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03018, &[method_name]) {
@@ -536,8 +540,8 @@ impl PythonValidator {
 
                         }
                     }
-                    if let Some(inverse_name) = eval_weak.get_weak().context.get("inverse_name").map(ContextValue::as_str) {
-                        let Some(comodel_name) = eval_weak.get_weak().context.get("comodel_name").map(ContextValue::as_str) else {
+                    if let Some(inverse_name) = eval_weak.get_weak().context.get(ContextKey::InverseName).map(ContextValue::as_str) {
+                        let Some(comodel_name) = eval_weak.get_weak().context.get(ContextKey::ComodelName).map(ContextValue::as_str) else {
                             continue;
                         };
                         let Some(model) = session.sync_odoo.models.get(comodel_name).cloned() else {
@@ -551,7 +555,7 @@ impl PythonValidator {
                             SymbolTable::get_member_symbol(session, main_sym.into(), inverse_name, Some(module), false, true, false, true, false).0
                         ).collect();
                         if symbols.is_empty() {
-                            let Some(arg_range) = eval_weak.get_weak().context.get("inverse_name_arg_range").map(|ctx_val| ctx_val.as_text_range()) else {
+                            let Some(arg_range) = eval_weak.get_weak().context.get(ContextKey::InverseNameArgRange).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };
                             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03021, &[inverse_name, comodel_name]) {
@@ -562,7 +566,7 @@ impl PythonValidator {
                             }
                         }
                         if symbols.iter().any(|&sym| !SymbolTable::is_specific_field(session, sym, &["Many2one", "Many2oneReference"])) {
-                            let Some(arg_range) = eval_weak.get_weak().context.get("inverse_name_arg_range").map(|ctx_val| ctx_val.as_text_range()) else {
+                            let Some(arg_range) = eval_weak.get_weak().context.get(ContextKey::InverseNameArgRange).map(|ctx_val| ctx_val.as_text_range()) else {
                                 continue;
                             };
                             if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03022, &[]) {
@@ -590,13 +594,13 @@ impl PythonValidator {
                                 }
                             }
                             for comodel_eval_weak in comodel_eval_weaks {
-                                let Some(comodel_name) = comodel_eval_weak.get_weak().context.get("comodel_name").map(ContextValue::as_str) else {
+                                let Some(comodel_name) = comodel_eval_weak.get_weak().context.get(ContextKey::ComodelName).map(ContextValue::as_str) else {
                                     continue;
                                 };
                                 if model_name == comodel_name { // valid
                                     continue;
                                 }
-                                let Some(arg_range) = eval_weak.get_weak().context.get("inverse_name_arg_range").map(|ctx_val| ctx_val.as_text_range()) else {
+                                let Some(arg_range) = eval_weak.get_weak().context.get(ContextKey::InverseNameArgRange).map(|ctx_val| ctx_val.as_text_range()) else {
                                     continue;
                                 };
                                 if let Some(diagnostic_base) = create_diagnostic(&session, DiagnosticCode::OLS03023, &[inverse_name, &model_name, comodel_name]) {

--- a/server/src/core/symbols/storage/function_symbol.rs
+++ b/server/src/core/symbols/storage/function_symbol.rs
@@ -4,7 +4,8 @@ use lsp_types::Diagnostic;
 use ruff_python_ast::{AtomicNodeIndex, Expr, ExprCall};
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{evaluation::{Context, Evaluation}, file_mgr::NoqaInfo, symbols::{SymbolTable, symbol_keys::{FunctionKey, SymbolKey, VariableKey, Wk}}}, oyarn, threads::SessionInfo};
+use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{evaluation::{Evaluation}, file_mgr::NoqaInfo, symbols::{SymbolTable, symbol_keys::{FunctionKey, SymbolKey, VariableKey, Wk}}}, oyarn, threads::SessionInfo};
+use crate::core::evaluation_context::Context;
 
 use super::{symbol_mgr::{SectionRange, SymbolMgr}};
 

--- a/server/src/core/symbols/storage/variable_symbol.rs
+++ b/server/src/core/symbols/storage/variable_symbol.rs
@@ -1,8 +1,7 @@
 use ruff_text_size::TextRange;
 
-use crate::{S, constants::OYarn, core::{evaluation::{ContextValue, Evaluation}, symbols::storage::SymbolTable}, threads::SessionInfo};
+use crate::{constants::OYarn, core::{evaluation::{Context, ContextKey, ContextValue, Evaluation}, symbols::storage::SymbolTable}, threads::SessionInfo};
 use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SymbolKey, VariableKey};
-use crate::utils::HashMap;
 
 #[derive(Debug)]
 pub struct VariableSymbol {
@@ -64,13 +63,13 @@ impl VariableSymbol {
             let parent = session.st()[target].parent();
             // To be able to follow related fields, we need to have the base_attr set in order to find the __get__ hook in next_refs
             // we update the context here for the case where we are coming from a decorator for example.
-            let mut context = Some(HashMap::default());
-            context.as_mut().unwrap().insert(S!("base_attr"), ContextValue::SYMBOL(parent.into()));
+            let mut context = Some(Context::default());
+            context.as_mut().unwrap().insert(ContextKey::BaseAttr, ContextValue::SYMBOL(parent.into()));
             let eval_weaks = SymbolTable::follow_ref(&symbol, session, &mut context, false, false, None, None);
             for eval_weak in eval_weaks.iter() {
                 if let Some(symbol) = eval_weak.upgrade_weak(session.st()) {
                     if ["Many2one", "One2many", "Many2many"].contains(&session.st().name(symbol).as_str()) {
-                        let Some(comodel) = eval_weak.get_weak().context.get("comodel_name") else {
+                        let Some(comodel) = eval_weak.get_weak().context.get(ContextKey::ComodelName) else {
                             continue;
                         };
                         let Some(model) = session.sync_odoo.models.get(comodel.as_str()) else {

--- a/server/src/core/symbols/storage/variable_symbol.rs
+++ b/server/src/core/symbols/storage/variable_symbol.rs
@@ -1,6 +1,7 @@
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::{evaluation::{Context, ContextKey, ContextValue, Evaluation}, symbols::storage::SymbolTable}, threads::SessionInfo};
+use crate::{constants::OYarn, core::{evaluation::{Evaluation}, symbols::storage::SymbolTable}, threads::SessionInfo};
+use crate::core::evaluation_context::{Context, ContextKey, ContextValue};
 use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SymbolKey, VariableKey};
 
 #[derive(Debug)]

--- a/server/src/core/symbols/storage/variable_symbol.rs
+++ b/server/src/core/symbols/storage/variable_symbol.rs
@@ -59,13 +59,12 @@ impl VariableSymbol {
         let variable_symbol = &session.st()[target]; // former method taking self
         let evaluations = variable_symbol.evaluations.clone();
         for eval in evaluations.iter() {
-            let symbol = eval.symbol.get_symbol(session, &mut None, &mut vec![], None);
+            let symbol = eval.symbol.get_symbol(session, None, &mut vec![], None);
             let parent = session.st()[target].parent();
             // To be able to follow related fields, we need to have the base_attr set in order to find the __get__ hook in next_refs
             // we update the context here for the case where we are coming from a decorator for example.
-            let mut context = Some(Context::default());
-            context.as_mut().unwrap().insert(ContextKey::BaseAttr, ContextValue::SYMBOL(parent.into()));
-            let eval_weaks = SymbolTable::follow_ref(&symbol, session, &mut context, false, false, None, None);
+            let context = Context::from_iter([(ContextKey::BaseAttr, ContextValue::SYMBOL(parent.into()))]);
+            let eval_weaks = SymbolTable::follow_ref(&symbol, session, Some(&context), false, false, None, None);
             for eval_weak in eval_weaks.iter() {
                 if let Some(symbol) = eval_weak.upgrade_weak(session.st()) {
                     if ["Many2one", "One2many", "Many2many"].contains(&session.st().name(symbol).as_str()) {

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
     rc::Rc,
 };
-use crate::{core::evaluation::ContextKey, utils::{HashMap, HashSet}};
+use crate::{core::evaluation_context::ContextKey, utils::{HashMap, HashSet}};
 
 use lsp_types::{Diagnostic, DiagnosticTag, Range, SymbolKind};
 use ruff_text_size::TextRange;
@@ -14,7 +14,7 @@ use crate::{
     constants::{BuildStatus, BuildSteps, OYarn, PackageType, SymType}, core::{
         diagnostics::{DiagnosticCode, create_diagnostic},
         entry_point::EntryPoint,
-        evaluation::{Context, ContextValue, Evaluation, EvaluationSymbolPtr},
+        evaluation::{Evaluation, EvaluationSymbolPtr},
         file_mgr::{FileMgr, NoqaInfo},
         model::Model,
         odoo::SyncOdoo,
@@ -36,6 +36,7 @@ use crate::{
     utils::PathSanitizer,
     weak_collections::WeakSet,
 };
+use crate::core::evaluation_context::{Context, ContextValue};
 
 impl SymbolTable {
 

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -1198,13 +1198,9 @@ impl SymbolTable {
         };
         SyncOdoo::ensure_func_evaluations(session, get_method);
         let evaluations = session.st()[get_method].evaluations.clone();
-        if context.is_none() {
-            *context = Some(Context::default());
-        }
+        let merged_context = Some(Context::merge(context.as_ref().unwrap_or(&Context::default()), symbol_context));
         for get_method_eval in evaluations.iter() {
-            let merged_context = Context::merge(context.as_ref().unwrap(), symbol_context);
-            // TODO: make get_symbol_as_weak and the callabe hook take a non-mutable ref to Context, and merge context once outside the loop.
-            let get_result = get_method_eval.symbol.get_symbol_as_weak(session, &mut Some(merged_context), &mut vec![], None);
+            let get_result = get_method_eval.symbol.get_symbol_as_weak(session, &merged_context, &mut vec![], None);
             if !get_result.weak.is_expired(session.st()) {
                 let mut eval = Evaluation::eval_from_symbol(session.st(), get_result.weak, get_result.instance);
                 match eval.symbol.get_mut_symbol_ptr() {
@@ -1228,9 +1224,9 @@ impl SymbolTable {
         let mut res = Vec::new();
         let var_symbol = &session.sync_odoo.symbol_table[key];
         let evaluations = var_symbol.evaluations.clone();
+        let ctx = Some(Context::merge(symbol_context, context.as_ref().unwrap_or(&Context::default())));
         for eval in evaluations.iter() {
-            let ctx = &mut Some(Context::merge(symbol_context, context.as_ref().unwrap_or(&Context::default())));
-            let mut sym = eval.symbol.get_symbol(session, ctx, &mut vec![], None);
+            let mut sym = eval.symbol.get_symbol(session, &ctx, &mut vec![], None);
             if let EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) = &mut sym {
                 if let Some(base_attr) = symbol_context.get(ContextKey::BaseAttr) {
                     if !w.context.get(ContextKey::IsAttrOfInstance).map(|x| x.as_bool()).unwrap_or(false) {

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -4,16 +4,15 @@ use std::{
     path::PathBuf,
     rc::Rc,
 };
-use crate::utils::{HashMap, HashSet};
+use crate::{core::evaluation::ContextKey, utils::{HashMap, HashSet}};
 
 use lsp_types::{Diagnostic, DiagnosticTag, Range, SymbolKind};
 use ruff_text_size::TextRange;
 use tracing::trace;
 
 use crate::{
-    constants::{BuildStatus, BuildSteps, OYarn, PackageType, SymType},
-    core::{
-        diagnostics::{create_diagnostic, DiagnosticCode},
+    constants::{BuildStatus, BuildSteps, OYarn, PackageType, SymType}, core::{
+        diagnostics::{DiagnosticCode, create_diagnostic},
         entry_point::EntryPoint,
         evaluation::{Context, ContextValue, Evaluation, EvaluationSymbolPtr},
         file_mgr::{FileMgr, NoqaInfo},
@@ -1177,11 +1176,11 @@ impl SymbolTable {
     fn next_refs_class(session: &mut SessionInfo, class_key: ClassKey, context: &mut Option<Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
         //if current symbol is a descriptor, we have to resolve __get__ method before going further
         let mut res = Vec::new();
-        let mut base_attr = symbol_context.get("base_attr");
+        let mut base_attr = symbol_context.get(ContextKey::BaseAttr);
         if base_attr.is_none() {
             //search in context (used in decorators to indicate on which base the field is searched)
             if let Some(context) = context.as_ref() {
-                base_attr = context.get("base_attr");
+                base_attr = context.get(ContextKey::BaseAttr);
             }
         }
         let Some(base_attr) = base_attr else {
@@ -1201,11 +1200,12 @@ impl SymbolTable {
         SyncOdoo::ensure_func_evaluations(session, get_method);
         let evaluations = session.st()[get_method].evaluations.clone();
         if context.is_none() {
-            *context = Some(HashMap::default());
+            *context = Some(Context::default());
         }
         for get_method_eval in evaluations.iter() {
-            context.as_mut().unwrap().extend(symbol_context.clone().into_iter());
-            let get_result = get_method_eval.symbol.get_symbol_as_weak(session, context, &mut vec![], None);
+            let merged_context = Context::merge(context.as_ref().unwrap(), symbol_context);
+            // TODO: make get_symbol_as_weak and the callabe hook take a non-mutable ref to Context, and merge context once outside the loop.
+            let get_result = get_method_eval.symbol.get_symbol_as_weak(session, &mut Some(merged_context), &mut vec![], None);
             if !get_result.weak.is_expired(session.st()) {
                 let mut eval = Evaluation::eval_from_symbol(session.st(), get_result.weak, get_result.instance);
                 match eval.symbol.get_mut_symbol_ptr() {
@@ -1215,13 +1215,12 @@ impl SymbolTable {
                                 continue;
                             }
                         }
-                        weak.context.insert(S!("base_attr"), ContextValue::SYMBOL(base_attr.into()));
+                        weak.context.insert(ContextKey::BaseAttr, ContextValue::SYMBOL(base_attr.into()));
                         res.push(eval.symbol.get_symbol_ptr().clone());
                     },
                     _ => {}
                 }
             }
-            context.as_mut().unwrap().retain(|k, _| !symbol_context.contains_key(k));
         }
         res
     }
@@ -1231,17 +1230,17 @@ impl SymbolTable {
         let var_symbol = &session.sync_odoo.symbol_table[key];
         let evaluations = var_symbol.evaluations.clone();
         for eval in evaluations.iter() {
-            let ctx = &mut Some(symbol_context.clone().into_iter().chain(context.clone().unwrap_or(HashMap::default()).into_iter()).collect::<HashMap<_, _>>());
+            let ctx = &mut Some(Context::merge(symbol_context, context.as_ref().unwrap_or(&Context::default())));
             let mut sym = eval.symbol.get_symbol(session, ctx, &mut vec![], None);
             if let EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) = &mut sym {
-                if let Some(base_attr) = symbol_context.get("base_attr") {
-                    if !w.context.get("is_attr_of_instance").map(|x| x.as_bool()).unwrap_or(false) {
-                        w.context.insert(S!("base_attr"), base_attr.clone());
+                if let Some(base_attr) = symbol_context.get(ContextKey::BaseAttr) {
+                    if !w.context.get(ContextKey::IsAttrOfInstance).map(|x| x.as_bool()).unwrap_or(false) {
+                        w.context.insert(ContextKey::BaseAttr, base_attr.clone());
                     }
                 }
-                if let Some(base_attr) = symbol_context.get("is_attr_of_instance") {
-                    if !w.context.get("is_attr_of_instance").map(|x| x.as_bool()).unwrap_or(false) {
-                        w.context.insert(S!("is_attr_of_instance"), base_attr.clone());
+                if let Some(base_attr) = symbol_context.get(ContextKey::IsAttrOfInstance) {
+                    if !w.context.get(ContextKey::IsAttrOfInstance).map(|x| x.as_bool()).unwrap_or(false) {
+                        w.context.insert(ContextKey::IsAttrOfInstance, base_attr.clone());
                     }
                 }
             }

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -35,7 +35,6 @@ use crate::{
     tree::{OYarnExt, Tree},
     utils::PathSanitizer,
     weak_collections::WeakSet,
-    S,
 };
 
 impl SymbolTable {
@@ -1193,7 +1192,7 @@ impl SymbolTable {
             return res;
         }
         //TODO shouldn't we set the from_module in the call to get_member_symbol?
-        let get_method = Self::get_member_symbol(session, class_key.into(), &S!("__get__"), None, true, false, false, true, false).0.first().copied();
+        let get_method = Self::get_member_symbol(session, class_key.into(), "__get__", None, true, false, false, true, false).0.first().copied();
         let Some(SymbolKey::Function(get_method)) = get_method else {
             return res;
         };

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -1172,13 +1172,13 @@ impl SymbolTable {
         return self.find_module(self.parent(key)?);
     }
 
-    fn next_refs_class(session: &mut SessionInfo, class_key: ClassKey, context: &mut Option<Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
+    fn next_refs_class(session: &mut SessionInfo, class_key: ClassKey, context: Option<&Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
         //if current symbol is a descriptor, we have to resolve __get__ method before going further
         let mut res = Vec::new();
         let mut base_attr = symbol_context.get(ContextKey::BaseAttr);
         if base_attr.is_none() {
             //search in context (used in decorators to indicate on which base the field is searched)
-            if let Some(context) = context.as_ref() {
+            if let Some(context) = context {
                 base_attr = context.get(ContextKey::BaseAttr);
             }
         }
@@ -1198,9 +1198,13 @@ impl SymbolTable {
         };
         SyncOdoo::ensure_func_evaluations(session, get_method);
         let evaluations = session.st()[get_method].evaluations.clone();
-        let merged_context = Some(Context::merge(context.as_ref().unwrap_or(&Context::default()), symbol_context));
+        let merged_context = if let Some(context) = context {
+            &Context::merge(context, symbol_context)
+        } else {
+            symbol_context
+        };
         for get_method_eval in evaluations.iter() {
-            let get_result = get_method_eval.symbol.get_symbol_as_weak(session, &merged_context, &mut vec![], None);
+            let get_result = get_method_eval.symbol.get_symbol_as_weak(session, Some(merged_context), &mut vec![], None);
             if !get_result.weak.is_expired(session.st()) {
                 let mut eval = Evaluation::eval_from_symbol(session.st(), get_result.weak, get_result.instance);
                 match eval.symbol.get_mut_symbol_ptr() {
@@ -1220,13 +1224,17 @@ impl SymbolTable {
         res
     }
 
-    fn next_refs_variable(session: &mut SessionInfo, key: VariableKey, context: &mut Option<Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
+    fn next_refs_variable(session: &mut SessionInfo, key: VariableKey, context: Option<&Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
         let mut res = Vec::new();
         let var_symbol = &session.sync_odoo.symbol_table[key];
         let evaluations = var_symbol.evaluations.clone();
-        let ctx = Some(Context::merge(symbol_context, context.as_ref().unwrap_or(&Context::default())));
+        let ctx = if let Some(context) = context {
+            &Context::merge(symbol_context, context)
+        } else {
+            symbol_context
+        };
         for eval in evaluations.iter() {
-            let mut sym = eval.symbol.get_symbol(session, &ctx, &mut vec![], None);
+            let mut sym = eval.symbol.get_symbol(session, Some(ctx), &mut vec![], None);
             if let EvaluationSymbolPtr::WEAK(w) | EvaluationSymbolPtr::SELF(w) = &mut sym {
                 if let Some(base_attr) = symbol_context.get(ContextKey::BaseAttr) {
                     if !w.context.get(ContextKey::IsAttrOfInstance).map(|x| x.as_bool()).unwrap_or(false) {
@@ -1258,7 +1266,7 @@ impl SymbolTable {
     ====
     next_refs on the 'a' in the print will return a SymbolRef to Test and one to Object
     */
-    fn next_refs(session: &mut SessionInfo, symbol_key: SymbolKey, context: &mut Option<Context>, symbol_context: &Context, stop_on_type: bool) -> Vec<EvaluationSymbolPtr> {
+    fn next_refs(session: &mut SessionInfo, symbol_key: SymbolKey, context: Option<&Context>, symbol_context: &Context, stop_on_type: bool) -> Vec<EvaluationSymbolPtr> {
         match symbol_key {
             SymbolKey::Class(c) if !stop_on_type => Self::next_refs_class(session, c, context, symbol_context),
             SymbolKey::Variable(v) => Self::next_refs_variable(session, v, context, symbol_context),
@@ -1271,7 +1279,7 @@ impl SymbolTable {
     If a symbol in the chain is a descriptor, return the __get__ return evaluation.
     If filter_on_tree is set, stop following when one of the symbols in the chain is in the tree, and only return those symbols.
         */
-    pub fn follow_ref(evaluation: &EvaluationSymbolPtr, session: &mut SessionInfo, context: &mut Option<Context>, stop_on_type: bool, stop_on_value: bool, filter_on_tree: Option<(&[&str], &[&str])>, max_scope: Option<SymbolKey>) -> Vec<EvaluationSymbolPtr> {
+    pub fn follow_ref(evaluation: &EvaluationSymbolPtr, session: &mut SessionInfo, context: Option<&Context>, stop_on_type: bool, stop_on_value: bool, filter_on_tree: Option<(&[&str], &[&str])>, max_scope: Option<SymbolKey>) -> Vec<EvaluationSymbolPtr> {
         let default_result = match filter_on_tree.as_ref() {
             Some(_) => vec![],
             None => vec![evaluation.clone()],
@@ -1413,7 +1421,7 @@ impl SymbolTable {
         results
     }
 
-    pub fn follow_imported_ref(evaluation: &EvaluationSymbolPtr, session: &mut SessionInfo, context: &mut Option<Context>) -> Vec<EvaluationSymbolPtr> {
+    pub fn follow_imported_ref(evaluation: &EvaluationSymbolPtr, session: &mut SessionInfo, context: Option<&Context>) -> Vec<EvaluationSymbolPtr> {
         let mut res = vec![];
         let mut symbols = VecDeque::new();
         symbols.push_back(evaluation.clone());
@@ -1682,8 +1690,8 @@ impl SymbolTable {
         let var_symbol = &session.sync_odoo.symbol_table[v];
         let evaluations = var_symbol.evaluations.clone();
         for eval in evaluations {
-            let symbol = eval.symbol.get_symbol(session, &mut None,  &mut vec![], None);
-            let eval_weaks = Self::follow_ref(&symbol, session, &mut None, true, false, None, None);
+            let symbol = eval.symbol.get_symbol(session, None,  &mut vec![], None);
+            let eval_weaks = Self::follow_ref(&symbol, session, None, true, false, None, None);
             for eval_weak in eval_weaks.iter() {
                 if let Some(key) = eval_weak.upgrade_weak(&session.sync_odoo.symbol_table) {
                     if Self::is_field_class(session, key) {
@@ -1706,8 +1714,8 @@ impl SymbolTable {
         let var_symbol = &session.sync_odoo.symbol_table[v];
         let evals = var_symbol.evaluations.clone();
         for eval in evals.iter() {
-            let symbol = eval.symbol.get_symbol(session, &mut None,  &mut vec![], None);
-            let eval_weaks = Self::follow_ref(&symbol, session, &mut None, true, false, None, None);
+            let symbol = eval.symbol.get_symbol(session, None,  &mut vec![], None);
+            let eval_weaks = Self::follow_ref(&symbol, session, None, true, false, None, None);
             for eval_weak in eval_weaks.iter() {
                 if let Some(key) = eval_weak.upgrade_weak(&session.sync_odoo.symbol_table) {
                     if matches!(key, SymbolKey::Function(_)) {
@@ -1816,8 +1824,8 @@ impl SymbolTable {
         };
         let evaluations = session.st()[v].evaluations.clone();
         for eval in evaluations.iter() {
-            let symbol = eval.symbol.get_symbol(session, &mut None, &mut vec![], None);
-            let eval_weaks = Self::follow_ref(&symbol, session, &mut None, true, false, None, None);
+            let symbol = eval.symbol.get_symbol(session, None, &mut vec![], None);
+            let eval_weaks = Self::follow_ref(&symbol, session, None, true, false, None, None);
             for eval_weak in eval_weaks.iter() {
                 if let Some(symbol) = eval_weak.upgrade_weak(session.st()) {
                     if Self::is_specific_field_class(session, symbol, field_names){

--- a/server/src/features/ast_utils.rs
+++ b/server/src/features/ast_utils.rs
@@ -47,11 +47,11 @@ impl AstUtils {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(Context::from_iter([
+        let mut context = Context::from_iter([
             (ContextKey::Module, from_module),
             (ContextKey::Range, ContextValue::RANGE(expr.range()))
-        ]));
-        let analyse_ast_result: AnalyzeAstResult = Evaluation::analyze_ast(session, &expr, parent_symbol, &expr.range().end(), &mut context,false, &mut vec![]);
+        ]);
+        let analyse_ast_result: AnalyzeAstResult = Evaluation::analyze_ast(session, &expr, parent_symbol, &expr.range().end(), &mut context, false, &mut vec![]);
         (analyse_ast_result, Some(expr.range()))
     }
 

--- a/server/src/features/ast_utils.rs
+++ b/server/src/features/ast_utils.rs
@@ -1,6 +1,5 @@
-use crate::utils::HashMap;
 use crate::constants::{BuildStatus, BuildSteps, SymType};
-use crate::core::evaluation::{AnalyzeAstResult, Context, ContextValue, Evaluation, ExprOrIdent};
+use crate::core::evaluation::{AnalyzeAstResult, Context, ContextKey, ContextValue, Evaluation, ExprOrIdent};
 use crate::core::odoo::SyncOdoo;
 use crate::core::symbols::symbol_keys::{SourceFileKey, SymbolKey};
 use crate::core::import_resolver::{resolve_from_stmt, resolve_import_stmt};
@@ -48,9 +47,9 @@ impl AstUtils {
         } else {
             from_module = ContextValue::BOOLEAN(false);
         }
-        let mut context: Option<Context> = Some(HashMap::from_iter([
-            (S!("module"), from_module),
-            (S!("range"), ContextValue::RANGE(expr.range()))
+        let mut context: Option<Context> = Some(Context::from_iter([
+            (ContextKey::Module, from_module),
+            (ContextKey::Range, ContextValue::RANGE(expr.range()))
         ]));
         let analyse_ast_result: AnalyzeAstResult = Evaluation::analyze_ast(session, &expr, parent_symbol, &expr.range().end(), &mut context,false, &mut vec![]);
         (analyse_ast_result, Some(expr.range()))

--- a/server/src/features/ast_utils.rs
+++ b/server/src/features/ast_utils.rs
@@ -1,5 +1,6 @@
 use crate::constants::{BuildStatus, BuildSteps, SymType};
-use crate::core::evaluation::{AnalyzeAstResult, Context, ContextKey, ContextValue, Evaluation, ExprOrIdent};
+use crate::core::evaluation::{AnalyzeAstResult, Evaluation, ExprOrIdent};
+use crate::core::evaluation_context::{Context, ContextKey, ContextValue};
 use crate::core::odoo::SyncOdoo;
 use crate::core::symbols::symbol_keys::{SourceFileKey, SymbolKey};
 use crate::core::import_resolver::{resolve_from_stmt, resolve_import_stmt};

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -554,7 +554,7 @@ fn complete_decorator_call(
     let mut followed_evals = vec![];
     for eval in dec_evals {
         followed_evals.extend(
-            SymbolTable::follow_ref(&eval.symbol.get_symbol(session, &mut None, &mut vec![], None), session, &mut None, true, false, None, None)
+            SymbolTable::follow_ref(&eval.symbol.get_symbol(session, None, &mut vec![], None), session, None, true, false, None, None)
         );
     }
     for decorator_eval in followed_evals{
@@ -599,7 +599,7 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
     AstUtils::build_scope(session, scope);
     let callable_evals = Evaluation::eval_from_ast(session, &expr_call.func, scope, &expr_call.func.range().start(), false, &mut vec![]).0;
     let callable_eval_sym_ptrs = callable_evals.iter().flat_map(|callable_eval|
-        SymbolTable::follow_ref(&callable_eval.symbol.get_symbol(session, &mut None, &mut vec![], None), session, &mut None, false, false, None, None)
+        SymbolTable::follow_ref(&callable_eval.symbol.get_symbol(session, None, &mut vec![], None), session, None, false, false, None, None)
     ).collect::<Vec<_>>();
     if let Some((arg_index, arg)) = expr_call.arguments.args.iter().find_position(|arg|
         offset > arg.range().start().to_usize() && offset <= arg.range().end().to_usize())
@@ -668,7 +668,7 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
                     match evaluation.symbol.get_symbol_ptr() {
                         EvaluationSymbolPtr::WEAK(_weak) => {
                             //if weak, use get_symbol
-                            let symbol =  evaluation.symbol.get_symbol_as_weak(session, &mut None, &mut vec![], None);
+                            let symbol =  evaluation.symbol.get_symbol_as_weak(session, None, &mut vec![], None);
                             if let Some(evaluation) = symbol.weak.upgrade(session.st()) {
                                 if let SymbolKey::Class(class) = evaluation {
                                     expected_type.push(ExpectedType::CLASS(class));
@@ -876,9 +876,9 @@ fn complete_attribut(session: &mut SessionInfo, file: SourceFileKey, attr: &Expr
         let from_module = session.st().find_module(file);
         for parent_eval in parent.iter() {
             //TODO shouldn't we set and clean context here?
-            let parent_sym_eval = parent_eval.symbol.get_symbol(session, &mut None, &mut vec![], Some(scope));
+            let parent_sym_eval = parent_eval.symbol.get_symbol(session, None, &mut vec![], Some(scope));
             if !parent_sym_eval.is_expired_if_weak(session.st()) {
-                let parent_sym_types = SymbolTable::follow_ref(&parent_sym_eval, session, &mut None, false, false, None, None);
+                let parent_sym_types = SymbolTable::follow_ref(&parent_sym_eval, session, None, false, false, None, None);
                 for parent_sym_type in parent_sym_types.iter() {
                     let Some(parent_sym) = parent_sym_type.upgrade_weak(session.st()) else {continue};
                     add_model_attributes(session, &mut items, from_module, parent_sym, parent_sym_eval.get_weak().is_super, false, false, attr.attr.id.as_str(), &None)
@@ -897,9 +897,9 @@ fn complete_subscript(session: &mut SessionInfo, file: SourceFileKey, expr_subsc
     AstUtils::build_scope(session, scope);
     let subscripted = Evaluation::eval_from_ast(session, &expr_subscript.value, scope, &expr_subscript.value.range().start(), false, &mut vec![]).0;
     for eval in subscripted.iter() {
-        let eval_symbol = eval.symbol.get_symbol(session, &mut None, &mut vec![], Some(scope));
+        let eval_symbol = eval.symbol.get_symbol(session, None, &mut vec![], Some(scope));
         if !eval_symbol.is_expired_if_weak(session.st()) {
-            let symbol_types = SymbolTable::follow_ref(&eval_symbol, session, &mut None, false, false, None, None);
+            let symbol_types = SymbolTable::follow_ref(&eval_symbol, session, None, false, false, None, None);
             for symbol_type in symbol_types.iter() {
                 if let Some(symbol_type) = symbol_type.upgrade_weak(session.st()) {
                     let get_item = session.st().get_symbol(symbol_type, (&[], &["__getitem__"]), u32::MAX);
@@ -1161,10 +1161,10 @@ fn build_completion_item_from_symbol(session: &mut SessionInfo, symbols: Vec<Sym
             symbol,
             None,
             false,
-        )), session, &mut None, false, false, None, None)
+        )), session, None, false, false, None, None)
     ).collect::<Vec<_>>();
     let type_details = typ.iter().map(|eval|
-        FeaturesUtils::get_inferred_types(session, eval, &mut Some(context_of_symbol.clone()), &symbols[0].typ())
+        FeaturesUtils::get_inferred_types(session, eval, Some(&context_of_symbol), &symbols[0].typ())
     ).collect::<HashSet<_>>();
     let label_details_description = match type_details.len() {
         0 => None,

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -1044,10 +1044,10 @@ fn add_nested_field_names(
     add_date_completions: bool,
     specific_field_type: &Option<OYarn>,
 ){
-    let split_expr: Vec<String> = field_prefix.split(".").map(|x| x.to_string()).collect();
+    let split_expr: Vec<_> = field_prefix.split(".").collect();
     let mut obj = Some(parent);
     let mut date_mode = false;
-    for (index, name) in split_expr.iter().enumerate() {
+    for (index, &name) in split_expr.iter().enumerate() {
         if add_date_completions && date_mode {
             if index != split_expr.len() - 1 {
                 break;
@@ -1092,7 +1092,7 @@ fn add_nested_field_names(
             } else {
                 let (symbols, _diagnostics) = SymbolTable::get_member_symbol(session,
                     object,
-                    &name.to_string(),
+                    name,
                     from_module,
                     false,
                     true,

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -1,8 +1,9 @@
 use super::features_utils::TypeInfo;
 use crate::constants::{OYarn, SymType};
 use crate::core::evaluation::{
-    Context, ContextKey, ContextValue, Evaluation, EvaluationSymbol, EvaluationSymbolPtr, EvaluationSymbolWeak, HookName
+    Evaluation, EvaluationSymbol, EvaluationSymbolPtr, EvaluationSymbolWeak, HookName
 };
+use crate::core::evaluation_context::{Context, ContextKey, ContextValue};
 use crate::core::file_mgr::FileInfo;
 use crate::core::import_resolver;
 use crate::core::odoo::SyncOdoo;

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -1,7 +1,7 @@
 use super::features_utils::TypeInfo;
 use crate::constants::{OYarn, SymType};
 use crate::core::evaluation::{
-    Context, ContextValue, Evaluation, EvaluationSymbol, EvaluationSymbolPtr, EvaluationSymbolWeak,
+    Context, ContextKey, ContextValue, Evaluation, EvaluationSymbol, EvaluationSymbolPtr, EvaluationSymbolWeak
 };
 use crate::core::file_mgr::FileInfo;
 use crate::core::import_resolver;
@@ -25,7 +25,7 @@ use ruff_python_ast::{
     ExprYield, Stmt, StmtGlobal, StmtImport, StmtImportFrom, StmtNonlocal,
 };
 use ruff_text_size::{Ranged, TextSize};
-use std::collections::{HashMap, HashSet};
+use crate::utils::HashSet;
 use std::{cell::RefCell, rc::Rc};
 
 
@@ -631,7 +631,7 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
             let is_on_instance = if callable_sym.typ() == SymType::CLASS {
                 Some(true)
             } else {
-                callable.context.get("is_attr_of_instance").map(|v| v.as_bool())
+                callable.context.get(ContextKey::IsAttrOfInstance).map(|v| v.as_bool())
             };
             let Some(func_arg_sym) = FunctionSymbol::get_indexed_arg_in_call(
                 session.st(),
@@ -676,7 +676,7 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
                             }
                         },
                         EvaluationSymbolPtr::DOMAIN => {
-                            if let Some(parent) = callable.context.get("base_attr")
+                            if let Some(parent) = callable.context.get(ContextKey::BaseAttr)
                                 .and_then(|parent_value| parent_value.as_symbol().upgrade(session.st())) {
                                 expected_type.push(ExpectedType::DOMAIN(parent));
                             }
@@ -934,7 +934,7 @@ fn complete_name(session: &mut SessionInfo, file: SourceFileKey, offset: usize, 
     Some(CompletionResponse::List(CompletionList {
         is_incomplete: false,
         items: symbols.into_iter().map(|(_symbol_name, symbols)| {
-            build_completion_item_from_symbol(session, symbols, HashMap::default())
+            build_completion_item_from_symbol(session, symbols, Context::default())
         }).collect::<Vec<_>>(),
     }))
 }
@@ -1079,7 +1079,7 @@ fn add_nested_field_names(
                         let mut found_one = false;
                         for (final_sym, dep) in symbols.iter() { //search for at least one that is a field
                             if dep.is_none() && (specific_field_type.is_none() || SymbolTable::is_specific_field(session, *final_sym, &["Many2one", "One2many", "Many2many", specific_field_type.as_ref().unwrap().as_str()])){
-                                items.push(build_completion_item_from_symbol(session, vec![*final_sym], HashMap::default()));
+                                items.push(build_completion_item_from_symbol(session, vec![*final_sym], Context::default()));
                                 found_one = true;
                                 continue;
                             }
@@ -1145,7 +1145,7 @@ fn add_model_attributes(
             }
         }
         if symbol_name.starts_with(attribute_name) {
-            let context_of_symbol = HashMap::from_iter([(S!("base_attr"), ContextValue::SYMBOL(parent_sym.into()))]);
+            let context_of_symbol = Context::from_iter([(ContextKey::BaseAttr, ContextValue::SYMBOL(parent_sym.into()))]);
             items.push(build_completion_item_from_symbol(session, vec![*final_sym], context_of_symbol));
         }
     }

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -1,7 +1,7 @@
 use super::features_utils::TypeInfo;
 use crate::constants::{OYarn, SymType};
 use crate::core::evaluation::{
-    Context, ContextKey, ContextValue, Evaluation, EvaluationSymbol, EvaluationSymbolPtr, EvaluationSymbolWeak
+    Context, ContextKey, ContextValue, Evaluation, EvaluationSymbol, EvaluationSymbolPtr, EvaluationSymbolWeak, HookName
 };
 use crate::core::file_mgr::FileInfo;
 use crate::core::import_resolver;
@@ -907,7 +907,7 @@ fn complete_subscript(session: &mut SessionInfo, file: SourceFileKey, expr_subsc
                         let evaluations = session.st().evaluations(get_item).unwrap();
                         if evaluations.len() == 1 {
                             let get_item_eval = evaluations.first().unwrap();
-                            if get_item_eval.symbol.get_symbol_hook.as_ref().map(|hook| &hook.name == "eval_env_get_item").unwrap_or_default() {
+                            if get_item_eval.symbol.get_symbol_hook.as_ref().map(|hook| hook.name == HookName::EvalEnvGetItem).unwrap_or_default() {
                                 return complete_expr(&expr_subscript.slice, session, file, offset, is_param, &vec![ExpectedType::MODEL_NAME]);
                             }
                         }

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -12,7 +12,8 @@ use crate::utils::HashMap;
 
 use crate::constants::{SymType};
 use crate::constants::OYarn;
-use crate::core::evaluation::{Context, ContextKey, ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationSymbolWeak, EvaluationValue};
+use crate::core::evaluation::{Evaluation, EvaluationSymbolPtr, EvaluationSymbolWeak, EvaluationValue};
+use crate::core::evaluation_context::{Context, ContextKey, ContextValue};
 use crate::threads::SessionInfo;
 use crate::{Sy, S};
 

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -438,7 +438,7 @@ impl FeaturesUtils {
         let mut aggregator: HashMap<SymbolGroupKey, Vec<SymbolInfo>> = HashMap::default();
         for (index, eval) in evals.iter().enumerate() {
             //search for a constant evaluation like a model name or domain field
-            if let Some(EvaluationValue::CONSTANT(Expr::StringLiteral(expr))) = eval.value.as_ref() {
+            if let Some(expr) = eval.value.as_ref().and_then(EvaluationValue::as_string_literal) {
                 let str = expr.value.to_str();
                 if let Some(SourceFileKey::Module(_)) = file_symbol
                 && file_path.is_some_and(|fp| fp.ends_with("__manifest__.py")) {

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -148,19 +148,19 @@ impl FeaturesUtils {
         }
         let mut parent_object = Some(base_symbol);
         let mut range_start = field_range.start() + TextSize::new(1);
-        for name in field_name.split(".").map(|x| x.to_string()) {
+        for name in field_name.split(".") {
             if parent_object.is_none() {
                 break;
             }
             let range_end = range_start + TextSize::new((name.len() + 1) as u32);
             let cursor_section = TextRange::new(range_start, range_end).contains(TextSize::new(*offset as u32));
             if cursor_section {
-                let fields = SymbolTable::get_member_symbol(session, parent_object.unwrap().into(), &name, from_module, false, true, false, true, false).0;
+                let fields = SymbolTable::get_member_symbol(session, parent_object.unwrap().into(), name, from_module, false, true, false, true, false).0;
                 return fields.into_iter().map(|f| (f, TextRange::new(range_start, range_end - TextSize::new(1)))).collect();
             } else {
                 let (symbols, _diagnostics) = SymbolTable::get_member_symbol(session,
                     parent_object.unwrap().into(),
-                    &name.to_string(),
+                    name,
                     from_module,
                     false,
                     true,

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -77,9 +77,9 @@ impl FeaturesUtils {
         for eval in evaluations {
             followed_evals.extend(
                 SymbolTable::follow_ref(
-                    &eval.symbol.get_symbol(session, &mut None, &mut vec![], None),
+                    &eval.symbol.get_symbol(session, None, &mut vec![], None),
                     session,
-                    &mut None,
+                    None,
                     true,
                     false,
                     None,
@@ -233,9 +233,9 @@ impl FeaturesUtils {
         for eval in callable_evals {
             followed_evals.extend(
                 SymbolTable::follow_ref(
-                    &eval.symbol.get_symbol(session, &mut None, &mut vec![], None),
+                    &eval.symbol.get_symbol(session, None, &mut vec![], None),
                     session,
-                    &mut None,
+                    None,
                     true,
                     false,
                     None,
@@ -350,9 +350,9 @@ impl FeaturesUtils {
         for eval in callable_evals {
             followed_evals.extend(
                 SymbolTable::follow_ref(
-                    &eval.symbol.get_symbol(session, &mut None, &mut vec![], None),
+                    &eval.symbol.get_symbol(session, None, &mut vec![], None),
                     session,
-                    &mut None,
+                    None,
                     true,
                     false,
                     None,
@@ -516,7 +516,7 @@ impl FeaturesUtils {
                     continue;
                 }
             }
-            let eval_symbol = eval.symbol.get_symbol(session, &mut None, &mut vec![], None);
+            let eval_symbol = eval.symbol.get_symbol(session, None, &mut vec![], None);
             let Some(symbol) = eval_symbol.upgrade_weak(session.st()) else {
                 if let EvaluationSymbolPtr::UNBOUND(name) = eval_symbol {
                     aggregator.entry(SymbolGroupKey { name: name.clone(), type_: SymType::VARIABLE }).or_default().push(
@@ -527,14 +527,14 @@ impl FeaturesUtils {
                 }
                 continue;
             };
-            let mut context = Some(eval_symbol.get_weak().context.clone());
-            let evaluation_ptrs = SymbolTable::follow_ref(&eval_symbol, session, &mut context, false, false, None, None);
+            let context = &eval_symbol.get_weak().context;
+            let evaluation_ptrs = SymbolTable::follow_ref(&eval_symbol, session, Some(context), false, false, None, None);
 
             let symbol_type = symbol.typ();
             let symbol_name = session.st().name(symbol).clone();
             let from_module = session.st().find_module(symbol);
             let sym_type_tag = FeaturesUtils::get_type_symbol_tag(&session.sync_odoo.symbol_table, symbol);
-            let return_types: Vec<TypeInfo> = evaluation_ptrs.iter().map(|eval| FeaturesUtils::get_inferred_types(session, eval, &mut context, &symbol_type)).unique().collect();
+            let return_types: Vec<TypeInfo> = evaluation_ptrs.iter().map(|eval| FeaturesUtils::get_inferred_types(session, eval, Some(context), &symbol_type)).unique().collect();
             let inferred_types = evaluation_ptrs.into_iter().zip(return_types.into_iter()).map(|(eval_ptr, eval_info)| InferredType{eval_ptr, eval_info}).collect();
 
             aggregator.entry(SymbolGroupKey { name: symbol_name.clone(), type_: symbol_type }).or_default().push(
@@ -581,7 +581,7 @@ impl FeaturesUtils {
             Some(anno_expr) => {
                 let Some(type_symbol) = session.st().parent(arg_symbol)
                 .and_then(|parent| Evaluation::eval_from_ast(session, &anno_expr, parent, &anno_expr.range().start(), false, &mut vec![]).0.first().cloned())
-                .and_then(|type_evaluation| type_evaluation.symbol.get_symbol_as_weak(session, &mut None, &mut vec![], None).weak.upgrade(session.st()))
+                .and_then(|type_evaluation| type_evaluation.symbol.get_symbol_as_weak(session, None, &mut vec![], None).weak.upgrade(session.st()))
                  else {
                     return arg_name.to_string()
                 };
@@ -596,7 +596,7 @@ impl FeaturesUtils {
     /// Return return type representation of evaluation
     /// for a function evaluation it is typically (_arg: _arg_type, ...) -> (_result_type)
     /// for variable it just shows the type, or Any if it fails to find it
-    pub fn get_inferred_types(session: &mut SessionInfo, eval: &EvaluationSymbolPtr, context: &mut Option<Context>, symbol_type: &SymType) -> TypeInfo {
+    pub fn get_inferred_types(session: &mut SessionInfo, eval: &EvaluationSymbolPtr, context: Option<&Context>, symbol_type: &SymType) -> TypeInfo {
         if *symbol_type == SymType::CLASS{
             return TypeInfo::VALUE(S!(""));
         }
@@ -606,7 +606,7 @@ impl FeaturesUtils {
                     // let inferred_type = inferred_type.borrow();
                     match inferred_type {
                         SymbolKey::Function(function_key) if !session.st()[function_key].is_property => {
-                            let base_attr_ctx_ref = eval.get_weak().context.get(ContextKey::BaseAttr).or(context.as_mut().and_then(|ctx| ctx.get(ContextKey::BaseAttr)));
+                            let base_attr_ctx_ref = eval.get_weak().context.get(ContextKey::BaseAttr).or(context.and_then(|ctx| ctx.get(ContextKey::BaseAttr)));
                             let call_parent = match base_attr_ctx_ref {
                                 Some(ContextValue::SYMBOL(s)) => *s,
                                 _ => {
@@ -618,12 +618,16 @@ impl FeaturesUtils {
                                     }
                                 }
                             };
-                            context.as_mut().map(|ctx| ctx.insert(ContextKey::BaseCall, ContextValue::SYMBOL(call_parent)));
+                            let mut ctx = context.map(|ctx| ctx.clone());
+                            if let Some(ctx) = ctx.as_mut() {
+                                ctx.insert(ContextKey::BaseCall, ContextValue::SYMBOL(call_parent));
+                            }
+                            // context.as_mut().map(|ctx| ctx.insert(ContextKey::BaseCall, ContextValue::SYMBOL(call_parent)));
                             let return_type = {
                                 let func_eval = session.st()[function_key].evaluations.clone();
                                 let type_names: Vec<_> = func_eval.iter().flat_map(|eval|{
-                                    let eval_symbol = eval.symbol.get_symbol_weak_transformed(session, context, &mut vec![], None);
-                                    let weak_eval_symbols = SymbolTable::follow_ref(&eval_symbol, session, context, false, false, None, None);
+                                    let eval_symbol = eval.symbol.get_symbol_weak_transformed(session, ctx.as_ref(), &mut vec![], None);
+                                    let weak_eval_symbols = SymbolTable::follow_ref(&eval_symbol, session, ctx.as_ref(), false, false, None, None);
                                     weak_eval_symbols.iter().map(|weak_eval_symbol| match weak_eval_symbol.upgrade_weak(session.st()) {
                                         //if fct is a variable, it means that evaluation is None.
                                         Some(s_type) if s_type.typ() != SymType::VARIABLE => session.st().name(s_type).to_string(),
@@ -632,7 +636,6 @@ impl FeaturesUtils {
                                 }).unique().collect();
                                 if !type_names.is_empty() {FeaturesUtils::represent_return_types(type_names)} else {S!("None")}
                             };
-                            context.as_mut().map(|ctx| ctx.remove(ContextKey::BaseCall));
                             let argument_names = session.st()[function_key].args.clone().iter().map(|arg| FeaturesUtils::argument_presentation(session, arg)).join(", ");
                             TypeInfo::CALLABLE(CallableSignature { arguments: argument_names, return_types: return_type })
                         },

--- a/server/src/features/features_utils.rs
+++ b/server/src/features/features_utils.rs
@@ -12,7 +12,7 @@ use crate::utils::HashMap;
 
 use crate::constants::{SymType};
 use crate::constants::OYarn;
-use crate::core::evaluation::{Context, ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationSymbolWeak, EvaluationValue};
+use crate::core::evaluation::{Context, ContextKey, ContextValue, Evaluation, EvaluationSymbolPtr, EvaluationSymbolWeak, EvaluationValue};
 use crate::threads::SessionInfo;
 use crate::{Sy, S};
 
@@ -210,7 +210,7 @@ impl FeaturesUtils {
         offset: &usize,
         from_module: Option<ModuleKey>,
     ) -> Vec<(SymbolKey, TextRange)> {
-        let Some(SymbolKey::Class(parent_object)) = callable.context.get("base_attr").and_then(|parent_object| parent_object.as_symbol().upgrade(session.st())) else {
+        let Some(SymbolKey::Class(parent_object)) = callable.context.get(ContextKey::BaseAttr).and_then(|parent_object| parent_object.as_symbol().upgrade(session.st())) else {
             return vec![];
         };
         FeaturesUtils::find_nested_fields(session, parent_object, from_module, field_range, field_name, offset)
@@ -291,7 +291,7 @@ impl FeaturesUtils {
                 // skip self on __init__
                 Some(true)
             } else {
-                callable.context.get("is_attr_of_instance").map(|v| v.as_bool())
+                callable.context.get(ContextKey::IsAttrOfInstance).map(|v| v.as_bool())
             };
 
             let func_arg = FunctionSymbol::get_indexed_arg_in_call(
@@ -606,7 +606,7 @@ impl FeaturesUtils {
                     // let inferred_type = inferred_type.borrow();
                     match inferred_type {
                         SymbolKey::Function(function_key) if !session.st()[function_key].is_property => {
-                            let base_attr_ctx_ref = eval.get_weak().context.get("base_attr").or(context.as_mut().and_then(|ctx| ctx.get("base_attr")));
+                            let base_attr_ctx_ref = eval.get_weak().context.get(ContextKey::BaseAttr).or(context.as_mut().and_then(|ctx| ctx.get(ContextKey::BaseAttr)));
                             let call_parent = match base_attr_ctx_ref {
                                 Some(ContextValue::SYMBOL(s)) => *s,
                                 _ => {
@@ -618,7 +618,7 @@ impl FeaturesUtils {
                                     }
                                 }
                             };
-                            context.as_mut().map(|ctx| ctx.insert(S!("base_call"), ContextValue::SYMBOL(call_parent)));
+                            context.as_mut().map(|ctx| ctx.insert(ContextKey::BaseCall, ContextValue::SYMBOL(call_parent)));
                             let return_type = {
                                 let func_eval = session.st()[function_key].evaluations.clone();
                                 let type_names: Vec<_> = func_eval.iter().flat_map(|eval|{
@@ -632,7 +632,7 @@ impl FeaturesUtils {
                                 }).unique().collect();
                                 if !type_names.is_empty() {FeaturesUtils::represent_return_types(type_names)} else {S!("None")}
                             };
-                            context.as_mut().map(|ctx| ctx.remove("base_call"));
+                            context.as_mut().map(|ctx| ctx.remove(ContextKey::BaseCall));
                             let argument_names = session.st()[function_key].args.clone().iter().map(|arg| FeaturesUtils::argument_presentation(session, arg)).join(", ");
                             TypeInfo::CALLABLE(CallableSignature { arguments: argument_names, return_types: return_type })
                         },
@@ -813,10 +813,10 @@ impl FeaturesUtils {
             };
             for eval in evals {
                 if let EvaluationSymbolPtr::WEAK(weak) = eval.symbol.get_mut_symbol_ptr() {
-                    if let Some(field_parent) = weak.context.get("field_parent").cloned() {
-                        if !weak.context.contains_key("base_attr") {
-                            weak.context.insert(S!("base_attr"), field_parent);
-                            weak.context.insert(S!("base_attr_inserted"), ContextValue::BOOLEAN(true));
+                    if let Some(field_parent) = weak.context.get(ContextKey::FieldParent).cloned() {
+                        if !weak.context.contains_key(&ContextKey::BaseAttr) {
+                            weak.context.insert(ContextKey::BaseAttr, field_parent);
+                            weak.context.insert(ContextKey::BaseAttrInserted, ContextValue::BOOLEAN(true));
                         }
                     }
                 }
@@ -834,9 +834,9 @@ impl FeaturesUtils {
             };
             for eval in evals {
                 if let EvaluationSymbolPtr::WEAK(weak) = eval.symbol.get_mut_symbol_ptr() {
-                    if let Some(ContextValue::BOOLEAN(true)) = weak.context.get("base_attr_inserted") {
-                        weak.context.remove("base_attr");
-                        weak.context.remove("base_attr_inserted");
+                    if let Some(ContextValue::BOOLEAN(true)) = weak.context.get(ContextKey::BaseAttrInserted) {
+                        weak.context.remove(ContextKey::BaseAttrInserted);
+                        weak.context.remove(ContextKey::BaseAttr);
                     }
                 }
             }

--- a/server/src/features/goto_utils.rs
+++ b/server/src/features/goto_utils.rs
@@ -44,7 +44,7 @@ pub struct GotoUtils {}
 impl GotoUtils {
     fn check_for_domain_field(session: &mut SessionInfo, eval: &Evaluation, file_symbol: SourceFileKey, call_expr: &Option<ExprCall>, offset: usize, sources: &mut Vec<GotoSource>) -> bool {
         let (field_name, field_range) = if let Some(eval_value) = eval.value.as_ref() {
-            if let EvaluationValue::CONSTANT(Expr::StringLiteral(expr)) = eval_value {
+            if let Some(expr) = eval_value.as_string_literal() {
                 (expr.value.to_str(), expr.range)
             } else {
                 return false;
@@ -74,7 +74,7 @@ impl GotoUtils {
 
     fn check_for_model_string(session: &mut SessionInfo, eval: &Evaluation, file_symbol: SourceFileKey, sources: &mut Vec<GotoSource>) -> bool {
         let value = if let Some(eval_value) = eval.value.as_ref() {
-            if let EvaluationValue::CONSTANT(Expr::StringLiteral(expr)) = eval_value {
+            if let Some(expr) = eval_value.as_string_literal() {
                 oyarn!("{}", expr.value.to_str())
             } else {
                 return false;
@@ -115,7 +115,7 @@ impl GotoUtils {
             return false;
         }
         let mut value = if let Some(eval_value) = eval.value.as_ref() {
-            if let EvaluationValue::CONSTANT(Expr::StringLiteral(expr)) = eval_value {
+            if let Some(expr) = eval_value.as_string_literal() {
                 oyarn!("{}", expr.value.to_str())
             } else {
                 return false;
@@ -139,7 +139,7 @@ impl GotoUtils {
 
     fn check_for_xml_id_string(session: &mut SessionInfo, eval: &Evaluation, file_symbol: SourceFileKey, sources: &mut Vec<GotoSource>) -> bool {
         let value = if let Some(eval_value) = eval.value.as_ref() {
-            if let EvaluationValue::CONSTANT(Expr::StringLiteral(expr)) = eval_value {
+            if let Some(expr) = eval_value.as_string_literal() {
                 oyarn!("{}", expr.value.to_str())
             } else {
                 return false;
@@ -166,7 +166,7 @@ impl GotoUtils {
 
     fn check_for_compute_string(session: &mut SessionInfo, eval: &Evaluation, file_symbol: SourceFileKey, call_expr: &Option<ExprCall>, offset: usize, sources: &mut Vec<GotoSource>) -> bool {
         let value = if let Some(eval_value) = eval.value.as_ref() {
-            if let EvaluationValue::CONSTANT(Expr::StringLiteral(expr)) = eval_value {
+            if let Some(expr) = eval_value.as_string_literal() {
                 expr.value.to_str()
             } else {
                 return false;

--- a/server/src/features/goto_utils.rs
+++ b/server/src/features/goto_utils.rs
@@ -203,7 +203,7 @@ impl GotoUtils {
             return;
         };
         let (analyse_ast_result, _range) = AstUtils::get_symbol_from_expr(session, file_symbol, &ExprOrIdent::Expr(&attr_expr.value), offset as u32);
-        let eval_ptrs = analyse_ast_result.evaluations.iter().flat_map(|eval| SymbolTable::follow_ref(eval.symbol.get_symbol_ptr(), session, &mut None, false, false, None, None)).collect::<Vec<_>>();
+        let eval_ptrs = analyse_ast_result.evaluations.iter().flat_map(|eval| SymbolTable::follow_ref(eval.symbol.get_symbol_ptr(), session, None, false, false, None, None)).collect::<Vec<_>>();
         let maybe_module = session.st().find_module(file_symbol);
         let symbols = eval_ptrs.iter().flat_map(|eval_ptr| {
             let Some(symbol) = eval_ptr.upgrade_weak(session.st()) else {
@@ -239,7 +239,7 @@ impl GotoUtils {
         let mut dislay_name_found = false;
         evaluations.retain(|eval| {
             // Filter out, variables, whose parents are a class, whose name is one of the magic fields, and have the same range as their parent
-            let eval_sym = eval.symbol.get_symbol(session, &mut None, &mut vec![], None);
+            let eval_sym = eval.symbol.get_symbol(session, None, &mut vec![], None);
             let Some(eval_sym) = eval_sym.upgrade_weak(session.st()) else { return true; };
             let SymbolKey::Variable(variable_key) = eval_sym else {
                 return true;
@@ -279,8 +279,8 @@ impl GotoUtils {
                 continue;
             }
             if matches!(goto_request, GotoRequest::Definition) {
-                let eval_ptr = eval.symbol.get_symbol(session, &mut None, &mut vec![], None);
-                let end_symbols = SymbolTable::follow_imported_ref(&eval_ptr, session, &mut None);
+                let eval_ptr = eval.symbol.get_symbol(session, None, &mut vec![], None);
+                let end_symbols = SymbolTable::follow_imported_ref(&eval_ptr, session, None);
                 for end_symbol in end_symbols.iter() {
                     if let Some(symbol) = end_symbol.upgrade_weak(session.st()) {
                         definition_sources.push(GotoSource{
@@ -290,7 +290,7 @@ impl GotoUtils {
                     }
                 }
             } else {
-                let Some(symbol) = eval.symbol.get_symbol_as_weak(session, &mut None, &mut vec![], None).weak.upgrade(session.st()) else {
+                let Some(symbol) = eval.symbol.get_symbol_as_weak(session, None, &mut vec![], None).weak.upgrade(session.st()) else {
                     index += 1;
                     continue;
                 };

--- a/server/src/features/references.rs
+++ b/server/src/features/references.rs
@@ -424,7 +424,7 @@ impl ReferenceVisitor {
             let variable = session.st().get_positioned_symbol(*self.sym_stack.last().unwrap(), var_name, &alias.range);
             let Some(SymbolKey::Variable(variable_key)) = variable else { continue };
             for evaluation in session.st()[variable_key].evaluations.clone() {
-                let eval_sym = evaluation.symbol.get_symbol(session, &mut None, &mut vec![], Some(file_symbol.into()));
+                let eval_sym = evaluation.symbol.get_symbol(session, None, &mut vec![], Some(file_symbol.into()));
                 let EvaluationSymbolPtr::WEAK(w) = eval_sym else {
                     panic!("Internal error: evaluated has invalid evaluationType");
                 };

--- a/server/src/features/references_xml.rs
+++ b/server/src/features/references_xml.rs
@@ -1,6 +1,6 @@
 use crate::{
     S, constants::SymType, core::{
-        evaluation::ContextValue,
+        evaluation_context::ContextValue,
         file_mgr::FileMgr,
         symbols::{
             storage::SymbolTable, symbol_keys::{ModuleKey, SymbolKey, XmlFileKey}

--- a/server/src/features/xml_ast_utils.rs
+++ b/server/src/features/xml_ast_utils.rs
@@ -1,6 +1,6 @@
 use crate::{
     S, core::{
-        evaluation::ContextValue,
+        evaluation_context::ContextValue,
         odoo::SyncOdoo,
         symbols::{
             ModuleSymbol, symbol_keys::{ModuleKey, SourceFileKey, SymbolKey, XmlId}
@@ -187,7 +187,7 @@ impl XmlAstUtils {
 
     fn add_xml_id_result(session: &mut SessionInfo, xml_id: &str, file_symbol: SourceFileKey, range: Range<usize>, results: &mut (Vec<SymbolKey>, Option<Range<usize>>), on_dep_only: bool) {
         let xml_ids = SyncOdoo::get_xml_ids(session, file_symbol, xml_id, &range, &mut vec![]);
-        
+
         for xml_id in xml_ids.iter_valid(session.st()) {
             if on_dep_only {
                 if let Some(module) = session.st().find_module(xml_id) {

--- a/server/tests/self_propagation_tests/self_propagation_tests.rs
+++ b/server/tests/self_propagation_tests/self_propagation_tests.rs
@@ -21,9 +21,9 @@ fn test_model_subscription() {
         match session.st().evaluations(sym).cloned() {
             Some(evals) => evals.into_iter().flat_map(|eval|
                 SymbolTable::follow_ref(
-                    &eval.symbol.get_symbol(session, &mut None, &mut vec![], None),
+                    &eval.symbol.get_symbol(session, None, &mut vec![], None),
                     session,
-                    &mut None,
+                    None,
                     false,
                     false,
                     None,

--- a/server/tests/test_basics.rs
+++ b/server/tests/test_basics.rs
@@ -44,7 +44,7 @@ fn test_assigns() {
     assert!(st.name(a[0]) == "a");
     assert!(st.evaluations(a[0]).as_ref().unwrap().len() == 1);
     assert!(st.evaluations(a[0]).as_ref().unwrap()[0].value.is_some());
-    assert!(matches!(st.evaluations(a[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::NumberLiteral(_))));
+    assert!(matches!(st.evaluations(a[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(c) if matches!(c.as_ref(), Expr::NumberLiteral(_))));
     assert!(st.evaluations(a[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_number_literal_expr());
     assert!(st.evaluations(a[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.is_int());
     assert!(st.evaluations(a[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap().as_i32().unwrap() == 5);
@@ -54,7 +54,7 @@ fn test_assigns() {
     assert!(st.name(b[0]) == "b");
     assert!(st.evaluations(b[0]).as_ref().unwrap().len() == 1);
     assert!(st.evaluations(b[0]).as_ref().unwrap()[0].value.is_some());
-    assert!(matches!(st.evaluations(b[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::StringLiteral(_))));
+    assert!(matches!(st.evaluations(b[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(c) if matches!(c.as_ref(), Expr::StringLiteral(_))));
     assert!(st.evaluations(b[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_string_literal_expr());
     assert!(st.evaluations(b[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_string_literal_expr().unwrap().value.to_str() == "test");
 
@@ -63,7 +63,7 @@ fn test_assigns() {
     assert!(st.name(c[0]) == "c");
     assert!(st.evaluations(c[0]).as_ref().unwrap().len() == 1);
     assert!(st.evaluations(c[0]).as_ref().unwrap()[0].value.is_some());
-    assert!(matches!(st.evaluations(c[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::NumberLiteral(_))));
+    assert!(matches!(st.evaluations(c[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(c) if matches!(c.as_ref(), Expr::NumberLiteral(_))));
     assert!(st.evaluations(c[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_number_literal_expr());
     assert!(st.evaluations(c[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.is_float());
     assert!(st.evaluations(c[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_number_literal_expr().unwrap().value.as_float().unwrap() == &3.14);
@@ -73,7 +73,7 @@ fn test_assigns() {
     assert!(st.name(d[0]) == "d");
     assert!(st.evaluations(d[0]).as_ref().unwrap().len() == 1);
     assert!(st.evaluations(d[0]).as_ref().unwrap()[0].value.is_some());
-    assert!(matches!(st.evaluations(d[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::BooleanLiteral(_))));
+    assert!(matches!(st.evaluations(d[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(c) if matches!(c.as_ref(), Expr::BooleanLiteral(_))));
     assert!(st.evaluations(d[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_boolean_literal_expr());
     assert!(st.evaluations(d[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_boolean_literal_expr().unwrap().value == true);
 
@@ -82,7 +82,7 @@ fn test_assigns() {
     assert!(st.name(e[0]) == "e");
     assert!(st.evaluations(e[0]).as_ref().unwrap().len() == 1);
     assert!(st.evaluations(e[0]).as_ref().unwrap()[0].value.is_some());
-    assert!(matches!(st.evaluations(e[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::BooleanLiteral(_))));
+    assert!(matches!(st.evaluations(e[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(c) if matches!(c.as_ref(), Expr::BooleanLiteral(_))));
     assert!(st.evaluations(e[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_boolean_literal_expr());
     assert!(st.evaluations(e[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().as_boolean_literal_expr().unwrap().value == false);
 
@@ -91,7 +91,7 @@ fn test_assigns() {
     assert!(st.name(f[0]) == "f");
     assert!(st.evaluations(f[0]).as_ref().unwrap().len() == 1);
     assert!(st.evaluations(f[0]).as_ref().unwrap()[0].value.is_some());
-    assert!(matches!(st.evaluations(f[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(Expr::NoneLiteral(_))));
+    assert!(matches!(st.evaluations(f[0]).as_ref().unwrap()[0].value.as_ref().unwrap(), EvaluationValue::CONSTANT(c) if matches!(c.as_ref(), Expr::NoneLiteral(_))));
     assert!(st.evaluations(f[0]).as_ref().unwrap()[0].value.as_ref().unwrap().as_constant().is_none_literal_expr());
 
     let g = session.sync_odoo.get_symbol(path.as_str(), (&[], &["g"]), u32::MAX);
@@ -165,7 +165,7 @@ fn test_sections() {
             let eval = evaluations.as_ref().unwrap();
             assert_eq!(eval.len(), 1);  // Check that each symbol has one evaluation
             let value = eval[0].value.as_ref().unwrap();
-            assert!(matches!(value, EvaluationValue::CONSTANT(Expr::NumberLiteral(_)))); // Check that the evaluation is a num literal
+            assert!(matches!(value, EvaluationValue::CONSTANT(c) if matches!(c.as_ref(), Expr::NumberLiteral(_)))); // Check that the evaluation is a num literal
             let number = value.as_constant().as_number_literal_expr().unwrap().value.as_int().unwrap();
             number.as_i32().unwrap()
         })

--- a/server/tests/test_utils.rs
+++ b/server/tests/test_utils.rs
@@ -168,7 +168,7 @@ pub fn get_resolved_symbols_at_position(
             SymbolTable::follow_ref(
                 eval.symbol.get_symbol_ptr(),
                 session,
-                &mut None,
+                None,
                 false,
                 false,
                 None,


### PR DESCRIPTION
> This is not a big PR. Just a big diff. :)

The main subject of this PR: new type for evaluation `Context`: use vector* instead of HashMap (faster and smaller).
Secondary subjects:
  - optimize memory usage related to Evaluations
    - Box EvaluationValue::CONSTANT
    - use enum for Hook `name`
  - avoid mutable Context everywhere
  
Perf gains:
  - 9,3 % less memory
  - 6,4 % less CPU time

`*` thin-vec actually. See [crate repo](https://github.com/mozilla/thin-vec). it's basically a vector of size 8 instead of 24 when empty.
```
════════════════════════════════════════════════════════════════
 Aggregated results (5 runs each, mean ± stddev)            
════════════════════════════════════════════════════════════════
commit                user (s)           sys (s)     total CPU (s)          wall (s)       peak RSS (MB)
──────────  ────────────────  ────────────────  ────────────────  ────────────────  ──────────────────
3b141e7e       22.124 ± 0.129    4.232 ± 0.181   26.356 ± 0.251   26.784 ± 1.157       2746.5 ± 0.3
9c73c515       20.644 ± 0.089    4.020 ± 0.034   24.664 ± 0.074   24.654 ± 0.087       2490.4 ± 0.2

Δ (after − before):
  user (s):              -1.480  ( -6.69%)   z=9.4
  sys (s):               -0.212  ( -5.01%)   z=1.2
  total CPU (s):         -1.692  ( -6.42%)   z=6.5
  wall (s):              -2.130  ( -7.95%)   z=1.8
  peak RSS (MB):         -256.1  ( -9.33%)   z=720.9

z = |Δ| / sqrt(σ_before² + σ_after²) — rough significance:
  z > 3 : clearly significant   1 < z < 3 : suggestive   z < 1 : likely noise
════════════════════════════════════════════════════════════════

 Raw data points                                                
════════════════════════════════════════════════════════════════

  Before (3b141e7e)
    run        user(s)     sys(s)    wall(s)        rss(MB)
    1            22.23       4.59      29.09         2746.6
    2            22.19       4.10      26.28         2746.1
    3            21.89       4.18      26.04         2746.3
    4            22.08       4.16      26.21         2746.9
    5            22.23       4.13      26.30         2746.4

  After  (9c73c515)
    run        user(s)     sys(s)    wall(s)        rss(MB)
    1            20.53       4.03      24.52         2490.7
    2            20.72       3.98      24.70         2490.3
    3            20.77       4.01      24.78         2490.0
    4            20.62       4.00      24.61         2490.5
    5            20.58       4.08      24.66         2490.4


```