### PR TITLE
[FIX] server: fix progress stuck on project switch

### DIFF
--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -725,7 +725,7 @@ impl SyncOdoo {
             token: ProgressToken::Number(session.sync_odoo.progress_token),
             value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(WorkDoneProgressBegin {
                 title: "Odoo: Indexing".to_string(),
-                cancellable: Some(false),
+                cancellable: Some(true),
                 message: None,
                 percentage: None,
             }))
@@ -760,7 +760,7 @@ impl SyncOdoo {
                 session.send_notification(Progress::METHOD, ProgressParams {
                     token: ProgressToken::Number(session.sync_odoo.progress_token),
                     value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(WorkDoneProgressReport {
-                        cancellable: Some(false),
+                        cancellable: Some(true),
                         message: Some(format!("{} items remaining", queue_size)),
                         percentage: None,
                     }))

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -302,7 +302,7 @@ impl Server {
                 }
                 if e.is_disconnected() {
                     warn!("Channel disconnected. Exiting program.");
-                    break;
+                    std::process::exit(0);
                 }
             }
             let msg = res.unwrap();


### PR DESCRIPTION
Set WorkDoneProgressBegin cancellable to true so the Processes tab shows a dismissable cancel button.

Exit immediately on client channel disconnect instead of joining rebuild threads which may hang, causing orphaned progress entries when switching projects or worktrees.