### PR TITLE
[FIX] server: no OLS03023 when the inverse field is overridden

### DIFF
--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -575,13 +575,24 @@ impl PythonValidator {
                                     comodel_eval_weaks.extend(followed);
                                 }
                             }
+                            // The inverse field may be declared several times, e.g. when a
+                            // model overrides the field of an inherited abstract model to
+                            // point to the concrete model instead. As the last declaration
+                            // overrides the comodel of the previous ones at runtime, the
+                            // inverse field is valid as soon as one declaration points to
+                            // the current model.
+                            let mut mismatched_model_name = None;
                             for comodel_eval_weak in comodel_eval_weaks {
                                 let Some(model_name) = comodel_eval_weak.get_weak().context.get(&S!("comodel_name")).map(|ctx_val| ctx_val.as_string()) else {
                                     continue;
                                 };
                                 if model_name == model_data.name.to_string() { // valid
-                                    continue;
+                                    mismatched_model_name = None;
+                                    break;
                                 }
+                                mismatched_model_name.get_or_insert(model_name);
+                            }
+                            if let Some(model_name) = mismatched_model_name {
                                 let Some(arg_range) = eval_weak.get_weak().context.get(&format!("inverse_name_arg_range")).map(|ctx_val| ctx_val.as_text_range()) else {
                                     continue;
                                 };
@@ -590,7 +601,6 @@ impl PythonValidator {
                                         range: Range::new(Position::new(arg_range.start().to_u32(), 0), Position::new(arg_range.end().to_u32(), 0)),
                                         ..diagnostic_base.clone()
                                     });
-                                    break;
                                 }
                             }
                         }

--- a/server/tests/data/addons/module_1/models/diagnostics.py
+++ b/server/tests/data/addons/module_1/models/diagnostics.py
@@ -146,3 +146,31 @@ class ModelWithDiagnostics2(models.Model):
         False or self.env["non.existent.model"]  # OLS03002
         () + self.env["non.existent.model"]  # OLS03002
         not self.env["non.existent.model"]  # OLS03002
+
+class AbstractO2mParent(models.AbstractModel):
+    _name = "module_1.abstract_o2m_parent"
+    _description = "Abstract model with a One2many to an abstract comodel"
+
+    line_ids = fields.One2many("module_1.abstract_o2m_line", "record_id")
+
+class AbstractO2mLine(models.AbstractModel):
+    _name = "module_1.abstract_o2m_line"
+    _description = "Abstract line model pointing to the abstract parent"
+
+    record_id = fields.Many2one("module_1.abstract_o2m_parent")
+
+class ConcreteO2mParent(models.Model):
+    _name = "module_1.concrete_o2m_parent"
+    _inherit = ["module_1.abstract_o2m_parent"]
+    _description = "Concrete model with a One2many to a concrete comodel"
+
+    # record_id is declared on both line models: the override on the concrete
+    # line points to this model, so no OLS03023 is expected here
+    line_ids = fields.One2many("module_1.concrete_o2m_line", "record_id")
+
+class ConcreteO2mLine(models.Model):
+    _name = "module_1.concrete_o2m_line"
+    _inherit = ["module_1.abstract_o2m_line"]
+    _description = "Concrete line model pointing to the concrete parent"
+
+    record_id = fields.Many2one("module_1.concrete_o2m_parent")


### PR DESCRIPTION
The inverse field of a One2many may be declared several times, e.g. when a model overrides the field of an inherited abstract model to point to the concrete model instead. As the last declaration  overrides the comodel of the previous ones at runtime, only raise OLS03023 when no declaration of the inverse field points to the current model.

(If you prefer me to target `release` or another branch, just tell me)