### PR TITLE
[FIX] String.as_slice() compile error

### DIFF
--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -606,7 +606,7 @@ impl SyncOdoo {
             if entry_point.is_public() || PathBuf::from(from_path).starts_with(&entry_point.path) {
                 let prefix = entry_point.addon_to_odoo_tree.as_ref().unwrap_or(&entry_point.tree);
                 let tree_0: Vec<&str> = prefix.iter()
-                    .map(|y| y.as_slice())
+                    .map(|y| y.as_str())
                     .chain(tree.0.iter().copied())
                     .collect();
                 let symbols = self.symbol_table.get_symbol(entry_point.root.into(), (&tree_0, &tree.1), position);


### PR DESCRIPTION
When `default = ["debug_yarn"]` is enabled in cargo.toml (for debugging), OYarn resolves to a String, which does not have the `as_slice` method. The correct method to call here (that suits both String and Yarn) is `as_str`.