### PR TITLE
[IMP] Limit ir_rule hook to 19.4

### DIFF
--- a/server/src/core/python_arch_builder_hooks.rs
+++ b/server/src/core/python_arch_builder_hooks.rs
@@ -88,7 +88,7 @@ static arch_class_hooks: Lazy<Vec<PythonArchClassHook>> = Lazy::new(|| {vec![
     PythonArchClassHook {
         odoo_entry: true,
         trees: vec![
-            ((15, 0), (999, 0), (&["odoo", "addons", "base", "models", "ir_rule"], &["IrRule"])),
+            ((15, 0), (19, 4), (&["odoo", "addons", "base", "models", "ir_rule"], &["IrRule"])),
         ],
         func: |symbol_table: &mut SymbolTable, class: ClassKey| {
             let range = symbol_table[class].range.clone();


### PR DESCRIPTION
As https://github.com/odoo/odoo/pull/166359 , ir_rule doesn't not exist anymore after the 19.4 branch