### PR TITLE
[PERF] Import resolution

### DIFF
--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{cell::RefCell, cmp, path::PathBuf, rc::Rc, u32};
 use crate::utils::HashMap;
 
@@ -351,10 +352,10 @@ impl EntryPointMgr {
 
     /// Transform the path of an addon to the odoo relative path.
     /// Otherwise, return the path as is.
-    pub fn transform_addon_path(&self, path: &PathBuf) -> String {
+    pub fn transform_addon_path(&self, path: &Path) -> String {
         for entry in self.addons_entry_points.iter() {
             if entry.borrow().is_valid_for(path) {
-                let path_str = path.sanitize();
+                let path_str = path.sanitize_cow();
                 return path_str.replace(&entry.borrow().path, entry.borrow().addon_to_odoo_path.as_ref().unwrap());
             }
         }
@@ -427,9 +428,9 @@ impl EntryPoint {
         }))
     }
 
-    pub fn is_valid_for(&self, path: &PathBuf) -> bool {
+    pub fn is_valid_for(&self, path: &Path) -> bool {
         if self.typ == EntryPointType::UNTITLED {
-            return self.path == path.sanitize();
+            return self.path == path.sanitize_cow();
         }
         path.starts_with(&self.path)
     }

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -234,7 +234,7 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
 pub fn create_module_from_name(session: &mut SessionInfo, odoo_addons: NamespaceKey, name: &str) -> Option<ModuleKey> {
     for path in session.st()[odoo_addons].paths() {
         let full_path = PathBuf::from(path).join(name);
-        if !is_dir_cs(full_path.sanitize()) {
+        if !is_dir_cs(&full_path.sanitize()) {
             continue;
         }
         let Some(module) = SymbolTable::create_module_from_path(session, &full_path, odoo_addons) else {
@@ -282,7 +282,7 @@ fn resolve_packages(symbol_table: &SymbolTable, from_file: SymbolKey, level: u32
 }
 
 fn get_or_create_symbol(
-    session: &mut SessionInfo, for_entry: &Rc<RefCell<EntryPoint>>, from_path: &str, symbol: Option<Vec<SymbolKey>>, names: &Vec<OYarn>, asname: Option<String>, level: u32
+    session: &mut SessionInfo, for_entry: &Rc<RefCell<EntryPoint>>, from_path: &str, symbol: Option<Vec<SymbolKey>>, names: &Vec<OYarn>, asname: Option<&str>, level: u32
 ) -> (Option<Vec<SymbolKey>>, Option<Vec<SymbolKey>>) {
     let mut syms = symbol.clone();
     let mut last_symbols = symbol.clone();
@@ -299,7 +299,7 @@ fn get_or_create_symbol(
                 for &s in symbols.iter() {
                     let mut current_batch_symbol = session.st().get_symbol(s, (&[branch.clone()], &[]), u32::MAX);
                     if current_batch_symbol.is_empty() && matches!(s, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
-                        current_batch_symbol = match resolve_new_symbol(session, s, &branch, asname.clone()) {
+                        current_batch_symbol = match resolve_new_symbol(session, s, &branch, asname) {
                             Ok(v) => vec![v],
                             Err(_) => vec![]
                         }
@@ -347,7 +347,7 @@ fn get_or_create_symbol(
                         if let Some(entry_point) = entry_point {
                             let mut next_symbols = session.st().get_symbol(entry_point, (&[branch.clone()], &[]), u32::MAX);
                             if next_symbols.is_empty() && matches!(entry_point, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
-                                next_symbols = match resolve_new_symbol(session, entry_point, &branch, asname.clone()) {
+                                next_symbols = match resolve_new_symbol(session, entry_point, &branch, asname) {
                                     Ok(v) => vec![v],
                                     Err(_) => vec![]
                                 }
@@ -395,72 +395,70 @@ fn get_or_create_symbol(
 
 /// Resolve a new symbol from disk, creating it if found, or just creating a COMPILED symbol if a parent is COMPILED
 /// parent : parent symbol where to search, either ROOT, NAMESPACE, PACKAGE, COMPILED or DISK_DIR
-fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_name: &OYarn, asname: Option<String>) -> Result<SymbolKey, String> {
-    if imported_name == "" {
-        return Err("Empty name".to_string());
+fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_name: &OYarn, asname: Option<&str>) -> Result<SymbolKey, &'static str> {
+    if imported_name.is_empty() {
+        return Err("Empty name");
     }
-    let sym_name: String = match asname {
-        Some(asname_inner) => asname_inner,
-        None => imported_name.to_string()
-    };
+    let sym_name = asname.unwrap_or(imported_name.as_str());
     // COMPILED: we can only create a COMPILED symbol
     if matches!(parent, SymbolKey::Compiled(_)) {
-        return Ok(session.st_mut().add_new_compiled(parent, &sym_name, "").into());
+        return Ok(session.st_mut().add_new_compiled(parent, sym_name, "").into());
     }
     // ROOT, NAMESPACE, PACKAGE or DISK_DIR: we can search on disk
-    let paths = session.st().paths(parent);
-    for path in paths.iter() {
-        let mut full_path = Path::new(path.as_str()).join(imported_name.to_string());
-        for stub in session.sync_odoo.stubs_dirs.iter() {
-            if path.as_str().to_string() == *stub {
-                full_path = full_path.join(imported_name.to_string());
+    'paths: for path in session.st().paths(parent) {
+        let is_stub = session.sync_odoo.stubs_dirs.contains(&path);
+        let mut full_path = PathBuf::from(path);
+        full_path.push(imported_name.as_str());
+        if is_stub {
+            full_path.push(imported_name.as_str());
+        }
+        let full_path_str = full_path.sanitize();
+        let is_dir = is_dir_cs(&full_path_str);
+        // Try as package/odoo module
+        if is_dir && (
+            is_file_cs(&full_path.join("__init__.py").sanitize())
+            || is_file_cs(&full_path.join("__init__.pyi").sanitize())
+        ) {
+            if let Some(symbol) = SymbolTable::create_from_path(session, &full_path, parent, false) {
+                SyncOdoo::build_now(session, symbol, BuildSteps::ARCH);
+                return Ok(symbol);
+            }
+            continue;
+        }
+        // Try as file (python module)
+        for extension in ["py", "pyi"] {
+            let path = full_path.with_extension(extension);
+            if is_file_cs(&path.sanitize()) {
+                if let Some(symbol) = SymbolTable::create_from_path(session, &path, parent, false) {
+                    SyncOdoo::build_now(session, symbol, BuildSteps::ARCH);
+                    return Ok(symbol);
+                }
+                continue 'paths;
             }
         }
-        if is_dir_cs(full_path.sanitize()) && (is_file_cs(full_path.join("__init__").with_extension("py").sanitize().as_str()) ||
-        is_file_cs(full_path.join("__init__").with_extension("pyi").sanitize().as_str())) {
-            //module directory
-            let _rc_symbol = SymbolTable::create_from_path(session, &full_path, parent, false);
-            if _rc_symbol.is_some() {
-                let _arc_symbol = _rc_symbol.unwrap();
-                SyncOdoo::build_now(session, _arc_symbol, BuildSteps::ARCH);
-                return Ok(_arc_symbol);
+        // Try as directory (namespace)
+        if is_dir {
+            if let Some(symbol) = SymbolTable::create_from_path(session, &full_path, parent, false) {
+                SyncOdoo::build_now(session, symbol, BuildSteps::ARCH);
+                return Ok(symbol);
             }
-        } else if is_file_cs(full_path.with_extension("py").sanitize().as_str()) {
-            let _arc_symbol = SymbolTable::create_from_path(session, &full_path.with_extension("py"), parent, false);
-            if _arc_symbol.is_some() {
-                let _arc_symbol = _arc_symbol.unwrap();
-                SyncOdoo::build_now(session, _arc_symbol, BuildSteps::ARCH);
-                return Ok(_arc_symbol);
-            }
-        } else if is_file_cs(full_path.with_extension("pyi").sanitize().as_str()) {
-            let _arc_symbol = SymbolTable::create_from_path(session, &full_path.with_extension("pyi"), parent, false);
-            if _arc_symbol.is_some() {
-                let _arc_symbol = _arc_symbol.unwrap();
-                SyncOdoo::build_now(session, _arc_symbol, BuildSteps::ARCH);
-                return Ok(_arc_symbol);
-            }
-        } else if is_dir_cs(full_path.sanitize()) {
-            //namespace directory
-            let _rc_symbol = SymbolTable::create_from_path(session, &full_path, parent, false);
-            if _rc_symbol.is_some() {
-                let _arc_symbol = _rc_symbol.unwrap();
-                SyncOdoo::build_now(session, _arc_symbol, BuildSteps::ARCH);
-                return Ok(_arc_symbol);
-            }
-        } else if !matches!(parent, SymbolKey::Root(_)) {
+            continue;
+        }
+        // Try as compiled
+        if !matches!(parent, SymbolKey::Root(_)) {
             // Probe the suffixes CPython itself accepts for extension modules,
             // in the order it would try them (see importlib.machinery.EXTENSION_SUFFIXES).
-            let base = full_path.sanitize();
+            let base = &full_path_str;
             let candidates = session.sync_odoo.python_ext_suffixes.iter()
                 .map(|suffix| format!("{}{}", base, suffix));
             for candidate in candidates {
                 if is_file_cs(&candidate) {
-                    return Ok(session.st_mut().add_new_compiled(parent, &sym_name, &candidate).into());
+                    return Ok(session.st_mut().add_new_compiled(parent, sym_name, &candidate).into());
                 }
             }
         }
     }
-    return Err("Symbol not found".to_string())
+    return Err("Symbol not found")
 }
 
 /*
@@ -581,7 +579,7 @@ fn valid_names_for_a_symbol(symbol_table: &SymbolTable, symbol: SymbolKey, start
 
 fn valid_name_from_disk(path: &String, start_filter: &str) -> HashMap<OYarn, SymType> {
     let mut res = HashMap::default();
-    if is_dir_cs(path.clone()) {
+    if is_dir_cs(path) {
         if let Ok(entries) = std::fs::read_dir(path) {
             for entry in entries {
                 if let Ok(entry) = entry {

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -447,7 +447,7 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
             continue;
         }
         // Try as compiled
-        if !matches!(parent, SymbolKey::Root(_)) {
+        if !is_stub && !matches!(parent, SymbolKey::Root(_)) {
             // Probe the suffixes CPython itself accepts for extension modules,
             // in the order it would try them (see importlib.machinery.EXTENSION_SUFFIXES).
             let base = &full_path_str;

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -1,4 +1,3 @@
-use glob::glob;
 use lsp_types::{Diagnostic, DiagnosticTag, Position, Range};
 use ruff_python_ast::name::Name;
 use tracing::error;
@@ -449,23 +448,14 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
                 return Ok(_arc_symbol);
             }
         } else if !matches!(parent, SymbolKey::Root(_)) {
-            if cfg!(target_os = "windows") {
-                for entry in glob((full_path.sanitize() + "*.pyd").as_str()).expect("Failed to read glob pattern") {
-                    match entry {
-                        Ok(_path) => {
-                            return Ok(session.st_mut().add_new_compiled(parent, &sym_name, _path.to_str().unwrap()).into());
-                        }
-                        Err(_) => {},
-                    }
-                }
-            } else if cfg!(target_os = "linux") {
-                for entry in glob((full_path.sanitize() + "*.so").as_str()).expect("Failed to read glob pattern") {
-                    match entry {
-                        Ok(_path) => {
-                            return Ok(session.st_mut().add_new_compiled(parent, &sym_name, _path.to_str().unwrap()).into());
-                        }
-                        Err(_) => {},
-                    }
+            // Probe the suffixes CPython itself accepts for extension modules,
+            // in the order it would try them (see importlib.machinery.EXTENSION_SUFFIXES).
+            let base = full_path.sanitize();
+            let candidates = session.sync_odoo.python_ext_suffixes.iter()
+                .map(|suffix| format!("{}{}", base, suffix));
+            for candidate in candidates {
+                if is_file_cs(&candidate) {
+                    return Ok(session.st_mut().add_new_compiled(parent, &sym_name, &candidate).into());
                 }
             }
         }

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -287,7 +287,7 @@ fn get_or_create_symbol(
     session: &mut SessionInfo, for_entry: &Rc<RefCell<EntryPoint>>, from_path: &str, symbol: Option<Vec<SymbolKey>>, names: &Vec<OYarn>, asname: Option<&str>, level: u32
 ) -> (Option<Vec<SymbolKey>>, Option<Vec<SymbolKey>>) {
     let mut syms = symbol.clone();
-    let mut last_symbols = symbol.clone();
+    let mut last_symbols = symbol;
     for branch in names.iter() {
         if branch.is_empty() {
             continue;
@@ -299,21 +299,21 @@ fn get_or_create_symbol(
             Some(ref symbols) => {
                 let mut next_symbol = vec![];
                 for &s in symbols.iter() {
-                    let mut current_batch_symbol = session.st().get_symbol(s, (&[branch.clone()], &[]), u32::MAX);
-                    if current_batch_symbol.is_empty() && matches!(s, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
+                    let mut current_batch_symbol = session.st().get_module_symbol(s, branch);
+                    if current_batch_symbol.is_none() && matches!(s, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
                         current_batch_symbol = match resolve_new_symbol(session, s, &branch, asname) {
-                            Ok(v) => vec![v],
-                            Err(_) => vec![]
+                            Ok(v) => Some(v),
+                            Err(_) => None
                         }
                     }
-                    next_symbol.extend(current_batch_symbol.clone());
+                    next_symbol.extend(current_batch_symbol);
                 }
                 if next_symbol.is_empty() {
                     syms = None;
                     break;
                 }
                 syms = Some(next_symbol.clone());
-                last_symbols = Some(next_symbol.clone());
+                last_symbols = Some(next_symbol);
             },
             None => {
                 // Can we have sym None and level != 0 ? maybe on get_all_valid_names? tbc
@@ -347,30 +347,30 @@ fn get_or_create_symbol(
                     if ((entry.borrow().is_public() && level == 0) || entry.borrow().is_valid_for(&from_path)) && entry.borrow().addon_to_odoo_path.is_none() {
                         let entry_point = entry.borrow().get_symbol(session.st());
                         if let Some(entry_point) = entry_point {
-                            let mut next_symbols = session.st().get_symbol(entry_point, (&[branch.clone()], &[]), u32::MAX);
-                            if next_symbols.is_empty() && matches!(entry_point, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
-                                next_symbols = match resolve_new_symbol(session, entry_point, &branch, asname) {
-                                    Ok(v) => vec![v],
-                                    Err(_) => vec![]
+                            let mut next_symbol = session.st().get_module_symbol(entry_point, branch);
+                            if next_symbol.is_none() && matches!(entry_point, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
+                                next_symbol = match resolve_new_symbol(session, entry_point, &branch, asname) {
+                                    Ok(v) => Some(v),
+                                    Err(_) => None,
                                 }
                             }
-                            if next_symbols.is_empty() {
+                            let Some(next_symbol) = next_symbol else {
                                 continue;
-                            }
+                            };
                             if level == 0 {
                                 if entry.borrow().is_public() {
                                     if let Some(cache) = session.sync_odoo.import_cache.as_mut() {
-                                        cache.modules.insert(branch.clone(), Some(next_symbols.clone()));
+                                        cache.modules.insert(branch.clone(), Some(vec![next_symbol]));
                                     }
                                 } else if matches!(entry.borrow().typ, EntryPointType::MAIN | EntryPointType::ADDON) {
                                     if let Some(cache) = session.sync_odoo.import_cache.as_mut() {
-                                        cache.main_modules.insert(branch.clone(), Some(next_symbols.clone()));
+                                        cache.main_modules.insert(branch.clone(), Some(vec![next_symbol]));
                                     }
                                 }
                             }
                             found = true;
-                            syms = Some(next_symbols.clone());
-                            last_symbols = Some(next_symbols.clone());
+                            syms = Some(vec![next_symbol]);
+                            last_symbols = Some(vec![next_symbol]);
                             break;
                         }
                     }

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -234,7 +234,7 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
 pub fn create_module_from_name(session: &mut SessionInfo, odoo_addons: NamespaceKey, name: &str) -> Option<ModuleKey> {
     for path in session.st()[odoo_addons].paths() {
         let full_path = PathBuf::from(path).join(name);
-        if !is_dir_cs(&full_path.sanitize()) {
+        if !is_dir_cs(&full_path.sanitize_cow()) {
             continue;
         }
         let Some(module) = SymbolTable::create_module_from_path(session, &full_path, odoo_addons) else {
@@ -339,7 +339,7 @@ fn get_or_create_symbol(
                 let mut found = false;
                 let entry_point_mgr = session.sync_odoo.entry_point_mgr.clone();
                 let entry_point_mgr = entry_point_mgr.borrow();
-                let from_path = session.sync_odoo.entry_point_mgr.borrow().transform_addon_path(&PathBuf::from(from_path));
+                let from_path = session.sync_odoo.entry_point_mgr.borrow().transform_addon_path(Path::new(from_path));
                 let from_path = PathBuf::from(from_path);
                 for entry in entry_point_mgr.iter_for_import(for_entry) {
                     if ((entry.borrow().is_public() && level == 0) || entry.borrow().is_valid_for(&from_path)) && entry.borrow().addon_to_odoo_path.is_none() {
@@ -412,12 +412,12 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
         if is_stub {
             full_path.push(imported_name.as_str());
         }
-        let full_path_str = full_path.sanitize();
+        let full_path_str = full_path.sanitize_cow();
         let is_dir = is_dir_cs(&full_path_str);
         // Try as package/odoo module
         if is_dir && (
-            is_file_cs(&full_path.join("__init__.py").sanitize())
-            || is_file_cs(&full_path.join("__init__.pyi").sanitize())
+            is_file_cs(&full_path.join("__init__.py").sanitize_cow())
+            || is_file_cs(&full_path.join("__init__.pyi").sanitize_cow())
         ) {
             if let Some(symbol) = SymbolTable::create_from_path(session, &full_path, parent, false) {
                 SyncOdoo::build_now(session, symbol, BuildSteps::ARCH);
@@ -428,7 +428,7 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
         // Try as file (python module)
         for extension in ["py", "pyi"] {
             let path = full_path.with_extension(extension);
-            if is_file_cs(&path.sanitize()) {
+            if is_file_cs(&path.sanitize_cow()) {
                 if let Some(symbol) = SymbolTable::create_from_path(session, &path, parent, false) {
                     SyncOdoo::build_now(session, symbol, BuildSteps::ARCH);
                     return Ok(symbol);
@@ -492,7 +492,7 @@ pub fn get_all_valid_names(session: &mut SessionInfo, source_file_symbol: Source
         } else { //nothing was provided, so we have to add the root symbol of any valid entrypoint
             let entry_point_mgr = session.sync_odoo.entry_point_mgr.clone();
             let entry_point_mgr = entry_point_mgr.borrow();
-            let from_path = session.sync_odoo.entry_point_mgr.borrow().transform_addon_path(&PathBuf::from(&source_path));
+            let from_path = session.sync_odoo.entry_point_mgr.borrow().transform_addon_path(Path::new(&source_path));
             let from_path = PathBuf::from(from_path);
             for entry in entry_point_mgr.iter_for_import(&entry) {
                 if (entry.borrow().is_public() && (level == 0)) || entry.borrow().is_valid_for(&from_path) {

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -13,7 +13,7 @@ use crate::core::symbols::symbol_keys::{ModuleKey, NamespaceKey, SourceFileKey, 
 use crate::{constants::*, oyarn, Sy, S};
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
 use crate::threads::SessionInfo;
-use crate::utils::{is_dir_cs, is_file_cs, PathSanitizer};
+use crate::utils::{is_dir_cs, PathSanitizer};
 
 use super::entry_point::{EntryPoint, EntryPointType};
 use super::odoo::SyncOdoo;
@@ -29,10 +29,12 @@ pub struct ImportResult {
 
 //class used to cache import results in a build execution to speed up subsequent imports.
 //It means of course than a modification during the build will not be taken into account, but it should be ok because reloaded after the build
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ImportCache {
     pub modules: HashMap<OYarn, Option<Vec<SymbolKey>>>,
     pub main_modules: HashMap<OYarn, Option<Vec<SymbolKey>>>,
+    pub is_file_cs: HashMap<String, bool>,
+    pub is_dir_cs: HashMap<String, bool>,
 }
 
 fn resolve_import_stmt_hook(alias: &Alias, from_symbols: &Option<Vec<SymbolKey>>, session: &mut SessionInfo, source_file_symbol: SymbolKey, from_stmt: Option<&Identifier>, level: u32, diagnostics: &mut Option<&mut Vec<Diagnostic>>) -> Option<ImportResult>{
@@ -234,7 +236,7 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
 pub fn create_module_from_name(session: &mut SessionInfo, odoo_addons: NamespaceKey, name: &str) -> Option<ModuleKey> {
     for path in session.st()[odoo_addons].paths() {
         let full_path = PathBuf::from(path).join(name);
-        if !is_dir_cs(&full_path.sanitize_cow()) {
+        if !session.sync_odoo.is_dir_cs(&full_path.sanitize_cow()) {
             continue;
         }
         let Some(module) = SymbolTable::create_module_from_path(session, &full_path, odoo_addons) else {
@@ -413,11 +415,11 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
             full_path.push(imported_name.as_str());
         }
         let full_path_str = full_path.sanitize_cow();
-        let is_dir = is_dir_cs(&full_path_str);
+        let is_dir = session.sync_odoo.is_dir_cs(&full_path_str);
         // Try as package/odoo module
         if is_dir && (
-            is_file_cs(&full_path.join("__init__.py").sanitize_cow())
-            || is_file_cs(&full_path.join("__init__.pyi").sanitize_cow())
+            session.sync_odoo.is_file_cs(&full_path.join("__init__.py").sanitize_cow())
+            || session.sync_odoo.is_file_cs(&full_path.join("__init__.pyi").sanitize_cow())
         ) {
             if let Some(symbol) = SymbolTable::create_from_path(session, &full_path, parent, false) {
                 SyncOdoo::build_now(session, symbol, BuildSteps::ARCH);
@@ -428,7 +430,7 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
         // Try as file (python module)
         for extension in ["py", "pyi"] {
             let path = full_path.with_extension(extension);
-            if is_file_cs(&path.sanitize_cow()) {
+            if session.sync_odoo.is_file_cs(&path.sanitize_cow()) {
                 if let Some(symbol) = SymbolTable::create_from_path(session, &path, parent, false) {
                     SyncOdoo::build_now(session, symbol, BuildSteps::ARCH);
                     return Ok(symbol);
@@ -450,9 +452,10 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
             // in the order it would try them (see importlib.machinery.EXTENSION_SUFFIXES).
             let base = &full_path_str;
             let candidates = session.sync_odoo.python_ext_suffixes.iter()
-                .map(|suffix| format!("{}{}", base, suffix));
+                .map(|suffix| format!("{}{}", base, suffix))
+                .collect::<Vec<_>>();
             for candidate in candidates {
-                if is_file_cs(&candidate) {
+                if session.sync_odoo.is_file_cs(&candidate) {
                     return Ok(session.st_mut().add_new_compiled(parent, sym_name, &candidate).into());
                 }
             }

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -20,7 +20,7 @@ use crate::features::definition::DefinitionFeature;
 use crate::features::hover::HoverFeature;
 use crate::threads::SessionInfo;
 use crate::weak_collections::{WeakMap, WeakSet};
-use crate::utils::HashMap;
+use crate::utils::{HashMap, is_dir_cs, is_file_cs};
 use std::cell::RefCell;
 use std::rc::{Rc};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -738,7 +738,7 @@ impl SyncOdoo {
             return false;
         }
         SyncOdoo::add_from_self_reload(session);
-        session.sync_odoo.import_cache = Some(ImportCache{ modules: HashMap::default(), main_modules: HashMap::default() });
+        session.sync_odoo.import_cache = Some(ImportCache::default());
         let mut already_arch_rebuilt: HashSet<Tree> = HashSet::default();
         let mut already_arch_eval_rebuilt: HashSet<Tree> = HashSet::default();
 
@@ -1436,6 +1436,24 @@ impl SyncOdoo {
         for sym in to_revalidate {
             self.add_to_validations(sym);
         }
+    }
+
+    /// Cached version of `is_file_cs` that uses the import cache if available.
+    /// Avoids multiple stat syscalls for the same file during a rebuild.
+    pub fn is_file_cs(&mut self, path: &str) -> bool {
+        let Some(cache) = self.import_cache.as_mut().map(|c| &mut c.is_file_cs) else {
+            return is_file_cs(path);
+        };
+        *cache.entry(path.to_string()).or_insert_with(|| is_file_cs(path))
+    }
+
+    /// Cached version of `is_dir_cs` that uses the import cache if available.
+    /// Avoids multiple stat syscalls for the same dir during a rebuild.
+    pub fn is_dir_cs(&mut self, path: &str) -> bool {
+        let Some(cache) = self.import_cache.as_mut().map(|c| &mut c.is_dir_cs) else {
+            return is_dir_cs(path);
+        };
+        *cache.entry(path.to_string()).or_insert_with(|| is_dir_cs(path))
     }
 }
 

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1049,7 +1049,7 @@ impl SyncOdoo {
     pub fn unload_path(session: &mut SessionInfo, path: &PathBuf) {
         let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
         for entry in ep_mgr.borrow().iter_all() {
-            let sym_in_data = entry.borrow().data_symbols.get(path.sanitize().as_str()).cloned();
+            let sym_in_data = entry.borrow().data_symbols.get(path.sanitize_cow().as_ref()).copied();
             if let Some(sym) = sym_in_data {
                 if let Some(sym) = sym.upgrade(session.st()) {
                     SymbolTable::unload(session, sym.into());

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -107,6 +107,12 @@ impl TypeshedWeakReferences {
 pub struct SyncOdoo {
     pub version: OdooVersion,
     pub python_version: Vec<u32>,
+    /// Filename suffixes the configured Python interpreter accepts for C
+    /// extension modules, in CPython's own probe order (the value of
+    /// `importlib.machinery.EXTENSION_SUFFIXES`). Used to detect compiled
+    /// modules without globbing. Populated from the Python query in `init`;
+    /// initialized to a platform default so non-Python init paths still work.
+    pub python_ext_suffixes: Vec<String>,
     pub config: ConfigEntry,
     pub config_file: Option<ConfigFile>,
     pub config_path: Option<String>,
@@ -157,6 +163,7 @@ impl SyncOdoo {
         let sync_odoo = Self {
             version: OdooVersion::default(),
             python_version: vec![0, 0, 0],
+            python_ext_suffixes: Vec::new(),
             config: ConfigEntry::new(),
             selected_config: None,
             config_file: None,
@@ -310,7 +317,7 @@ impl SyncOdoo {
                     }
                 }
             }
-            match Command::new(session.sync_odoo.config.python_path.clone()).args(&["-c", "import sys; import json; print(json.dumps(sys.version_info))"]).output() {
+            match Command::new(session.sync_odoo.config.python_path.clone()).args(&["-c", "import sys, importlib.machinery, json; print(json.dumps({'version_info': list(sys.version_info)[:3], 'ext_suffixes': list(importlib.machinery.EXTENSION_SUFFIXES)}))"]).output() {
                 Err(err) => {
                     warn!("Wrong python command: {}, error: {}", session.sync_odoo.config.python_path.clone(), err);
                     session.send_notification("$Odoo/invalid_python_path", ());
@@ -319,19 +326,23 @@ impl SyncOdoo {
                     session.sync_odoo.has_valid_python = true;
                     if output.status.success() {
                         let stdout = String::from_utf8_lossy(&output.stdout);
-                        session.log_message(MessageType::INFO, format!("Detected sys.version_info: {}", stdout));
-                        let version_infos: Value = serde_json::from_str(&stdout).expect("Unable to get python version info with json of sys.version_info output");
-                        session.sync_odoo.python_version = version_infos.as_array()
-                            .expect("Expected JSON array")
+                        session.log_message(MessageType::INFO, format!("Detected python info: {}", stdout));
+                        let info: Value = serde_json::from_str(&stdout).expect("Unable to parse python info json");
+                        session.sync_odoo.python_version = info["version_info"].as_array()
+                            .expect("Expected JSON array for version_info")
                             .iter()
                             .filter_map(|v| v.as_u64())
                             .map(|v| v as u32)
                             .take(3)
                             .collect();
+                        session.sync_odoo.python_ext_suffixes = info["ext_suffixes"].as_array()
+                            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+                            .unwrap_or_default();
                         info!("Detected python version: {}.{}.{}", session.sync_odoo.python_version[0], session.sync_odoo.python_version[1], session.sync_odoo.python_version[2]);
+                        info!("Detected python EXTENSION_SUFFIXES: {:?}", session.sync_odoo.python_ext_suffixes);
                     } else {
                         let stderr = String::from_utf8_lossy(&output.stderr);
-                        warn!("Error reading sys.version_info: {}", stderr);
+                        warn!("Error reading python info: {}", stderr);
                     }
                 }
             }

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -195,8 +195,8 @@ impl PythonValidator {
             }
             if !session.sync_odoo.config.file_cache {
                 if let SymbolKey::Module(m) = symbol {
-                    let manifest_path = PathBuf::from(&session.st()[m].path).join("__manifest__.py").sanitize();
-                    if let Some(manifest_file) = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path) {
+                    let manifest_path = PathBuf::from(&session.st()[m].path).join("__manifest__.py");
+                    if let Some(manifest_file) = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize_cow()) {
                         if !manifest_file.borrow().opened {
                             let manifest_file = manifest_file.borrow();
                             manifest_file.file_info_ast.borrow_mut().indexed_module = None;

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -20,15 +20,16 @@ impl ModuleSymbol {
         for (data_url, data_range) in data_paths.iter() {
             let path = Path::new(&module_path).join(data_url);
             let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
+            let path_string = path.sanitize();
             //check if already exists
-            if session.st()[symbol_key].data_symbols().contains_key(&path.sanitize()) {
+            if session.st()[symbol_key].data_symbols().contains_key(&path_string) {
                 continue;
             }
             //load data from file
             if !path.exists() {
-                session.st_mut()[symbol_key].not_found_data.insert(path.sanitize(), BuildSteps::ARCH_EVAL);
+                session.st_mut()[symbol_key].not_found_data.insert(path_string.clone(), BuildSteps::ARCH_EVAL);
                 session.st_mut().get_entry(symbol_key).borrow_mut().not_found_symbols.insert(symbol_key.into());
-                if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05049, &[&path.sanitize()]) {
+                if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05049, &[&path_string]) {
                     diagnostics.push(Diagnostic {
                         range: Range::new(Position::new(data_range.start().to_u32(), 0), Position::new(data_range.end().to_u32(), 0)),
                         ..diagnostic.clone()
@@ -36,7 +37,7 @@ impl ModuleSymbol {
                 }
                 continue;
             } else if path.extension().map_or(true, |ext| !["xml", "csv", "sql"].contains(&ext.to_str().unwrap_or(""))) {
-                if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05050, &[&path.sanitize()]) {
+                if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05050, &[&path_string]) {
                     diagnostics.push(Diagnostic {
                         range: Range::new(Position::new(data_range.start().to_u32(), 0), Position::new(data_range.end().to_u32(), 0)),
                         ..diagnostic.clone()
@@ -44,10 +45,10 @@ impl ModuleSymbol {
                 }
                 continue;
             }
-            let (_, file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, &path.sanitize(), None, None, false); //create ast if not in cache
+            let (_, file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, &path_string, None, None, false); //create ast if not in cache
             let mut file_info = file_info.borrow_mut();
             if file_name.ends_with(".xml") {
-                let xml_sym = session.st_mut().add_new_xml_file(symbol_key, &file_name, &path.sanitize());
+                let xml_sym = session.st_mut().add_new_xml_file(symbol_key, &file_name, &path_string);
                 Self::on_data_file_load(session.st(), xml_sym.into());
                 session.st_mut().add_dependency(symbol_key.into(), xml_sym.into(), BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
                 let data = match file_info.file_info_ast.borrow().text_document.as_ref() {
@@ -71,7 +72,7 @@ impl ModuleSymbol {
                     continue
                 }
             } else if file_name.ends_with(".csv") {
-                let csv_sym = session.st_mut().add_new_csv_file(symbol_key, &file_name, &path.sanitize());
+                let csv_sym = session.st_mut().add_new_csv_file(symbol_key, &file_name, &path_string);
                 Self::on_data_file_load(session.st(), csv_sym.into());
                 session.st_mut().add_dependency(symbol_key.into(), csv_sym.into(), BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
                 if file_info.file_info_ast.borrow().text_document.as_ref().is_none() {
@@ -86,7 +87,7 @@ impl ModuleSymbol {
             }
         }
         let manifest_path = PathBuf::from(&module_path).join("__manifest__.py");
-        let Some(manifest_file_info) = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize()) else {
+        let Some(manifest_file_info) = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize_cow()) else {
             return;
         };
         let mut manifest_file_info = (*manifest_file_info).borrow_mut();

--- a/server/src/core/symbols/manifest_create.rs
+++ b/server/src/core/symbols/manifest_create.rs
@@ -16,7 +16,7 @@ impl ModuleSymbol {
         if DEBUG_STEPS {
             info!("ARCH       - MANIFEST: {}", manifest_path.sanitize());
         }
-        let (_, manifest_file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, manifest_path.sanitize().as_str(), None, None, false);
+        let (_, manifest_file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, &manifest_path.sanitize_cow(), None, None, false);
         let mut manifest_file_info = (*manifest_file_info).borrow_mut();
         if manifest_file_info.file_info_ast.borrow().indexed_module.is_none() {
             return;

--- a/server/src/core/symbols/manifest_validation.rs
+++ b/server/src/core/symbols/manifest_validation.rs
@@ -41,7 +41,7 @@ impl ModuleSymbol {
             }
         }
         let manifest_path = PathBuf::from(root_path).join("__manifest__.py");
-        let manifest_file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize()).expect("file not found in cache").clone();
+        let manifest_file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize_cow()).expect("file not found in cache").clone();
         let mut manifest_file_info = (*manifest_file_info).borrow_mut();
         manifest_file_info.replace_diagnostics(BuildSteps::VALIDATION, diagnostics);
         manifest_file_info.publish_diagnostics(session);

--- a/server/src/core/symbols/module_utils.rs
+++ b/server/src/core/symbols/module_utils.rs
@@ -17,7 +17,7 @@ impl ModuleSymbol {
         let module = &mut session.st_mut()[module_key];
         module.loaded = true;
         let manifest_path = PathBuf::from(&module.root_path).join("__manifest__.py");
-        let manifest_file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize()).expect("file not found in cache").clone();
+        let manifest_file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize_cow()).expect("file not found in cache").clone();
         let mut manifest_file_info = (*manifest_file_info).borrow_mut();
         manifest_file_info.replace_diagnostics(crate::constants::BuildSteps::ARCH, diagnostics);
     }

--- a/server/src/core/symbols/storage/disk_dir_symbol.rs
+++ b/server/src/core/symbols/storage/disk_dir_symbol.rs
@@ -1,5 +1,5 @@
 
-use std::{path::PathBuf};
+use std::path::Path;
 use crate::utils::HashMap;
 
 use crate::{constants::OYarn, core::symbols::symbol_keys::SymbolKey, oyarn, utils::PathSanitizer};
@@ -14,7 +14,7 @@ pub struct DiskDirSymbol {
     pub path: String,
     pub is_external: bool,
     pub in_workspace: bool,
-    
+
     // parent / child symbols
     parent: SymbolKey,
     pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
@@ -25,7 +25,7 @@ impl DiskDirSymbol {
     pub fn new(name: &str, path: &str, parent: SymbolKey, is_external: bool) -> Self {
         Self {
             name: oyarn!("{}", name),
-            path: PathBuf::from(path).sanitize(),
+            path: Path::new(path).sanitize(),
             is_external,
             parent,
             in_workspace: false,
@@ -40,11 +40,11 @@ impl DiskDirSymbol {
     pub fn parent(&self) -> SymbolKey {
         self.parent
     }
-    
+
     pub fn children(&self) -> Vec<SymbolKey> {
         self.module_symbols.values().copied().collect()
     }
-    
+
     /*pub fn load(sesion: &mut SessionInfo, dir: &Rc<RefCell<Symbol>>) -> Rc<RefCell<Symbol>> {
         let path = dir.borrow().as_disk_dir_sym().path.clone();
     }*/

--- a/server/src/core/symbols/storage/package_symbol.rs
+++ b/server/src/core/symbols/storage/package_symbol.rs
@@ -1,7 +1,7 @@
 use weak_table::PtrWeakHashSet;
 
 use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn, utils::PathSanitizer};
-use std::{cell::RefCell, path::PathBuf, rc::Weak};
+use std::{cell::RefCell, path::Path, rc::Weak};
 use crate::utils::HashMap;
 
 use super::symbol_mgr::{SectionRange, SymbolMgr};
@@ -40,7 +40,7 @@ impl PythonPackageSymbol {
         let mut res = Self {
             name: oyarn!("{}", name),
             path: path.to_string(),
-            init_path: PathBuf::from(path).join("__init__.py").sanitize() + i_ext,
+            init_path: Path::new(path).join("__init__.py").sanitize() + i_ext,
             is_external,
             i_ext,
             parent,

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -551,7 +551,7 @@ impl SymbolTable {
         } else {
             path.with_extension("").components().next_back().unwrap().as_os_str().to_str().unwrap().to_string()
         };
-        let path_str = path.sanitize();
+        let path_str = path.sanitize_cow();
         if path_str.ends_with(".py") || path_str.ends_with(".pyi") || FileMgr::is_untitled(&path_str) {
             return Some(session.st_mut().add_new_file(parent, &name, &path_str).into());
         }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -70,13 +70,13 @@ pub fn is_file_cs(path: &str) -> bool {
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn is_file_cs(path: &str) -> bool {
     let p = Path::new(path);
-    p.exists() && p.is_file()
+    p.is_file()
 }
 
 #[cfg(target_os = "windows")]
 pub fn is_dir_cs(path: &str) -> bool {
     let mut p = Path::new(path);
-    if p.exists() && p.is_dir() {
+    if p.is_dir() {
         while p.parent().is_some() {
             let mut found = false;
             if let Ok(entries) = fs::read_dir(p.parent().unwrap()) {
@@ -102,7 +102,7 @@ pub fn is_dir_cs(path: &str) -> bool {
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn is_dir_cs(path: &str) -> bool {
     let p = Path::new(path);
-    p.exists() && p.is_dir()
+    p.is_dir()
 }
 
 //TODO use it?

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -73,8 +73,8 @@ pub fn is_file_cs(path: &str) -> bool {
 }
 
 #[cfg(target_os = "windows")]
-pub fn is_dir_cs(path: String) -> bool {
-    let mut p = Path::new(&path);
+pub fn is_dir_cs(path: &str) -> bool {
+    let mut p = Path::new(path);
     if p.exists() && p.is_dir() {
         while p.parent().is_some() {
             let mut found = false;
@@ -99,8 +99,8 @@ pub fn is_dir_cs(path: String) -> bool {
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-pub fn is_dir_cs(path: String) -> bool {
-    let p = Path::new(&path);
+pub fn is_dir_cs(path: &str) -> bool {
+    let p = Path::new(path);
     p.exists() && p.is_dir()
 }
 

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,7 +1,8 @@
 use crate::core::file_mgr::legacy_unc_paths;
-use path_slash::{PathBufExt, PathExt};
+use path_slash::PathExt;
 use regex::Regex;
 use ruff_text_size::TextSize;
+use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::process::Command;
 use std::sync::atomic::Ordering;
@@ -134,36 +135,44 @@ impl ToFilePath for lsp_types::Uri {
 }
 
 pub trait PathSanitizer {
+    fn sanitize_cow(&self) -> Cow<'_, str>;
     fn sanitize(&self) -> String;
     fn to_tree(&self) -> Tree;
     fn to_tree_path(&self) -> PathBuf;
 }
 
-impl PathSanitizer for PathBuf {
+impl PathSanitizer for Path {
 
-    fn sanitize(&self) -> String {
+    fn sanitize_cow(&self) -> Cow<'_, str> {
         #[cfg(windows)]
         {
-            let mut path = self.to_slash_lossy().to_string();
+            let mut path = self.to_slash_lossy();
             // check if path begins with //?/ if yes remove it
             // to handle extended-length path prefix
             // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
             if path.starts_with("\\\\?\\") {
-                path = path[4..].to_string();
+                path = path[4..].to_string().into();
             }
-            // Check if path begin with a letter + ':'
-            if path.len() > 2 && path.chars().nth(1) == Some(':') {
-                let disk_letter = path.chars().next().unwrap().to_ascii_lowercase();
-                path.replace_range(0..1, &disk_letter.to_string());
+            // Check if path begin with uppercase letter + ':'
+            let mut chars = path.chars();
+            if path.len() > 2
+                && let (Some(disk), Some(':')) = (chars.next(), chars.next())
+                && disk.is_ascii_uppercase()
+            {
+                let disk_letter = disk.to_ascii_lowercase();
+                path = format!("{}{}", disk_letter, &path[1..]).into();
             }
             return path;
         }
 
         #[cfg(not(windows))]
-        return self.to_slash_lossy().to_string();
+        return self.to_slash_lossy();
     }
 
-    /// Convert the path to a tree structure.
+    fn sanitize(&self) -> String {
+        self.sanitize_cow().into_owned()
+    }
+
     fn to_tree(&self) -> Tree {
         // Drop extension it is .py or .pyi
         let modified_path = if let Some(ext) = self.extension().and_then(OsStr::to_str)
@@ -181,7 +190,7 @@ impl PathSanitizer for PathBuf {
                 trimmed_path
             }
         } else {
-            self.clone()
+            self.to_path_buf()
         };
         Tree(
             modified_path
@@ -190,42 +199,6 @@ impl PathSanitizer for PathBuf {
                 .collect(),
             vec![],
         )
-    }
-
-    /// Convert the path to a path valid for the tree structure (without __init__.py or __manifest__.py).
-    fn to_tree_path(&self) -> PathBuf {
-        if let Some(file_name) = self.file_name() {
-            if file_name.to_str().unwrap() == "__init__.py" || file_name.to_str().unwrap() == "__manifest__.py" {
-                return self.parent().unwrap().to_path_buf();
-            }
-        }
-        self.clone()
-    }
-}
-
-impl PathSanitizer for Path {
-
-    fn sanitize(&self) -> String {
-        #[cfg(windows)]
-        {
-            let mut path = self.to_slash_lossy().to_string();
-            if path.starts_with("\\\\?\\") {
-                path = path[4..].to_string();
-            }
-            // Check if path begin with a letter + ':'
-            if path.len() > 2 && path.chars().nth(1) == Some(':') {
-                let disk_letter = path.chars().next().unwrap().to_ascii_lowercase();
-                path.replace_range(0..1, &disk_letter.to_string());
-            }
-            return path;
-        }
-
-        #[cfg(not(windows))]
-        return self.to_slash_lossy().to_string();
-    }
-
-    fn to_tree(&self) -> Tree {
-        self.to_path_buf().to_tree()
     }
 
     /// Convert the path to a path valid for the tree structure (without __init__.py or __manifest__.py).

--- a/server/tests/config_tests.rs
+++ b/server/tests/config_tests.rs
@@ -32,7 +32,7 @@ fn test_config_entry_single_workspace_with_addons_path() {
     addon_dir.create_dir_all().unwrap();
     addon_dir.child("__manifest__.py").touch().unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -54,8 +54,8 @@ fn test_config_entry_multiple_workspaces_with_various_addons() {
     // ws2 has no addon subdir, so it is not an addon path
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
@@ -73,7 +73,7 @@ fn test_config_entry_with_odoo_path_detection() {
     ws_folder.child("odoo").create_dir_all().unwrap();
     ws_folder.child("odoo").child("release.py").touch().unwrap();
 
-    let ws_folders = vec![(S!("odoo_ws"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("odoo_ws"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -97,7 +97,7 @@ fn test_single_odools_toml_config() {
     "#;
     ws_folder.child("odools.toml").write_str(toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -138,7 +138,7 @@ fn test_multiple_odools_toml_shadowing() {
     "#;
     ws_folder.child("odools.toml").write_str(ws_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -184,7 +184,7 @@ fn test_extends_and_shadowing() {
     "#;
     ws_folder.child("odools.toml").write_str(ws_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -230,8 +230,8 @@ fn test_workspacefolder_template_variable_variations() {
     ws_folder.child("odools.toml").write_str(toml_content).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws_folder.path().sanitize().to_string()),
-        (S!("ws2"), ws2_folder.path().sanitize().to_string()),
+        (S!("ws1"), ws_folder.path().sanitize()),
+        (S!("ws2"), ws2_folder.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
@@ -276,8 +276,8 @@ fn test_workspacefolder_template_ws2_in_ws1_add_workspace_addon_path_behavior() 
     ws1.child("odools.toml").write_str(toml_content).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     // By default, ws1 should NOT be added as an addon path, only ws2
@@ -317,7 +317,7 @@ fn test_config_file_sources_single_file() {
     let odools_path = ws_folder.child("odools.toml");
     odools_path.write_str(toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (_config_map, config_file) = get_configuration(&mut session).unwrap();
     let config_entry = &config_file.config[0];
@@ -363,7 +363,7 @@ fn test_config_file_sources_multiple_files_and_extends() {
     let ws_odools = ws_folder.child("odools.toml");
     ws_odools.write_str(ws_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (_config_map, config_file) = get_configuration(&mut session).unwrap();
     let config_entry = config_file.config.iter().find(|c| c.name == "default").unwrap();
@@ -407,8 +407,8 @@ fn test_config_file_sources_template_variable_workspacefolder() {
     ws1_odools.write_str(toml_content).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (_config_map, config_file) = get_configuration(&mut session).unwrap();
@@ -427,7 +427,7 @@ fn test_config_file_sources_default_values() {
     ws_folder.create_dir_all().unwrap();
 
     // No odools.toml, so all values should be defaults and sourced from "$default"
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (_config_map, config_file) = get_configuration(&mut session).unwrap();
 
@@ -463,8 +463,8 @@ fn test_config_file_sources_multiple_workspace_folders_and_shadowing() {
     ws2_odools.write_str(ws2_toml).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (_config_map, config_file) = get_configuration(&mut session).unwrap();
@@ -496,7 +496,7 @@ fn test_config_file_sources_json_serialization() {
     "#;
     ws1.child("odools.toml").write_str(toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (_config_map, config_file) = get_configuration(&mut session).unwrap();
 
@@ -531,8 +531,8 @@ fn test_conflict_two_workspace_folders_both_odoo_path() {
     ws2.child("odoo").child("release.py").touch().unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     // Should error due to ambiguous odoo_path
@@ -564,8 +564,8 @@ fn test_no_conflict_when_config_files_point_to_same_odoo_path() {
     ws2.child("odools.toml").write_str(&ws1_toml).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     // Should NOT error, odoo_path is unambiguous
@@ -636,8 +636,8 @@ fn test_merge_different_odoo_paths_and_addons_paths() {
     ws2.child("odools.toml").write_str(&ws2_toml).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let result = get_configuration(&mut session);
@@ -722,7 +722,7 @@ fn test_addons_paths_merge_method_override_vs_merge() {
     );
     ws_folder.child("odools.toml").write_str(&ws_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     // With override, only workspace's addons_paths should be present
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
@@ -779,8 +779,8 @@ fn test_conflict_and_merge_of_boolean_fields() {
     ws2.child("odools.toml").write_str(ws2_toml).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let result = get_configuration(&mut session);
@@ -804,7 +804,7 @@ fn test_conflict_and_merge_of_boolean_fields() {
     "#;
     ws1.child("odools.toml").write_str(ws1_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize())];
     let mut session2 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session2).unwrap();
     let config = config_map.get("default").unwrap();
@@ -924,7 +924,7 @@ fn test_extends_chain_multiple_profiles_and_order() {
     "#;
     ws_folder.child("odools.toml").write_str(ws_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1025,7 +1025,7 @@ fn test_extends_cycle_detection() {
     "#;
     ws_folder.child("odools.toml").write_str(ws_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let result = get_configuration(&mut session);
     assert!(result.is_err());
@@ -1047,7 +1047,7 @@ fn test_extends_nonexistent_profile_error() {
     "#;
     temp.child("odools.toml").write_str(parent_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let result = get_configuration(&mut session);
     assert!(result.is_err());
@@ -1069,7 +1069,7 @@ fn test_invalid_toml_config() {
     "#;
     ws_folder.child("odools.toml").write_str(invalid_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let result = get_configuration(&mut session);
     assert!(result.is_err());
@@ -1089,7 +1089,7 @@ fn test_malformed_config_missing_required_fields() {
     "#;
     ws_folder.child("odools.toml").write_str(toml_missing_name).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     // Should not error, should default name to "default"
     let result = get_configuration(&mut session);
@@ -1139,7 +1139,7 @@ fn test_template_variable_expansion_userhome_and_workspacefolder() {
     );
     ws1.child("odools.toml").write_str(&toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1181,7 +1181,7 @@ fn test_config_with_relative_addons_paths() {
     "#;
     ws.child("odools.toml").write_str(toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws"), ws.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws"), ws.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1224,7 +1224,7 @@ fn test_relative_addons_paths_in_parent_config() {
     temp.child("odools.toml").write_str(toml_content).unwrap();
 
     // Workspace folder does not have its own odools.toml
-    let ws_folders = vec![(S!("ws"), ws.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws"), ws.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1251,7 +1251,7 @@ fn test_auto_refresh_delay_boundaries() {
     "#;
     ws_folder.child("odools.toml").write_str(toml_content_min).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1308,7 +1308,7 @@ fn test_odoo_path_with_version_variable_and_workspace_folder() {
     temp.child("odools.toml").write_str(toml_content).unwrap();
 
     // Workspace: temp (simulate as workspace root)
-    let ws_folders = vec![(S!("ws"), temp.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws"), temp.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1332,7 +1332,7 @@ fn test_odoo_path_with_version_variable_and_workspace_folder() {
     "#;
     ws_18_addons.child("odools.toml").write_str(ws18_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws18"), ws_18_addons.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws18"), ws_18_addons.path().sanitize())];
     let mut session2 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session2).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1356,7 +1356,7 @@ fn test_odoo_path_with_version_variable_and_workspace_folder() {
     "#;
     ws_17_addons.child("odools.toml").write_str(ws17_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws17"), ws_17_addons.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws17"), ws_17_addons.path().sanitize())];
     let mut session3 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session3).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1404,7 +1404,7 @@ fn test_odoo_path_with_version_from_manifest_file() {
     "#;
     ws_18_addons.child("odools.toml").write_str(ws18_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws18"), ws_18_addons.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws18"), ws_18_addons.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1429,7 +1429,7 @@ fn test_odoo_path_with_version_from_manifest_file() {
     "#;
     ws_17_addons.child("odools.toml").write_str(ws17_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws17"), ws_17_addons.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws17"), ws_17_addons.path().sanitize())];
     let mut session2 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session2).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1459,7 +1459,7 @@ fn test_addons_paths_unset_vs_empty_behavior() {
     "#;
     ws.child("odools.toml").write_str(toml_unset).unwrap();
 
-    let ws_folders = vec![(S!("ws"), ws.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws"), ws.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1524,7 +1524,7 @@ fn test_addons_merge_override_cases() {
     );
     ws.child("odools.toml").write_str(&child_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws"), ws.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws"), ws.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1603,7 +1603,7 @@ fn test_detect_version_variable_creates_profiles_for_each_version() {
     "#;
     ws1.child("odools.toml").write_str(toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, config_file) = get_configuration(&mut session).unwrap();
 
@@ -1664,7 +1664,7 @@ fn test_config_file_path_priority() {
     let ext_config = temp.child("external_config.toml");
     ext_config.write_str(&ext_toml).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let config_path = ext_config.path().sanitize();
     session.sync_odoo.config_path = Some(config_path);
@@ -1688,7 +1688,7 @@ fn test_config_file_path_nonexistent_errors() {
     let ws_folder = temp.child("workspace1");
     ws_folder.create_dir_all().unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     // Provide a non-existent config file path
     let non_existent = temp.child("does_not_exist.toml");
@@ -1722,7 +1722,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
     temp.child("odools.toml").write_str(&toml_content).unwrap();
 
     // Test with workspace at /temp/17.0
-    let ws_folders = vec![(S!("ws1"), vdir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), vdir.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1730,7 +1730,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
     assert!(config.addons_paths.contains(&addon_dir.path().sanitize()));
 
     // Test with workspace at /temp/17.0/odoo
-    let ws_folders = vec![(S!("ws2"), odoo_dir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws2"), odoo_dir.path().sanitize())];
     let mut session2 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session2).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1738,7 +1738,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
     assert!(config.addons_paths.contains(&addon_dir.path().sanitize()));
 
     // Test with workspace at /temp/17.0/addon-path
-    let ws_folders = vec![(S!("ws3"), addon_dir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws3"), addon_dir.path().sanitize())];
     let mut session3 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session3).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1756,7 +1756,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
     temp.child("odools.toml").write_str(&toml_content_version).unwrap();
 
     // Test with workspace at /temp/17.0
-    let ws_folders = vec![(S!("ws1"), vdir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), vdir.path().sanitize())];
     let mut session4 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session4).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1764,7 +1764,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
     assert!(config.addons_paths.contains(&addon_dir.path().sanitize()));
 
     // Test with workspace at /temp/17.0/odoo
-    let ws_folders = vec![(S!("ws2"), odoo_dir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws2"), odoo_dir.path().sanitize())];
     let mut session5 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session5).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1772,7 +1772,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
     assert!(config.addons_paths.contains(&addon_dir.path().sanitize()));
 
     // Test with workspace at /temp/17.0/addon-path
-    let ws_folders = vec![(S!("ws3"), addon_dir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws3"), addon_dir.path().sanitize())];
     let mut session6 = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session6).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1787,7 +1787,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
         addons_paths = [ "${{base}}/addon-path" ]
     "#);
     temp.child("odools.toml").write_str(&toml_content_abs).unwrap();
-    let ws_folders = vec![(S!("ws_abs"), vdir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws_abs"), vdir.path().sanitize())];
     let mut session7 = mock_session_with_workspaces(&ws_folders);
     let result = get_configuration(&mut session7);
     assert!(result.is_err(), "Expected error when $base is an absolute path");
@@ -1801,7 +1801,7 @@ fn test_base_and_version_resolve_for_workspace_subpaths() {
         addons_paths = [ "${base}/addon-path" ]
     "#;
     temp.child("odools.toml").write_str(toml_content_invalid).unwrap();
-    let ws_folders = vec![(S!("ws_invalid"), vdir.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws_invalid"), vdir.path().sanitize())];
     let mut session8 = mock_session_with_workspaces(&ws_folders);
     let result = get_configuration(&mut session8);
     assert!(result.is_err(), "Expected error when $base is not a valid path");
@@ -1827,7 +1827,7 @@ fn test_diagnostic_filter_path_variable_expansion() {
     "#, version);
     ws1.child("odools.toml").write_str(&toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws1.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1858,8 +1858,8 @@ fn test_ambiguous_workspace_names_pattern_ignored() {
     // Both workspaces have the same name
     let ws_name = S!("duplicate");
     let ws_folders = vec![
-        (ws_name.clone(), ws1.path().sanitize().to_string()),
-        (ws_name.clone(), ws2.path().sanitize().to_string()),
+        (ws_name.clone(), ws1.path().sanitize()),
+        (ws_name.clone(), ws2.path().sanitize()),
     ];
     // Write odools.toml with ambiguous pattern
     let toml_content = r#"
@@ -1921,7 +1921,7 @@ fn test_additional_languages_merge_and_base_expansion() {
 
     // let mut ws_folders = HashMap::default();
     // ws_folders.insert(S!("ws1"), ws_folder.path().sanitize().to_string());
-    let ws_folders = [(S!("ws1"), ws_folder.path().sanitize().to_string())]; 
+    let ws_folders = [(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1958,7 +1958,7 @@ fn test_additional_stubs_basic_path_resolution() {
     );
     ws_folder.child("odools.toml").write_str(&toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -1998,8 +1998,8 @@ fn test_additional_stubs_template_variable_resolution() {
     ws1.child("odools.toml").write_str(&toml_content).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
@@ -2032,7 +2032,7 @@ fn test_additional_stubs_relative_path_canonicalization() {
     "#;
     ws_folder.child("odools.toml").write_str(toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -2067,7 +2067,7 @@ fn test_additional_stubs_invalid_path_filtered() {
     );
     ws_folder.child("odools.toml").write_str(&toml_content).unwrap();
 
-    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize().to_string())];
+    let ws_folders = vec![(S!("ws1"), ws_folder.path().sanitize())];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();
     let config = config_map.get("default").unwrap();
@@ -2104,8 +2104,8 @@ fn test_stdlib_path_template_variable_resolution() {
     ws1.child("odools.toml").write_str(&toml_content).unwrap();
 
     let ws_folders = vec![
-        (S!("ws1"), ws1.path().sanitize().to_string()),
-        (S!("ws2"), ws2.path().sanitize().to_string()),
+        (S!("ws1"), ws1.path().sanitize()),
+        (S!("ws2"), ws2.path().sanitize()),
     ];
     let mut session = mock_session_with_workspaces(&ws_folders);
     let (config_map, _config_file) = get_configuration(&mut session).unwrap();


### PR DESCRIPTION
Main topics:
- avoid `glob`
- cache `stat` system calls (is_file, is_dir)

Bench with cold page cache for each run.
Note the reduction in both "user" and (specially) "sys" time, which reflect on CPU (and wall) time.
```
════════════════════════════════════════════════════════════════
 Aggregated results (5 runs each, mean ± stddev)            
════════════════════════════════════════════════════════════════
commit                user (s)           sys (s)     total CPU (s)          wall (s)       peak RSS (MB)
──────────  ────────────────  ────────────────  ────────────────  ────────────────  ──────────────────
3b141e7e       10.846 ± 0.073    2.556 ± 0.075   13.402 ± 0.075   14.910 ± 0.059       1588.5 ± 0.4
07e51c40       10.086 ± 0.084    1.396 ± 0.052   11.482 ± 0.077   12.954 ± 0.080       1589.2 ± 0.4

Δ (after − before):
  user (s):              -0.760  ( -7.01%)   z=6.8
  sys (s):               -1.160  (-45.38%)   z=12.7
  total CPU (s):         -1.920  (-14.33%)   z=17.8
  wall (s):              -1.956  (-13.12%)   z=19.7
  peak RSS (MB):           +0.7  ( +0.04%)   z=1.2

z = |Δ| / sqrt(σ_before² + σ_after²) — rough significance:
  z > 3 : clearly significant   1 < z < 3 : suggestive   z < 1 : likely noise

```