### PR TITLE
[FIX] Terminate progress reporting

### DIFF
--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -737,6 +737,15 @@ impl SyncOdoo {
         });
     }
 
+    fn end_reporting(session: &mut SessionInfo) {
+        session.send_notification(Progress::METHOD, ProgressParams {
+            token: ProgressToken::Number(session.sync_odoo.progress_token),
+            value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
+                message: None,
+            }))
+        });
+    }
+
     pub fn process_rebuilds(session: &mut SessionInfo, no_validation: bool) -> bool {
         session.sync_odoo.interrupt_rebuild.store(false, Ordering::SeqCst);
         if session.sync_odoo.watched_file_updates > MAX_WATCHED_FILES_UPDATES_BEFORE_RESTART {
@@ -773,6 +782,9 @@ impl SyncOdoo {
             }
             if session.sync_odoo.terminate_rebuild.load(Ordering::SeqCst){
                 info!("Terminating rebuilds due to server shutdown");
+                if is_reporting_progress {
+                    SyncOdoo::end_reporting(session);
+                }
                 return false;
             }
             let sym = session.sync_odoo.pop_item(BuildSteps::ARCH);
@@ -822,12 +834,7 @@ impl SyncOdoo {
                         session.request_delayed_rebuild();
                         session.sync_odoo.add_to_validations(sym_rc.clone());
                         if is_reporting_progress {
-                            session.send_notification(Progress::METHOD, ProgressParams {
-                                token: ProgressToken::Number(session.sync_odoo.progress_token),
-                                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
-                                    message: None,
-                                }))
-                            });
+                            SyncOdoo::end_reporting(session);
                         }
                         return true;
                     }
@@ -858,12 +865,7 @@ impl SyncOdoo {
         session.sync_odoo.import_cache = None;
         session.sync_odoo.watched_file_updates = 0;
         if is_reporting_progress {
-            session.send_notification(Progress::METHOD, ProgressParams {
-                token: ProgressToken::Number(session.sync_odoo.progress_token),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
-                    message: None,
-                }))
-            });
+            SyncOdoo::end_reporting(session);
         }
         trace!("Leaving rebuild with remaining tasks: {:?} - {:?} - {:?}", session.sync_odoo.rebuild_arch.len(), session.sync_odoo.rebuild_arch_eval.len(), session.sync_odoo.rebuild_validation.len());
         true

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -270,6 +270,25 @@ impl Server {
         info!(message);
     }
 
+    /// Drain pending respones and notifications from worker threads to the client.
+    fn flush_pending_messages(receivers_w_to_s: &[Receiver<Message>], connection: &Connection) {
+        for receiver in receivers_w_to_s.iter() {
+            while let Ok(msg) = receiver.try_recv() {
+                match msg {
+                    Message::Response(r) => {
+                        let _ = connection.sender.send(Message::Response(r));
+                    },
+                    Message::Notification(n) if n.method != Shutdown::METHOD => {
+                        if n.method != Shutdown::METHOD {
+                            let _ = connection.sender.send(Message::Notification(n));
+                        }
+                    },
+                    _ => {}, // Skip shutdown (not possible) and requests (should not happen / not useful at this stage)
+                }
+            }
+        }
+    }
+
     pub fn run(mut self, client_pid: Option<u32>) -> bool {
         let mut select = Select::new();
         let receiver_clone = self.connection.as_ref().unwrap().receiver.clone();
@@ -355,7 +374,7 @@ impl Server {
                         self.connection.as_ref().unwrap().sender.send(Message::Request(r)).unwrap();
                     },
                     Message::Notification(n) => {
-                        if n.method == Shutdown::METHOD{
+                        if n.method == Shutdown::METHOD {
                             self.shutdown_threads("Server-initiated shutdown request. Exiting");
                             break;
                         }
@@ -372,13 +391,14 @@ impl Server {
         let hook = panic::take_hook(); //drop sender stored in panic
         drop(hook);
         let _ = stop_sender.send(());
-        self.connection = None; //drop connection before joining threads
         if let Some(pid_join_handle) = pid_thread {
             pid_join_handle.join().unwrap();
         }
         self.main_thread.join().unwrap();
         let _ = self.sender_to_delayed_process.send(DelayedProcessingMessage::EXIT);
         self.delayed_process_thread.join().unwrap();
+        Server::flush_pending_messages(&self.receivers_w_to_s, self.connection.as_ref().unwrap());
+        self.connection = None; //drop connection after flushing pending worker notifications
         exit_no_error_code
     }
 


### PR DESCRIPTION
In process_rebuilds, progress was not ended when a termination signal is received. The fix comes in two stages
1. Send an End notification in process rebuilds
2. Make sure any pending notifications are flushed after shutdown in the master process

Closes https://github.com/odoo/odoo-pycharm/issues/26

