### PR TITLE
[IMP] complete and validate xml_ids in python strings

### DIFF
--- a/server/src/core/csv_validation.rs
+++ b/server/src/core/csv_validation.rs
@@ -7,7 +7,7 @@ use tracing::info;
 use crate::{
     Sy, constants::{BuildStatus, BuildSteps, DEBUG_STEPS, DiagnosticSource, MissingDataSource, OYarn}, core::{
         diagnostics::{DiagnosticCode, create_diagnostic}, evaluation_utils::DeepFieldEvalWalker, file_mgr::FileInfo, symbols::{SymbolTable, symbol_keys::{CsvFileKey, ModuleKey}}
-    }, features::csv_ast_utils::CsvFieldIter, oyarn, threads::SessionInfo
+    }, features::csv_ast_utils::{CsvFieldIter, split_csv_xml_ids}, oyarn, threads::SessionInfo
 };
 use std::{cell::RefCell, rc::Rc};
 
@@ -119,11 +119,16 @@ impl CsvValidator {
 
     fn validate_record(&self, session: &mut SessionInfo, csv_module: ModuleKey, headers_is_xml: &[bool], record: &StringRecord, diagnostics: &mut Vec<Diagnostic>, data: &str) {
         let Some(field_iter) = CsvFieldIter::new(record, data) else { return; };
-        for (idx, (start, end, field)) in field_iter.enumerate() {
+        for (idx, (start, _end, field)) in field_iter.enumerate() {
             let Some(&should_be_xml_id) = headers_is_xml.get(idx) else { break;};
-            if should_be_xml_id {
+            if !should_be_xml_id {
+                continue;
+            }
+            // the cell spans its quotes when it carries them, the ids inside it do not
+            let value_start = start + usize::from(data.as_bytes().get(start) == Some(&b'"'));
+            for (xml_id, id_start, id_end) in split_csv_xml_ids(field, value_start) {
                 //check that field_data is a valid xml id
-                let id_split = field.split(".").collect::<Vec<&str>>();
+                let id_split = xml_id.split(".").collect::<Vec<&str>>();
                 let mut module_name = session.st().name(csv_module).as_str();
                 if id_split.len() == 2 {
                     module_name = id_split.first().unwrap();
@@ -134,7 +139,7 @@ impl CsvValidator {
                 let Some(&module_symbol) = session.sync_odoo.modules.get(module_name) else {
                     if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05003, &[]) {
                         diagnostics.push(Diagnostic {
-                            range: Range { start: Position::new(start as u32, 0), end: Position::new(end as u32, 0) },
+                            range: Range { start: Position::new(id_start as u32, 0), end: Position::new(id_end as u32, 0) },
                             ..diagnostic.clone()
                         });
                     }
@@ -147,7 +152,7 @@ impl CsvValidator {
                     session.sync_odoo.get_main_entry().borrow_mut().not_found_data_ids.insert(csv_module.into());
                     if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05001, &[]) {
                         diagnostics.push(Diagnostic {
-                            range: Range { start: Position::new(start as u32, 0), end: Position::new(end as u32, 0) },
+                            range: Range { start: Position::new(id_start as u32, 0), end: Position::new(id_end as u32, 0) },
                             ..diagnostic.clone()
                         });
                     }

--- a/server/src/core/csv_validation.rs
+++ b/server/src/core/csv_validation.rs
@@ -7,7 +7,7 @@ use tracing::info;
 use crate::{
     Sy, constants::{BuildStatus, BuildSteps, DEBUG_STEPS, DiagnosticSource, MissingDataSource, OYarn}, core::{
         diagnostics::{DiagnosticCode, create_diagnostic}, evaluation_utils::DeepFieldEvalWalker, file_mgr::FileInfo, symbols::{SymbolTable, symbol_keys::{CsvFileKey, ModuleKey}}
-    }, features::csv_ast_utils::CsvFieldIter, oyarn, threads::SessionInfo
+    }, features::csv_ast_utils::{CsvFieldIter, split_csv_xml_ids}, oyarn, threads::SessionInfo
 };
 use std::{cell::RefCell, rc::Rc};
 
@@ -119,11 +119,14 @@ impl CsvValidator {
 
     fn validate_record(&self, session: &mut SessionInfo, csv_module: ModuleKey, headers_is_xml: &[bool], record: &StringRecord, diagnostics: &mut Vec<Diagnostic>, data: &str) {
         let Some(field_iter) = CsvFieldIter::new(record, data) else { return; };
-        for (idx, (start, end, field)) in field_iter.enumerate() {
+        for (idx, (start, _end, field)) in field_iter.enumerate() {
             let Some(&should_be_xml_id) = headers_is_xml.get(idx) else { break;};
-            if should_be_xml_id {
+            if !should_be_xml_id {
+                continue;
+            }
+            for (xml_id, id_start, id_end) in split_csv_xml_ids(field, data, start) {
                 //check that field_data is a valid xml id
-                let id_split = field.split(".").collect::<Vec<&str>>();
+                let id_split = xml_id.split(".").collect::<Vec<&str>>();
                 let mut module_name = session.st().name(csv_module).as_str();
                 if id_split.len() == 2 {
                     module_name = id_split.first().unwrap();
@@ -134,7 +137,7 @@ impl CsvValidator {
                 let Some(&module_symbol) = session.sync_odoo.modules.get(module_name) else {
                     if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05003, &[]) {
                         diagnostics.push(Diagnostic {
-                            range: Range { start: Position::new(start as u32, 0), end: Position::new(end as u32, 0) },
+                            range: Range { start: Position::new(id_start as u32, 0), end: Position::new(id_end as u32, 0) },
                             ..diagnostic.clone()
                         });
                     }
@@ -147,7 +150,7 @@ impl CsvValidator {
                     session.sync_odoo.get_main_entry().borrow_mut().not_found_data_ids.insert(csv_module.into());
                     if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05001, &[]) {
                         diagnostics.push(Diagnostic {
-                            range: Range { start: Position::new(start as u32, 0), end: Position::new(end as u32, 0) },
+                            range: Range { start: Position::new(id_start as u32, 0), end: Position::new(id_end as u32, 0) },
                             ..diagnostic.clone()
                         });
                     }

--- a/server/src/core/evaluation_context.rs
+++ b/server/src/core/evaluation_context.rs
@@ -32,6 +32,8 @@ pub enum ContextKey {
     Default,
     Delegate,
     FieldParent,
+    Groups,
+    GroupsArgRange,
     IsAttrOfInstance,
     IsInValidation,
     Inverse,

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1524,6 +1524,50 @@ impl SyncOdoo {
         ModuleSymbol::get_xml_id(session.st(), module_key, id_split.last().unwrap()).unwrap_or_default()
     }
 
+    /// Xml ids matching a prefix as (defining module, local id, in deps), filtered while iterating.
+    pub fn get_xml_ids_by_prefix(session: &SessionInfo, from_file: SourceFileKey, prefix: &str, model_filter: Option<&OYarn>) -> Vec<(ModuleKey, OYarn, bool)> {
+        let mut results = vec![];
+        if !session.st().get_entry(from_file).borrow().is_main() {
+            return results;
+        }
+        let Some(current_module) = session.st().find_module(from_file) else {
+            return results;
+        };
+        // a qualified prefix names its module, a bare one is a module name still being typed
+        let (module_prefix, id_prefix) = match prefix.split_once('.') {
+            Some((module_prefix, id_prefix)) => (module_prefix, Some(id_prefix)),
+            None => (prefix, None),
+        };
+        for module_wk in session.sync_odoo.modules.values() {
+            let Some(module_key) = module_wk.upgrade(session.st()) else { continue };
+            let dir_name = &session.st()[module_key].dir_name;
+            let names_module = match id_prefix {
+                Some(_) => dir_name == module_prefix,
+                None => dir_name.starts_with(module_prefix),
+            };
+            if !names_module {
+                continue;
+            }
+            let in_deps = ModuleSymbol::is_in_deps(session.st(), current_module, dir_name);
+            for (local_id, xml_ids) in session.st()[module_key].xml_ids.iter().filter(|(local_id, _)| local_id.starts_with(id_prefix.unwrap_or(""))) {
+                if xml_ids.iter_valid(session.st()).any(|xml_id| match model_filter {
+                    None => true,
+                    Some(model) => matches!(xml_id, XmlId::XmlRecord(record_key) if session.st()[record_key].model.0 == *model),
+                }) {
+                    results.push((module_key, local_id.clone(), in_deps));
+                }
+            }
+        }
+        results
+    }
+
+    /// Whether an xml id points to a res.groups record, a `groups` list accepting no other model.
+    pub fn is_group_xml_id(session: &mut SessionInfo, from_file: SourceFileKey, group: &str, range: &std::ops::Range<usize>, diagnostics: &mut Vec<Diagnostic>) -> bool {
+        let xml_ids = SyncOdoo::get_xml_ids(session, from_file, group, range, diagnostics);
+        xml_ids.iter_valid(session.st()).any(|xml_id|
+            matches!(xml_id, XmlId::XmlRecord(record_key) if session.st()[record_key].model.0 == "res.groups"))
+    }
+
     pub fn get_ts_dict(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.dict.is_expired(&self.symbol_table) {
             self.typeshed_weak_cache.dict = self.get_symbol("", (&["builtins"], &["dict"]), u32::MAX).last().copied().unwrap().into();

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1524,6 +1524,71 @@ impl SyncOdoo {
         ModuleSymbol::get_xml_id(session.st(), module_key, id_split.last().unwrap()).unwrap_or_default()
     }
 
+    /// Xml ids matching a prefix as (defining module, local id, in deps), filtered while iterating.
+    pub fn get_xml_ids_by_prefix(session: &SessionInfo, from_file: SourceFileKey, prefix: &str, model_filter: Option<&OYarn>) -> Vec<(ModuleKey, OYarn, bool)> {
+        let mut results = vec![];
+        if !session.st().get_entry(from_file).borrow().is_main() {
+            return results;
+        }
+        let Some(current_module) = session.st().find_module(from_file) else {
+            return results;
+        };
+        // a qualified prefix names its module, a bare one is a module name still being typed
+        let (module_prefix, id_prefix) = match prefix.split_once('.') {
+            Some((module_prefix, id_prefix)) => (module_prefix, Some(id_prefix)),
+            None => (prefix, None),
+        };
+        for module_wk in session.sync_odoo.modules.values() {
+            let Some(module_key) = module_wk.upgrade(session.st()) else { continue };
+            let dir_name = &session.st()[module_key].dir_name;
+            let names_module = match id_prefix {
+                Some(_) => dir_name == module_prefix,
+                None => dir_name.starts_with(module_prefix),
+            };
+            if !names_module {
+                continue;
+            }
+            let in_deps = ModuleSymbol::is_in_deps(session.st(), current_module, dir_name);
+            for (local_id, xml_ids) in session.st()[module_key].xml_ids.iter().filter(|(local_id, _)| local_id.starts_with(id_prefix.unwrap_or(""))) {
+                if xml_ids.iter_valid(session.st()).any(|xml_id| match model_filter {
+                    None => true,
+                    Some(model) => matches!(xml_id, XmlId::XmlRecord(record_key) if session.st()[record_key].model.0 == *model),
+                }) {
+                    results.push((module_key, local_id.clone(), in_deps));
+                }
+            }
+        }
+        results
+    }
+
+    /// Modules an xml id prefix can still name, as (module, in deps), those with no id skipped.
+    pub fn get_xml_id_modules(session: &SessionInfo, from_file: SourceFileKey, prefix: &str) -> Vec<(ModuleKey, bool)> {
+        let mut results = vec![];
+        if !session.st().get_entry(from_file).borrow().is_main() {
+            return results;
+        }
+        let Some(current_module) = session.st().find_module(from_file) else {
+            return results;
+        };
+        for module_wk in session.sync_odoo.modules.values() {
+            let Some(module_key) = module_wk.upgrade(session.st()) else { continue };
+            let dir_name = &session.st()[module_key].dir_name;
+            if session.st()[module_key].xml_ids.is_empty() || !dir_name.starts_with(prefix) {
+                continue;
+            }
+            let in_deps = ModuleSymbol::is_in_deps(session.st(), current_module, dir_name);
+            results.push((module_key, in_deps));
+        }
+        results
+    }
+
+    /// Whether an xml id points to a res.groups record, a `groups` list accepting no other model.
+    pub fn is_group_xml_id(session: &mut SessionInfo, from_file: SourceFileKey, group: &str, range: &std::ops::Range<usize>, diagnostics: &mut Vec<Diagnostic>) -> bool {
+        let xml_ids = SyncOdoo::get_xml_ids(session, from_file, group, range, diagnostics);
+        xml_ids.iter_valid(session.st()).any(|xml_id|
+            matches!(xml_id, XmlId::XmlRecord(record_key) if session.st()[record_key].model.0 == "res.groups"))
+    }
+
     pub fn get_ts_dict(&mut self) -> Wk<SymbolKey> {
         if self.typeshed_weak_cache.dict.is_expired(&self.symbol_table) {
             self.typeshed_weak_cache.dict = self.get_symbol("", (&["builtins"], &["dict"]), u32::MAX).last().copied().unwrap().into();

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -18,6 +18,7 @@ use crate::core::evaluation_context::Context;
 use crate::constants::*;
 use crate::tree::OYarnExt;
 use crate::tree::Tree;
+use crate::core::symbols::ModuleSymbol;
 use crate::core::symbols::symbol_keys::FunctionKey;
 use crate::core::symbols::symbol_keys::SourceFileKey;
 use crate::core::symbols::symbol_keys::SymbolKey;
@@ -1136,6 +1137,7 @@ impl PythonArchEvalHooks {
         let context_arguments = [
             ("comodel_name", "str", ContextKey::ComodelName, ContextKey::ComodelNameArgRange),
             ("related", "str", ContextKey::Related, ContextKey::RelatedArgRange),
+            ("groups", "str", ContextKey::Groups, ContextKey::GroupsArgRange),
             ("compute", "str", ContextKey::Compute, ContextKey::ComputeArgRange),
             ("inverse", "str", ContextKey::Inverse, ContextKey::InverseArgRange),
             ("search", "str", ContextKey::Search, ContextKey::SearchArgRange),
@@ -1369,6 +1371,20 @@ impl PythonArchEvalHooks {
             return None;
         }
         let module_key = module.unwrap().upgrade(session.st())?;
+        // ir.model.data entries the registry builds at install time, never declared in the sources
+        let is_generated = (module_name == "base" && xml_id.starts_with("module_"))
+            || xml_id.starts_with("selection__")
+            || xml_id.strip_prefix("field_").is_some_and(|field| field.contains("__"));
+        if in_validation && !xml_id.is_empty() && !xml_id.contains('.') && !is_generated {
+            let is_known = ModuleSymbol::get_xml_id(session.st(), module_key, &xml_id)
+                .is_some_and(|xml_ids| xml_ids.iter_valid(session.st()).next().is_some());
+            if !is_known && let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05001, &[]) {
+                diagnostics.push(Diagnostic {
+                    range: FileMgr::textRange_to_temporary_Range(&xml_id_expr.range()),
+                    ..diagnostic
+                });
+            }
+        }
         if let Some(scope) = scope && let Some(file) = session.st_mut().get_file(scope)
             && file != module_key.into() {
                 session.st_mut().add_dependency(file, module_key.into(), BuildSteps::VALIDATION, BuildSteps::ARCH);

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -1327,10 +1327,12 @@ impl PythonArchEvalHooks {
         if !parameters.args[0].is_string_literal_expr() {
             return None;
         }
-        if parameters.keywords.len() == 1
-        // read raise_if_not_found keyword argument
-        && !parameters.keywords[0].value.as_boolean_literal_expr().map(|b| b.value).unwrap_or(true) {
-            return None; // No need to process if the second argument (raise_if_not_found) is false
+        // `ref(xml_id, raise_if_not_found=False)` asks for an empty result rather than a raise
+        let raise_arg = parameters.args.get(1).or_else(|| parameters.keywords.iter()
+            .find(|keyword| keyword.arg.as_ref().is_some_and(|arg| arg.id == "raise_if_not_found"))
+            .map(|keyword| &keyword.value));
+        if raise_arg.is_some_and(|arg| arg.as_boolean_literal_expr().is_some_and(|literal| !literal.value)) {
+            return None;
         }
         let xml_id_expr = parameters.args[0].as_string_literal_expr().unwrap();
         let xml_id_str = xml_id_expr.value.to_str();

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -479,6 +479,22 @@ impl PythonValidator {
                             session.sync_odoo.get_main_entry().borrow_mut().not_found_symbols_for_models.insert(file_symbol);
                         }
                     }
+                    if let Some(groups) = eval_weak.get_weak().context.get(ContextKey::Groups).map(ContextValue::as_str)
+                        && let Some(groups_range) = eval_weak.get_weak().context.get(ContextKey::GroupsArgRange).map(ContextValue::as_text_range)
+                        && let Some(file_symbol) = session.st().get_file(class.into()) {
+                        // an entry may be negated with '!', and a lone '.' is odoo.fields.NO_ACCESS
+                        let missing_groups = groups.split(',').map(|group| group.trim().trim_start_matches('!'))
+                            .filter(|group| !group.is_empty() && *group != "."
+                                && !SyncOdoo::is_group_xml_id(session, file_symbol, group, &(0..0), &mut vec![]))
+                            .collect::<Vec<_>>();
+                        if !missing_groups.is_empty()
+                            && let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS05054, &[&missing_groups.join(", ")]) {
+                                self.diagnostics.push(Diagnostic {
+                                    range: Range::new(Position::new(groups_range.start().to_u32(), 0), Position::new(groups_range.end().to_u32(), 0)),
+                                    ..diagnostic_base
+                                });
+                            }
+                    }
                     for (special_fn_field_name, special_fn_field_arg_range) in [
                         (ContextKey::Compute, ContextKey::ComputeArgRange),
                         (ContextKey::Inverse, ContextKey::InverseArgRange),

--- a/server/src/core/symbols/manifest_create.rs
+++ b/server/src/core/symbols/manifest_create.rs
@@ -67,8 +67,10 @@ impl ModuleSymbol {
                                 ModuleSymbol::load_manifest_name(session, module_key, &mut res, key_literal, value);
                             } else if key_str == "depends" {
                                 ModuleSymbol::load_manifest_depends(session, module_key, &mut res, key_literal, value);
-                            } else if key_str == "data" {
-                                ModuleSymbol::load_manifest_data(session, module_key, &mut res, key_literal, value);
+                            } else if key_str == "data" || key_str == "demo" {
+                                ModuleSymbol::load_manifest_data(session, module_key, &mut res, key_literal, value, false);
+                            } else if key_str == "other_files" {
+                                ModuleSymbol::load_manifest_data(session, module_key, &mut res, key_literal, value, true);
                             } else if key_str == "assets" {
                                 ModuleSymbol::load_manifest_assets(session, module_key, &mut res, key_literal, value);
                             } else if key_str == "active"
@@ -153,7 +155,8 @@ impl ModuleSymbol {
         }
     }
 
-    fn load_manifest_data(session: &mut SessionInfo, module_key: ModuleKey, diagnostics: &mut Vec<Diagnostic>, key_literal: &ExprStringLiteral, value: &Expr) {
+    /// A manifest key listing data files, `other_files` alone being limited to the xml it declares.
+    fn load_manifest_data(session: &mut SessionInfo, module_key: ModuleKey, diagnostics: &mut Vec<Diagnostic>, key_literal: &ExprStringLiteral, value: &Expr, xml_only: bool) {
         if !value.is_list_expr() {
             if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS04007, &[]) {
                 diagnostics.push(Diagnostic {
@@ -171,8 +174,13 @@ impl ModuleSymbol {
                         });
                     }
                 } else {
+                    let data_url = data.as_string_literal_expr().unwrap().value.to_string();
+                    // an `other_files` csv is read by module code, so it does not name a model
+                    if xml_only && !data_url.ends_with(".xml") {
+                        continue;
+                    }
                     let module = &mut session.st_mut()[module_key];
-                    module.data.push((data.as_string_literal_expr().unwrap().value.to_string(), data.range()));
+                    module.data.push((data_url, data.range()));
                 }
             }
         }

--- a/server/src/core/xml_arch_builder.rs
+++ b/server/src/core/xml_arch_builder.rs
@@ -6,12 +6,11 @@ use crate::{
     core::{
         data_hooks,
         diagnostics::{create_diagnostic, DiagnosticCode},
-        odoo::SyncOdoo,
         symbols::{Buildable, symbol_keys::XmlFileKey},
     },
 };
 use lsp_types::Diagnostic;
-use roxmltree::{Attribute, Node};
+use roxmltree::Node;
 use tracing::{info, error, warn};
 
 /*
@@ -116,19 +115,5 @@ impl XmlArchBuilder {
                 session.sync_odoo.js_templates.entry(t_name).or_default().insert(template);
             }
         }
-    }
-
-    pub fn get_group_ids(&self, session: &mut SessionInfo, xml_id: &str, attr: &Attribute, diagnostics: &mut Vec<Diagnostic>) -> Vec<XmlId> {
-        let xml_ids = SyncOdoo::get_xml_ids(session, self.xml_symbol.into(), xml_id, &attr.range(), diagnostics);
-        let mut res = vec![];
-        for data in xml_ids.iter_valid(session.st()) {
-            if let XmlId::XmlRecord(r) = data {
-                let record = &session.st()[r];
-                if record.model.0 == "res.groups" {
-                    res.push(data);
-                }
-            }
-        }
-        res
     }
 }

--- a/server/src/core/xml_arch_builder_rng_validation.rs
+++ b/server/src/core/xml_arch_builder_rng_validation.rs
@@ -98,7 +98,7 @@ impl XmlArchBuilder {
                 },
                 "groups" => {
                     let missing_groups = attr.value().split(",")
-                        .filter(|group| self.get_group_ids(session, group.trim_start_matches("-"), &attr, diagnostics).is_empty())
+                        .filter(|group| !SyncOdoo::is_group_xml_id(session, self.xml_symbol.into(), group.trim_start_matches("-"), &attr.range(), diagnostics))
                         .collect::<Vec<&str>>()
                         .join(",");
                     if !missing_groups.is_empty()

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -11,7 +11,7 @@ use crate::core::odoo::SyncOdoo;
 use crate::core::python_odoo_builder::ACCESS_OPERATOR_OPTIONS;
 use crate::core::symbols::storage::xml::xml_field_symbol::XmlFieldName;
 use crate::core::symbols::{FunctionSymbol, ModuleSymbol};
-use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SourceFileKey, SymbolKey};
+use crate::core::symbols::symbol_keys::{ClassKey, FunctionKey, ModuleKey, SourceFileKey, SymbolKey};
 use crate::core::symbols::storage::SymbolTable;
 use crate::features::ast_utils::AstUtils;
 use crate::features::features_utils::FeaturesUtils;
@@ -47,6 +47,7 @@ pub enum ExpectedType {
     EXTERNAL_FIELD(OYarn), // Like in inverse_name='field_name', we attach the comodel_name
     METHOD_NAME,
     INHERITS,
+    XML_ID(Option<OYarn>), // the model the record must have, e.g. res.groups for a groups list
 }
 
 pub struct CompletionFeature;
@@ -612,6 +613,9 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
             } else {
                 callable_sym.unwrap_function_key()
             };
+            if arg_index == 0 && let Some(xml_id_type) = xml_id_first_arg_type(session, func_key) {
+                return complete_expr(arg, session, file, offset, is_param, &[xml_id_type]);
+            }
             let is_on_instance = if callable_sym.typ() == SymType::CLASS {
                 Some(true)
             } else {
@@ -685,6 +689,7 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
         }
         let Some(expected_type) = keyword.arg.as_ref().and_then(|kw_arg_id|
             match kw_arg_id.id.as_str() {
+                "groups" => Some(vec![ExpectedType::XML_ID(Some(Sy!("res.groups")))]),
                 "related" => Some(vec![ExpectedType::NESTED_FIELD(Some(session.st().name(callable_sym).clone()))]),
                 "comodel_name" => if SymbolTable::is_specific_field_class(session, callable_sym, &["Many2one", "One2many", "Many2many"]) {
                         Some(vec![ExpectedType::MODEL_NAME])
@@ -711,6 +716,18 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
         return complete_expr(&keyword.value, session, file, offset, is_param, &expected_type);
     }
     complete_expr(&keyword.value, session, file, offset, is_param, &[])
+}
+
+/// Expected type of the first argument of the functions taking an xml_id.
+fn xml_id_first_arg_type(session: &SessionInfo, func_key: FunctionKey) -> Option<ExpectedType> {
+    let func = &session.st()[func_key];
+    if func.evaluations.iter().any(|evaluation|
+        evaluation.symbol.get_symbol_hook.as_ref().is_some_and(|hook| hook.name == HookName::EvalEnvRef)) {
+        return Some(ExpectedType::XML_ID(None));
+    }
+    // `user_has_groups` is the BaseModel helper deprecated in 17.0, the others live on res.users
+    matches!(func.name.as_str(), "has_group" | "has_groups" | "user_has_groups")
+        .then(|| ExpectedType::XML_ID(Some(Sy!("res.groups"))))
 }
 
 fn complete_string_literal(session: &mut SessionInfo, file: SourceFileKey, expr_string_literal: &ruff_python_ast::ExprStringLiteral, _offset: usize, _is_param: bool, expected_type: &[ExpectedType]) -> Option<CompletionResponse> {
@@ -849,6 +866,31 @@ fn complete_string_literal(session: &mut SessionInfo, file: SourceFileKey, expr_
                 main_syms.iter().filter_map(|s| s.as_class_key()).for_each(|class_key| {
                     add_model_attributes(session, &mut items, current_module, class_key.into(), false, true, false, expr_string_literal.value.to_str(), &Some(Sy!("Many2one")))
                 });
+            },
+            ExpectedType::XML_ID(model_filter) => {
+                // a `groups` value is a list, so only the segment being typed is completed
+                let prefix = expr_string_literal.value.to_str().rsplit(',').next().unwrap_or_default().trim_start().trim_start_matches('!');
+                let prefix_head = prefix.rfind('.').map_or("", |index| &prefix[..=index]);
+                for (module_key, local_id, in_deps) in SyncOdoo::get_xml_ids_by_prefix(session, file, prefix, model_filter.as_ref()) {
+                    if !in_deps && !session.sync_odoo.config.ac_filter_model_names() {
+                        continue;
+                    }
+                    let dir_name = session.st()[module_key].dir_name.clone();
+                    let label = format!("{}.{}", dir_name, local_id);
+                    // out of deps last, then the other modules, then the current one
+                    let sort_prefix = if !in_deps { "~" } else if current_module == Some(module_key) { "_" } else { "" };
+                    items.push(CompletionItem {
+                        insert_text: label.strip_prefix(prefix_head).map(str::to_string),
+                        sort_text: Some(format!("{sort_prefix}{label}")),
+                        kind: Some(lsp_types::CompletionItemKind::REFERENCE),
+                        label_details: (!in_deps).then(|| CompletionItemLabelDetails {
+                            detail: None,
+                            description: Some(format!("require {dir_name}")),
+                        }),
+                        label,
+                        ..Default::default()
+                    });
+                }
             },
             ExpectedType::CLASS(_) => {},
             ExpectedType::INHERITS => {},

--- a/server/src/features/completion.rs
+++ b/server/src/features/completion.rs
@@ -11,7 +11,7 @@ use crate::core::odoo::SyncOdoo;
 use crate::core::python_odoo_builder::ACCESS_OPERATOR_OPTIONS;
 use crate::core::symbols::storage::xml::xml_field_symbol::XmlFieldName;
 use crate::core::symbols::{FunctionSymbol, ModuleSymbol};
-use crate::core::symbols::symbol_keys::{ClassKey, ModuleKey, SourceFileKey, SymbolKey};
+use crate::core::symbols::symbol_keys::{ClassKey, FunctionKey, ModuleKey, SourceFileKey, SymbolKey};
 use crate::core::symbols::storage::SymbolTable;
 use crate::features::ast_utils::AstUtils;
 use crate::features::features_utils::FeaturesUtils;
@@ -47,6 +47,7 @@ pub enum ExpectedType {
     EXTERNAL_FIELD(OYarn), // Like in inverse_name='field_name', we attach the comodel_name
     METHOD_NAME,
     INHERITS,
+    XML_ID(Option<OYarn>), // the model the record must have, e.g. res.groups for a groups list
 }
 
 pub struct CompletionFeature;
@@ -612,6 +613,9 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
             } else {
                 callable_sym.unwrap_function_key()
             };
+            if arg_index == 0 && let Some(xml_id_type) = xml_id_first_arg_type(session, func_key) {
+                return complete_expr(arg, session, file, offset, is_param, &[xml_id_type]);
+            }
             let is_on_instance = if callable_sym.typ() == SymType::CLASS {
                 Some(true)
             } else {
@@ -685,6 +689,7 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
         }
         let Some(expected_type) = keyword.arg.as_ref().and_then(|kw_arg_id|
             match kw_arg_id.id.as_str() {
+                "groups" => Some(vec![ExpectedType::XML_ID(Some(Sy!("res.groups")))]),
                 "related" => Some(vec![ExpectedType::NESTED_FIELD(Some(session.st().name(callable_sym).clone()))]),
                 "comodel_name" => if SymbolTable::is_specific_field_class(session, callable_sym, &["Many2one", "One2many", "Many2many"]) {
                         Some(vec![ExpectedType::MODEL_NAME])
@@ -711,6 +716,18 @@ fn complete_call(session: &mut SessionInfo, file: SourceFileKey, expr_call: &ruf
         return complete_expr(&keyword.value, session, file, offset, is_param, &expected_type);
     }
     complete_expr(&keyword.value, session, file, offset, is_param, &[])
+}
+
+/// Expected type of the first argument of the functions taking an xml_id.
+fn xml_id_first_arg_type(session: &SessionInfo, func_key: FunctionKey) -> Option<ExpectedType> {
+    let func = &session.st()[func_key];
+    if func.evaluations.iter().any(|evaluation|
+        evaluation.symbol.get_symbol_hook.as_ref().is_some_and(|hook| hook.name == HookName::EvalEnvRef)) {
+        return Some(ExpectedType::XML_ID(None));
+    }
+    // `user_has_groups` is the BaseModel helper deprecated in 17.0, the others live on res.users
+    matches!(func.name.as_str(), "has_group" | "has_groups" | "user_has_groups")
+        .then(|| ExpectedType::XML_ID(Some(Sy!("res.groups"))))
 }
 
 fn complete_string_literal(session: &mut SessionInfo, file: SourceFileKey, expr_string_literal: &ruff_python_ast::ExprStringLiteral, _offset: usize, _is_param: bool, expected_type: &[ExpectedType]) -> Option<CompletionResponse> {
@@ -849,6 +866,53 @@ fn complete_string_literal(session: &mut SessionInfo, file: SourceFileKey, expr_
                 main_syms.iter().filter_map(|s| s.as_class_key()).for_each(|class_key| {
                     add_model_attributes(session, &mut items, current_module, class_key.into(), false, true, false, expr_string_literal.value.to_str(), &Some(Sy!("Many2one")))
                 });
+            },
+            ExpectedType::XML_ID(model_filter) => {
+                // a `groups` value is a list, so only the segment being typed is completed
+                let prefix = expr_string_literal.value.to_str().rsplit(',').next().unwrap_or_default().trim_start().trim_start_matches('!');
+                // unfiltered ids number in the hundreds of thousands, so the module is named first
+                if model_filter.is_none() && !prefix.contains('.') {
+                    for (module_key, in_deps) in SyncOdoo::get_xml_id_modules(session, file, prefix) {
+                        if !in_deps && !session.sync_odoo.config.ac_filter_model_names() {
+                            continue;
+                        }
+                        let dir_name = session.st()[module_key].dir_name.clone();
+                        let sort_prefix = if !in_deps { "~" } else if current_module == Some(module_key) { "_" } else { "" };
+                        items.push(CompletionItem {
+                            insert_text: Some(format!("{dir_name}.")),
+                            sort_text: Some(format!("{sort_prefix}{dir_name}")),
+                            kind: Some(lsp_types::CompletionItemKind::MODULE),
+                            label_details: (!in_deps).then(|| CompletionItemLabelDetails {
+                                detail: None,
+                                description: Some(format!("require {dir_name}")),
+                            }),
+                            label: dir_name.to_string(),
+                            ..Default::default()
+                        });
+                    }
+                    continue;
+                }
+                let prefix_head = prefix.rfind('.').map_or("", |index| &prefix[..=index]);
+                for (module_key, local_id, in_deps) in SyncOdoo::get_xml_ids_by_prefix(session, file, prefix, model_filter.as_ref()) {
+                    if !in_deps && !session.sync_odoo.config.ac_filter_model_names() {
+                        continue;
+                    }
+                    let dir_name = session.st()[module_key].dir_name.clone();
+                    let label = format!("{}.{}", dir_name, local_id);
+                    // out of deps last, then the other modules, then the current one
+                    let sort_prefix = if !in_deps { "~" } else if current_module == Some(module_key) { "_" } else { "" };
+                    items.push(CompletionItem {
+                        insert_text: label.strip_prefix(prefix_head).map(str::to_string),
+                        sort_text: Some(format!("{sort_prefix}{label}")),
+                        kind: Some(lsp_types::CompletionItemKind::REFERENCE),
+                        label_details: (!in_deps).then(|| CompletionItemLabelDetails {
+                            detail: None,
+                            description: Some(format!("require {dir_name}")),
+                        }),
+                        label,
+                        ..Default::default()
+                    });
+                }
             },
             ExpectedType::CLASS(_) => {},
             ExpectedType::INHERITS => {},

--- a/server/src/features/csv_ast_utils.rs
+++ b/server/src/features/csv_ast_utils.rs
@@ -63,6 +63,17 @@ impl<'a> Iterator for CsvFieldIter<'a> {
     }
 }
 
+/// Each xml id of a `/id` cell with its byte range, a relational column comma separating them.
+pub fn split_csv_xml_ids(field: &str, value_start: usize) -> impl Iterator<Item = (&str, usize, usize)> {
+    let mut offset = 0;
+    field.split(',').filter_map(move |segment| {
+        let start = value_start + offset + segment.len() - segment.trim_start().len();
+        offset += segment.len() + 1;
+        let xml_id = segment.trim();
+        (!xml_id.is_empty()).then_some((xml_id, start, start + xml_id.len()))
+    })
+}
+
 pub struct CsvRecordIter<'a> {
     content: &'a str,
     records: csv::StringRecordsIter<'a, &'a [u8]>,

--- a/server/src/features/csv_ast_utils.rs
+++ b/server/src/features/csv_ast_utils.rs
@@ -1,8 +1,12 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use csv::{Reader, StringRecord};
 use lsp_types::Range;
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::core::evaluation_utils::DeepFieldEvalWalker;
+use crate::core::file_mgr::FileInfo;
 use crate::core::symbols::storage::xml::xml_field_symbol::XmlFieldName;
 use crate::core::symbols::symbol_keys::CsvFileKey;
 use crate::features::goto_utils::{GotoSource, GotoSourceType};
@@ -61,6 +65,19 @@ impl<'a> Iterator for CsvFieldIter<'a> {
         self.field_idx += 1;
         Some((start, end, field))
     }
+}
+
+/// Each xml id of a `/id` cell with its byte range, a relational column comma separating them.
+pub fn split_csv_xml_ids<'a>(field: &'a str, content: &str, cell_start: usize) -> impl Iterator<Item = (&'a str, usize, usize)> {
+    // the cell spans its quotes when it carries them, the ids inside it do not
+    let value_start = cell_start + usize::from(content.as_bytes().get(cell_start) == Some(&b'"'));
+    let mut offset = 0;
+    field.split(',').filter_map(move |segment| {
+        let start = value_start + offset + segment.len() - segment.trim_start().len();
+        offset += segment.len() + 1;
+        let xml_id = segment.trim();
+        (!xml_id.is_empty()).then_some((xml_id, start, start + xml_id.len()))
+    })
 }
 
 pub struct CsvRecordIter<'a> {
@@ -193,7 +210,18 @@ impl CsvAstUtils {
         }
         if headers.contains(&oyarn!("id")) {
             for record in csv_reader.records().filter_map(Result::ok) {
-                    CsvAstUtils::get_symbols_in_record(session, offset, &headers, &record, &mut results, file_symbol, main_symbol.into(), module, content);
+                CsvAstUtils::get_symbols_in_record(
+                    session,
+                    offset,
+                    &headers,
+                    &record,
+                    &mut results,
+                    file_symbol,
+                    main_symbol.into(),
+                    module,
+                    content,
+                    &file_info,
+                );
             }
         }
         results
@@ -209,6 +237,7 @@ impl CsvAstUtils {
         main_symbol: SymbolKey,
         module: Option<ModuleKey>,
         content: &str,
+        file_info: &Rc<RefCell<FileInfo>>,
     ) {
         let Some(field_iter) = CsvFieldIter::new(record, content) else { return; };
         //Search for selected field
@@ -252,18 +281,27 @@ impl CsvAstUtils {
                 return;
             };
             // We found the relational model referred to, we can lookup the xml_id now
+            let Some((xml_id, id_start, id_end)) = split_csv_xml_ids(field, content, start)
+                .find(|(_, id_start, id_end)| offset >= *id_start && offset <= *id_end)
+            else {
+                return;
+            };
+            let id_range = Range {
+                start: file_info.borrow().offset_to_position(id_start as u32, session.sync_odoo.encoding),
+                end: file_info.borrow().offset_to_position(id_end as u32, session.sync_odoo.encoding),
+            };
             results.extend(
                 SyncOdoo::get_xml_ids(
                     session,
                     csv_symbol.into(),
-                    field_data.as_str(),
+                    xml_id,
                     &std::ops::Range::default(), //we don't care about range as it's used only for diagnostic
                     &mut vec![],
                 )
                 .iter_valid(session.st())
                 .map(|xml_id| GotoSource {
                     source: GotoSourceType::SymbolKey(xml_id.into()),
-                    origin_selection_range: None,
+                    origin_selection_range: Some(id_range),
                 }),
             );
         }

--- a/server/tests/data/addons/module_1/models/__init__.py
+++ b/server/tests/data/addons/module_1/models/__init__.py
@@ -2,3 +2,4 @@ from . import base_test_models
 from . import diagnostics
 from . import models
 from . import to_complete
+from . import xml_id_probe

--- a/server/tests/data/addons/module_1/models/xml_id_probe.py
+++ b/server/tests/data/addons/module_1/models/xml_id_probe.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class XmlIdProbe(models.Model):
+    _name = "module_1.xml_id_probe"
+    _description = "Xml Id Probe"
+
+    # partial xml_ids, completed in test_xml_id_completion
+    group_restricted = fields.Char(groups="base.group_")
+    module_restricted = fields.Char(groups="module_1.")
+
+    def probe(self):
+        self.env.ref("module_1.")
+        self.env["res.users"].browse(1).has_group("base.group_")

--- a/server/tests/data/addons/module_1/models/xml_id_probe.py
+++ b/server/tests/data/addons/module_1/models/xml_id_probe.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class XmlIdProbe(models.Model):
+    _name = "module_1.xml_id_probe"
+    _description = "Xml Id Probe"
+
+    # partial xml_ids, completed in test_xml_id_completion
+    group_restricted = fields.Char(groups="base.group_")
+    module_restricted = fields.Char(groups="module_1.")
+
+    def probe(self):
+        self.env.ref("base")
+        self.env.ref("module_1.")
+        self.env["res.users"].browse(1).has_group("base.group_")

--- a/server/tests/data/addons/module_for_diagnostics/__manifest__.py
+++ b/server/tests/data/addons/module_for_diagnostics/__manifest__.py
@@ -22,4 +22,11 @@ This is the description of the module for diagnostics
         "data/file.does.not.exist", # OLS05049
         "data/file.invalid", # OLS05050
     ],
+    "demo": [
+        "demo/bikes_demo.xml",
+    ],
+    "other_files": [
+        "other/bikes_other.xml",
+        "other/reference_table.csv",
+    ],
 }

--- a/server/tests/data/addons/module_for_diagnostics/__manifest__.py
+++ b/server/tests/data/addons/module_for_diagnostics/__manifest__.py
@@ -18,6 +18,7 @@ This is the description of the module for diagnostics
         "data/bikes.xml",
         "data/buttons.xml",
         "data/bike_parts.wheel.csv",
+        "data/bikes.bike.csv",
         "data/file.does.not.exist", # OLS05049
         "data/file.invalid", # OLS05050
     ],

--- a/server/tests/data/addons/module_for_diagnostics/data/bikes.bike.csv
+++ b/server/tests/data/addons/module_for_diagnostics/data/bikes.bike.csv
@@ -1,0 +1,3 @@
+id,name,wheel_ids/id
+bike_m2m_ok,Ok Bike,"bike_wheel_6,module_for_diagnostics.bike_wheel_6"
+bike_m2m_bad,Bad Bike,"bike_wheel_6, bike_wheel_DOES_NOT_EXIST"

--- a/server/tests/data/addons/module_for_diagnostics/data/bikes.bike.csv
+++ b/server/tests/data/addons/module_for_diagnostics/data/bikes.bike.csv
@@ -1,3 +1,4 @@
 id,name,wheel_ids/id
 bike_m2m_ok,Ok Bike,"bike_wheel_6,module_for_diagnostics.bike_wheel_6"
 bike_m2m_bad,Bad Bike,"bike_wheel_6, bike_wheel_DOES_NOT_EXIST"
+bike_m2m_data,Data Bike,"bike_wheel_demo,bike_wheel_other"

--- a/server/tests/data/addons/module_for_diagnostics/demo/bikes_demo.xml
+++ b/server/tests/data/addons/module_for_diagnostics/demo/bikes_demo.xml
@@ -1,0 +1,6 @@
+<odoo>
+    <record id="bike_wheel_demo" model="bike_parts.wheel">
+        <field name="name">Demo Wheel</field>
+        <field name="price">100.0</field>
+    </record>
+</odoo>

--- a/server/tests/data/addons/module_for_diagnostics/models/bike_parts_wheel.py
+++ b/server/tests/data/addons/module_for_diagnostics/models/bike_parts_wheel.py
@@ -19,6 +19,9 @@ class BikesBike(models.Model):
     name = fields.Char(string='Wheel Name', required=True, translate=True)
     wheel_id = fields.Many2one('bike_parts.wheel', string='Wheel')
     wheel_ids = fields.Many2many('bike_parts.wheel', string='Wheels')
+    restricted = fields.Char(groups='base.group_user,!base.group_portal,module_for_diagnostics.no_such_group') # OLS05054
+    hidden = fields.Char(groups='.') # Ok, odoo.fields.NO_ACCESS
+    not_a_group = fields.Char(groups='module_for_diagnostics.bike_1') # OLS05054
     bike_weight = fields.Float(string='Bike Weight (kg)', compute='_compute_bike_weight', store=True)
 
     @api.depends('wheel_id.price')
@@ -28,9 +31,12 @@ class BikesBike(models.Model):
                 bike.bike_weight = bike.wheel_id.price * 0.5
             else:
                 bike.bike_weight = 0.0
-        self.env.ref('module_for_diagnostics.bike_wheel_DOES_NOT_EXIST') # TODO: OLS05001
+        self.env.ref('module_for_diagnostics.bike_wheel_DOES_NOT_EXIST') # OLS05001
         self.env.ref('bike_wheel_DOES_NOT_EXIST') # OLS05002
         self.env.ref('module_for_diagnostics.bike_wheel_6') # Ok
+        self.env.ref('base.module_base') # Ok, the registry generates it
+        self.env.ref('base.field_res_partner__name') # Ok, the registry generates it
+        self.env.ref('base.selection__res_partner__type__contact') # Ok, the registry generates it
         self.env.ref('WRONG_MODULE.bike_wheel_6') # OLS05003
         self.env.ref('module_for_diagnostics.bike_wheel_6.too.many.dots') # OLS05051
         self.env.ref('WRONG_MODULE.bike_wheel_6', False) # Ok, the caller takes an empty result

--- a/server/tests/data/addons/module_for_diagnostics/models/bike_parts_wheel.py
+++ b/server/tests/data/addons/module_for_diagnostics/models/bike_parts_wheel.py
@@ -33,3 +33,5 @@ class BikesBike(models.Model):
         self.env.ref('module_for_diagnostics.bike_wheel_6') # Ok
         self.env.ref('WRONG_MODULE.bike_wheel_6') # OLS05003
         self.env.ref('module_for_diagnostics.bike_wheel_6.too.many.dots') # OLS05051
+        self.env.ref('WRONG_MODULE.bike_wheel_6', False) # Ok, the caller takes an empty result
+        self.env.ref('WRONG_MODULE.bike_wheel_6', raise_if_not_found=False) # Ok, same spelled by name

--- a/server/tests/data/addons/module_for_diagnostics/models/bike_parts_wheel.py
+++ b/server/tests/data/addons/module_for_diagnostics/models/bike_parts_wheel.py
@@ -18,6 +18,7 @@ class BikesBike(models.Model):
 
     name = fields.Char(string='Wheel Name', required=True, translate=True)
     wheel_id = fields.Many2one('bike_parts.wheel', string='Wheel')
+    wheel_ids = fields.Many2many('bike_parts.wheel', string='Wheels')
     bike_weight = fields.Float(string='Bike Weight (kg)', compute='_compute_bike_weight', store=True)
 
     @api.depends('wheel_id.price')

--- a/server/tests/data/addons/module_for_diagnostics/other/bikes_other.xml
+++ b/server/tests/data/addons/module_for_diagnostics/other/bikes_other.xml
@@ -1,0 +1,6 @@
+<odoo>
+    <record id="bike_wheel_other" model="bike_parts.wheel">
+        <field name="name">Other Wheel</field>
+        <field name="price">150.0</field>
+    </record>
+</odoo>

--- a/server/tests/data/addons/module_for_diagnostics/other/reference_table.csv
+++ b/server/tests/data/addons/module_for_diagnostics/other/reference_table.csv
@@ -1,0 +1,2 @@
+code,label
+be,Belgium

--- a/server/tests/test_csv_diagnostics.rs
+++ b/server/tests/test_csv_diagnostics.rs
@@ -161,3 +161,24 @@ fn test_valid_file_no_errors(diagnostics: &[Diagnostic]) {
             .join("; ")
     );
 }
+
+/// A relational `/id` column lists its ids comma separated, each one validated on its own.
+#[test]
+fn test_csv_relational_id_column_is_a_list() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests").join("data").join("addons")
+        .join("module_for_diagnostics").join("data").join("bikes.bike.csv")
+        .sanitize();
+
+    let diagnostics = setup::setup::get_diagnostics_for_path(&mut session, &path);
+    let unknown = diagnostics.iter().filter(|diag| has_code(diag, "OLS05001")).collect::<Vec<_>>();
+    assert_eq!(unknown.len(), 1, "only the one bogus id is unknown, got: {diagnostics:?}");
+
+    // The range spans that id alone, not the whole cell, so the ids beside it stay untouched.
+    let content = std::fs::read_to_string(&path).unwrap();
+    let range = &unknown[0].range;
+    let line = content.lines().nth(range.start.line as usize).expect("diagnostic line");
+    assert_eq!(&line[range.start.character as usize..range.end.character as usize], "bike_wheel_DOES_NOT_EXIST");
+}

--- a/server/tests/test_get_symbol.rs
+++ b/server/tests/test_get_symbol.rs
@@ -450,6 +450,31 @@ fn test_definition_csv() {
 }
 
 #[test]
+fn test_definition_csv_relational_ids() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let test_addons_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("data").join("addons");
+    let bikes_csv = test_addons_path.join("module_for_diagnostics").join("data").join("bikes.bike.csv").sanitize();
+    let wheels_csv = test_addons_path.join("module_for_diagnostics").join("data").join("bike_parts.wheel.csv").sanitize();
+    assert!(Path::new(&bikes_csv).exists(), "Test file does not exist: {}", bikes_csv);
+
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&bikes_csv).unwrap();
+    let Some(file_symbol) = SyncOdoo::get_symbol_of_opened_file(&mut session, Path::new(&bikes_csv)) else {
+        panic!("Failed to get file symbol");
+    };
+
+    // line 1 is bike_m2m_ok,Ok Bike,"bike_wheel_6,module_for_diagnostics.bike_wheel_6"
+    for (character, id_start, id_end) in [(25, 21, 33), (40, 34, 69)] {
+        let locs = test_utils::get_definition_locs(&mut session, file_symbol, &file_info, 1, character);
+        assert!(!locs.is_empty(), "Expected a location for the xml id at character {character}");
+        assert_eq!(locs[0].target_uri.to_file_path().unwrap().sanitize(), wheels_csv, "Expected the definition to be in bike_parts.wheel.csv");
+        let origin = locs[0].origin_selection_range.expect("Expected the clicked xml id to be the origin range");
+        assert_eq!((origin.start.line, origin.start.character, origin.end.character), (1, id_start, id_end), "Expected only the clicked xml id to be highlighted");
+    }
+}
+
+#[test]
 fn test_model_subscription() {
     // Setup: Get the symbol for BaseTestModel and verify its existence
     let (mut odoo, config) = setup::setup::setup_server(true);

--- a/server/tests/test_utils.rs
+++ b/server/tests/test_utils.rs
@@ -14,6 +14,16 @@ use std::{
 };
 
 
+/// Cursor position right after the single occurrence of `needle` in `content`.
+pub fn position_after(content: &str, needle: &str) -> lsp_types::Position {
+    let start = content.find(needle).unwrap_or_else(|| panic!("{needle:?} not found in the fixture"));
+    assert!(content[start + 1..].find(needle).is_none(), "{needle:?} is not unique in the fixture");
+    let offset = start + needle.len();
+    let line = content[..offset].matches('\n').count();
+    let character = offset - content[..offset].rfind('\n').map(|index| index + 1).unwrap_or(0);
+    lsp_types::Position::new(line as u32, character as u32)
+}
+
 /// Returns the correct class name for Partner/ResPartner depending on Odoo version
 pub static PARTNER_CLASS_NAME: LazyLock<fn(OdooVersion) -> &'static str> = LazyLock::new(|| {
     |version: OdooVersion| {

--- a/server/tests/test_xml_id_completion.rs
+++ b/server/tests/test_xml_id_completion.rs
@@ -1,0 +1,51 @@
+mod setup;
+mod test_utils;
+
+use std::path::Path;
+
+use lsp_types::CompletionResponse;
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::features::completion::CompletionFeature;
+use odoo_ls_server::threads::SessionInfo;
+use odoo_ls_server::utils::PathSanitizer;
+
+use test_utils::position_after;
+
+/// Labels offered with the cursor right after the single occurrence of `needle`.
+fn labels_after(session: &mut SessionInfo, path: &str, content: &str, needle: &str) -> Vec<String> {
+    let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(path).unwrap();
+    let file_symbol = SyncOdoo::get_symbol_of_opened_file(session, Path::new(path)).expect("probe file symbol");
+    let position = position_after(content, needle);
+    let items = match CompletionFeature::autocomplete(session, file_symbol, &file_info, None, position.line, position.character) {
+        Some(CompletionResponse::Array(items)) => items,
+        Some(CompletionResponse::List(list)) => list.items,
+        None => vec![],
+    };
+    items.into_iter().map(|item| item.label).collect()
+}
+
+/// An xml_id string literal completes from the current module and its dependencies.
+#[test]
+fn test_xml_id_completion() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let probe = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests").join("data").join("addons")
+        .join("module_1").join("models").join("xml_id_probe.py")
+        .sanitize();
+    let content = std::fs::read_to_string(&probe).unwrap();
+
+    // env.ref("module_1.") -> the xml_ids the current module declares
+    let refs = labels_after(&mut session, &probe, &content, r#"self.env.ref("module_1."#);
+    assert!(refs.contains(&"module_1.test_xml_test_record".to_string()), "env.ref completes the ids of the module, got: {refs:?}");
+
+    // groups="module_1." -> none of them, as none is a res.groups record
+    let own = labels_after(&mut session, &probe, &content, r#"module_restricted = fields.Char(groups="module_1."#);
+    assert!(own.is_empty(), "groups= only completes res.groups records, got: {own:?}");
+
+    // groups="base.group_" and has_group("base.group_") -> the res.groups records of base
+    for needle in [r#"group_restricted = fields.Char(groups="base.group_"#, r#"has_group("base.group_"#] {
+        let groups = labels_after(&mut session, &probe, &content, needle);
+        assert!(groups.contains(&"base.group_user".to_string()), "{needle} completes the groups of base, got: {groups:?}");
+    }
+}

--- a/server/tests/test_xml_id_completion.rs
+++ b/server/tests/test_xml_id_completion.rs
@@ -1,0 +1,56 @@
+mod setup;
+mod test_utils;
+
+use std::path::Path;
+
+use lsp_types::CompletionResponse;
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::features::completion::CompletionFeature;
+use odoo_ls_server::threads::SessionInfo;
+use odoo_ls_server::utils::PathSanitizer;
+
+use test_utils::position_after;
+
+/// Labels offered with the cursor right after the single occurrence of `needle`.
+fn labels_after(session: &mut SessionInfo, path: &str, content: &str, needle: &str) -> Vec<String> {
+    let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(path).unwrap();
+    let file_symbol = SyncOdoo::get_symbol_of_opened_file(session, Path::new(path)).expect("probe file symbol");
+    let position = position_after(content, needle);
+    let items = match CompletionFeature::autocomplete(session, file_symbol, &file_info, None, position.line, position.character) {
+        Some(CompletionResponse::Array(items)) => items,
+        Some(CompletionResponse::List(list)) => list.items,
+        None => vec![],
+    };
+    items.into_iter().map(|item| item.label).collect()
+}
+
+/// An xml_id string literal completes from the current module and its dependencies.
+#[test]
+fn test_xml_id_completion() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let probe = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests").join("data").join("addons")
+        .join("module_1").join("models").join("xml_id_probe.py")
+        .sanitize();
+    let content = std::fs::read_to_string(&probe).unwrap();
+
+    // env.ref("base") -> the modules that could still be named, not their ids
+    let modules = labels_after(&mut session, &probe, &content, r#"self.env.ref("base"#);
+    assert!(modules.contains(&"base".to_string()), "env.ref completes module names first, got: {modules:?}");
+    assert!(!modules.iter().any(|label| label.contains('.')), "env.ref does not offer any id before a module is named, got: {modules:?}");
+
+    // env.ref("module_1.") -> the xml_ids the current module declares
+    let refs = labels_after(&mut session, &probe, &content, r#"self.env.ref("module_1."#);
+    assert!(refs.contains(&"module_1.test_xml_test_record".to_string()), "env.ref completes the ids of the module, got: {refs:?}");
+
+    // groups="module_1." -> none of them, as none is a res.groups record
+    let own = labels_after(&mut session, &probe, &content, r#"module_restricted = fields.Char(groups="module_1."#);
+    assert!(own.is_empty(), "groups= only completes res.groups records, got: {own:?}");
+
+    // groups="base.group_" and has_group("base.group_") -> the res.groups records of base
+    for needle in [r#"group_restricted = fields.Char(groups="base.group_"#, r#"has_group("base.group_"#] {
+        let groups = labels_after(&mut session, &probe, &content, needle);
+        assert!(groups.contains(&"base.group_user".to_string()), "{needle} completes the groups of base, got: {groups:?}");
+    }
+}


### PR DESCRIPTION
Hover and go-to-definition already resolved xml_id string literals, but completion and validation did not exist for them. Add an `XML_ID` expected type wired to `env.ref()` (via the `EvalEnvRef `hook), the `groups=` field keyword, and `has_group`/`has_groups` on r`es.users` (`user_has_groups` on earlier versions), with candidates enumerated by prefix from the module dependency graph and filtered to r`es.groups` where the position implies it. `groups=` entries complete per comma-segment and honor the '!' negation prefix from `odoo.tools.set_expression`.

Validate the same positions: `env.ref()` with an unknown local id now raises `OLS05001` and unresolvable `groups=` entries raise `OLS05054`, matching the codes already used for the XML-side checks. Only literal strings are diagnosed; dynamically built values are ignored.