### PR TITLE
[IMP] standardization of error codes

### DIFF
--- a/server/src/core/js_utils.rs
+++ b/server/src/core/js_utils.rs
@@ -37,7 +37,7 @@ pub fn oxc_diagnostic_to_lsp_diagnostic(diag: &OxcDiagnostic, uri: &lsp_types::U
             oxc::diagnostics::Severity::Warning => lsp_types::DiagnosticSeverity::WARNING,
             oxc::diagnostics::Severity::Advice => lsp_types::DiagnosticSeverity::INFORMATION,
         }),
-        code: Some(lsp_types::NumberOrString::String(format!("OLSoxc{}", diag.code))),
+        code: Some(lsp_types::NumberOrString::String(format!("oxc_{}", diag.code))),
         code_description: None,
         source: Some(S!(EXTENSION_NAME)),
         message: message,

--- a/server/src/core/tsserver_bridge.rs
+++ b/server/src/core/tsserver_bridge.rs
@@ -1,5 +1,6 @@
 use lsp_types::{CompletionItem, CompletionItemKind, Diagnostic, DiagnosticSeverity, DocumentSymbol, Location, NumberOrString, Position, Range, SymbolKind};
 use serde_json::{Value, json};
+use crate::S;
 use crate::features::tsserver_completion::{TsCompletionDetails, entry_to_completion_item, response_to_completion_details};
 use crate::utils::{HashMap, HashSet, PathSanitizer};
 use tracing::{debug, info, warn};
@@ -10,7 +11,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::constants::DiagnosticSource;
+use crate::constants::{DiagnosticSource, EXTENSION_NAME};
 use crate::core::file_mgr::FileMgr;
 use crate::threads::{TsServerDiagnostics, ThreadMessage};
 
@@ -949,7 +950,7 @@ fn ts_diag_event_to_diagnostics(body: &Value) -> Option<(String, Vec<Diagnostic>
         let end_offset   = end.get("offset").and_then(Value::as_u64)? as u32;
         let code = d.get("code")
             .and_then(Value::as_u64)
-            .map(|c| NumberOrString::Number(c as i32));
+            .map(|c| NumberOrString::String(format!("tsserver_{}", c)));
         let severity = match d.get("category").and_then(Value::as_str) {
             Some("error")      => DiagnosticSeverity::ERROR,
             Some("warning")    => DiagnosticSeverity::WARNING,
@@ -963,7 +964,7 @@ fn ts_diag_event_to_diagnostics(body: &Value) -> Option<(String, Vec<Diagnostic>
             },
             severity: Some(severity),
             code,
-            source: Some("OdooLS-TsServer".to_string()),
+            source: Some(S!(EXTENSION_NAME)),
             message: text.to_string(),
             ..Diagnostic::default()
         })


### PR DESCRIPTION
Source is now always "Odoo"
Code is now:
`tsserver_` + code from tsserver
`oxc_` + code from oxc
`OLS**` for python diagnostics