### PR TITLE
[FIX] properly resolve the type of env.user and other properties

### DIFF
--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -144,7 +144,7 @@ impl ExprOrIdent<'_> {
  * diagnostics: a vec the hook can fill to add diagnostics
  * file_symbol: if provided, can be used to add dependencies
  */
-type GetSymbolHookCallable = fn (session: &mut SessionInfo, eval: &EvaluationSymbol, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>;
+pub type GetSymbolHookCallable = fn (session: &mut SessionInfo, eval: &EvaluationSymbol, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>;
 
 #[derive(Debug, Clone)]
 pub struct GetSymbolHook {
@@ -162,6 +162,8 @@ pub enum HookName {
     EvalInitRelational,
     EvalInitRelationalOne2many,
     EvalEnvRef,
+    EvalEnvUser,
+    EvalEnvCompany,
 }
 
 

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -737,23 +737,26 @@ impl PythonArchBuilder {
         let func_sym = &mut session.st_mut()[function_key];
         func_sym.node_index.set(func_def.node_index.load());
         for decorator in func_def.decorator_list.iter() {
-            if decorator.expression.is_name_expr() {
-                if decorator.expression.as_name_expr().unwrap().id == "staticmethod" {
-                    func_sym.is_static = true;
+            if let Some(name) = decorator.expression.as_name_expr() {
+                match name.id.as_str() {
+                    "staticmethod" => func_sym.is_static = true,
+                    "property" | "cached_property" | "lazy_property" => func_sym.is_property = true,
+                    "overload" => func_sym.is_overloaded = true,
+                    "classmethod" => func_sym.is_class_method = true,
+                    "classproperty" | "lazy_classproperty" => {
+                        func_sym.is_property = true;
+                        func_sym.is_class_method = true;
+                    },
+                    _ => {}
                 }
-                else if decorator.expression.as_name_expr().unwrap().id == "property" {
-                    func_sym.is_property = true;
-                }
-                else if decorator.expression.as_name_expr().unwrap().id == "overload" {
-                    func_sym.is_overloaded = true;
-                }
-                else if decorator.expression.as_name_expr().unwrap().id == "classmethod" {
-                    func_sym.is_class_method = true;
-                }
-                else if decorator.expression.as_name_expr().unwrap().id == "classproperty" ||
-                decorator.expression.as_name_expr().unwrap().id == "lazy_classproperty" {
-                    func_sym.is_property = true;
-                    func_sym.is_class_method = true;
+            }
+            // decorators can also be reached through their module, e.g. functools.cached_property,
+            // tools.lazy_property, and typing.overload as odoo's orm uses it
+            else if let Some(attr) = decorator.expression.as_attribute_expr() {
+                match attr.attr.id.as_str() {
+                    "cached_property" | "lazy_property" => func_sym.is_property = true,
+                    "overload" => func_sym.is_overloaded = true,
+                    _ => {}
                 }
             }
         }

--- a/server/src/core/python_arch_eval_hooks.rs
+++ b/server/src/core/python_arch_eval_hooks.rs
@@ -13,6 +13,8 @@ use ruff_text_size::TextRange;
 use tracing::warn;
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
 use crate::core::evaluation::GetSymbolHook;
+use crate::core::evaluation::GetSymbolHookCallable;
+use crate::core::model::Model;
 use crate::core::odoo::SyncOdoo;
 use crate::core::evaluation_context::Context;
 use crate::constants::*;
@@ -496,6 +498,16 @@ pub struct PythonArchEvalFunctionHook {
     pub func: PythonArchEvalHookFunc
 }
 
+/// Hook on a symbol of the Environment class, which moved out of odoo.api in 18.1
+fn environment_attr_hook(content_tree: &'static [&'static str], func: PythonArchEvalHookFunc) -> PythonArchEvalFunctionHook {
+    PythonArchEvalFunctionHook {odoo_entry: true,
+        tree: vec![((0, 0), (18, 1), (&["odoo", "api"], content_tree)),
+        ((18, 1), (999, 0), (&["odoo", "orm", "environments"], content_tree))],
+        if_exist_only: true,
+        func
+    }
+}
+
 #[allow(non_upper_case_globals)]
 static arch_eval_function_hooks: LazyLock<Vec<PythonArchEvalFunctionHook>> = LazyLock::new(|| {vec![
     PythonArchEvalFunctionHook {odoo_entry: true,
@@ -513,6 +525,30 @@ static arch_eval_function_hooks: LazyLock<Vec<PythonArchEvalFunctionHook>> = Laz
             range: None
         }];
     }},
+    /* Environment.user/company/companies are annotated with the generic BaseModel, and are refined
+       to their model (res.users / res.company) through a get_symbol_hook, as the model classes are
+       not loaded yet when the Environment file is built. Function hooks, unlike file hooks, are
+       applied after the annotation of the function, and so can override it. */
+    environment_attr_hook(&["Environment", "user"], |odoo, _entry_point, symbol| {
+        PythonArchEvalHooks::set_hook_evaluation(odoo, symbol, PythonArchEvalHooks::eval_env_user, HookName::EvalEnvUser);
+    }),
+    environment_attr_hook(&["Environment", "company"], |odoo, _entry_point, symbol| {
+        PythonArchEvalHooks::set_hook_evaluation(odoo, symbol, PythonArchEvalHooks::eval_env_company, HookName::EvalEnvCompany);
+    }),
+    // companies is a recordset of res.company; there is no multiplicity distinction here.
+    environment_attr_hook(&["Environment", "companies"], |odoo, _entry_point, symbol| {
+        PythonArchEvalHooks::set_hook_evaluation(odoo, symbol, PythonArchEvalHooks::eval_env_company, HookName::EvalEnvCompany);
+    }),
+    // lang is typed str | None and does not depend on any model, so we resolve it eagerly.
+    environment_attr_hook(&["Environment", "lang"], |odoo, _entry_point, symbol| {
+        let str_sym = odoo.get_symbol(odoo.config.odoo_path().as_ref().unwrap(), (&["builtins"], &["str"]), u32::MAX);
+        if let Some(&str_sym) = str_sym.last() {
+            odoo.symbol_table[symbol].evaluations = vec![
+                Evaluation::eval_from_symbol(&odoo.symbol_table, str_sym, Some(true)),
+                Evaluation::new_none(),
+            ];
+        }
+    }),
     PythonArchEvalFunctionHook {odoo_entry: true,
                         tree: vec![((0, 0), (18, 1), (&["odoo", "modules", "registry"], &["Registry", "__getitem__"])),
                         ((18, 1), (999, 0), (&["odoo", "orm", "registry"], &["Registry", "__getitem__"]))],
@@ -851,6 +887,78 @@ impl PythonArchEvalHooks {
         diagnostics
     }
 
+    /// Set the evaluation of a function to a single hook, resolving its symbol at evaluation time.
+    fn set_hook_evaluation(odoo: &mut SyncOdoo, symbol: FunctionKey, callable: GetSymbolHookCallable, name: HookName) {
+        odoo.symbol_table[symbol].evaluations = vec![Evaluation {
+            symbol: EvaluationSymbol::new_with_symbol(Wk::null(),
+                Some(true),
+                Context::default(),
+                Some(GetSymbolHook{callable, name})
+            ),
+            value: None,
+            range: None
+        }];
+    }
+
+    /// Make the file of `scope` depend on the definitions of `model`, unless it is an orm file
+    /// itself, as that would create a self-dependency.
+    fn add_model_dependencies_outside_orm(session: &mut SessionInfo, scope: Option<SymbolKey>, model: &Rc<RefCell<Model>>) {
+        let Some(scope_file) = scope.and_then(|s| session.st().get_file(s)) else {
+            return;
+        };
+        let is_orm_file = if session.sync_odoo.version < (18, 1) {
+            let env_files = session.sync_odoo.get_symbol(session.sync_odoo.config.odoo_path().as_ref().unwrap(), (&["odoo", "api"], &[]), u32::MAX);
+            env_files.last().is_some_and(|&env_file| env_file == scope_file)
+        } else {
+            session.sync_odoo.get_main_entry_tree(scope_file).0.starts_with_strs(&["odoo", "orm"])
+        };
+        if !is_orm_file {
+            session.st_mut().add_model_dependencies(scope_file, model);
+        }
+    }
+
+    /// Resolve a fixed model name to its main class instance at evaluation time, mirroring the
+    /// model-index lookup and dependency handling of `eval_env_get_item`. Used by the Environment
+    /// attribute hooks (user/company/companies) whose model classes cannot be known when the
+    /// Environment file is built.
+    fn eval_env_model(session: &mut SessionInfo, model_name: &str, context: Option<&Context>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    {
+        let res = Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(Wk::null(), Some(true), false)));
+        let maybe_model = session.sync_odoo.models.get(model_name).cloned();
+        let model_exists = maybe_model.as_ref().map(|m| m.borrow_mut().has_symbols(session.st())).unwrap_or(false);
+        if !model_exists {
+            return res;
+        }
+        let Some(model) = maybe_model else { unreachable!() };
+        let from_module = if let Some(ContextValue::MODULE(m)) = context.and_then(|c| c.get(ContextKey::Module)) {
+            m.upgrade(session.st())
+        } else {
+            None
+        };
+        PythonArchEvalHooks::add_model_dependencies_outside_orm(session, scope, &model);
+        let model = model.borrow();
+        let mut symbols = model.get_main_symbols(session, from_module);
+        if let Some(first_class) = symbols.next() {
+            return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(first_class, Some(true), false)));
+        }
+        // model exists but not in the current dependencies: retry ignoring the module
+        drop(symbols);
+        if let Some(first_class) = model.get_main_symbols(session, None).next() {
+            return Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(first_class, Some(true), false)));
+        }
+        res
+    }
+
+    pub fn eval_env_user(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: Option<&Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    {
+        PythonArchEvalHooks::eval_env_model(session, "res.users", context, scope)
+    }
+
+    pub fn eval_env_company(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: Option<&Context>, _diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
+    {
+        PythonArchEvalHooks::eval_env_model(session, "res.company", context, scope)
+    }
+
     pub fn eval_env_get_item(session: &mut SessionInfo, _evaluation_sym: &EvaluationSymbol, context: Option<&Context>, diagnostics: &mut Vec<Diagnostic>, scope: Option<SymbolKey>) -> Option<EvaluationSymbolPtr>
     {
         let res = Some(EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(Wk::null(), Some(true), false)));
@@ -872,21 +980,7 @@ impl PythonArchEvalHooks {
             } else {
                 None
             };
-            if let Some(scope_file) = scope.and_then(|s| session.st().get_file(s)) {
-                //exclude orm files
-                if session.sync_odoo.version < (18, 1) {
-                    let env_files = session.sync_odoo.get_symbol(session.sync_odoo.config.odoo_path().as_ref().unwrap(), (&["odoo", "api"], &[]), u32::MAX);
-                    let env_file = *env_files.last().unwrap();
-                    if env_file != scope_file {
-                        session.st_mut().add_model_dependencies(scope_file, &model);
-                    }
-                } else {
-                    let tree = session.sync_odoo.get_main_entry_tree(scope_file);
-                    if !tree.0.starts_with_strs(&["odoo", "orm"]) {
-                        session.st_mut().add_model_dependencies(scope_file, &model);
-                    }
-                }
-            }
+            PythonArchEvalHooks::add_model_dependencies_outside_orm(session, scope, &model);
             let model = model.clone();
             let model = model.borrow();
             let mut symbols = model.get_main_symbols(session, from_module);

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -1355,9 +1355,21 @@ impl SymbolTable {
     }
 
     fn next_refs_variable(session: &mut SessionInfo, key: VariableKey, context: Option<&Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
+        let evaluations = session.sync_odoo.symbol_table[key].evaluations.clone();
+        Self::next_refs_of_evaluations(session, evaluations, context, symbol_context)
+    }
+
+    /* A property (including cached_property/lazy_property) exposes the type of its return value
+    when accessed as an attribute, so we follow the function's evaluations just like a variable's.
+    This also lets evaluation hooks placed on the property (e.g. Environment.user) contribute. */
+    fn next_refs_property_function(session: &mut SessionInfo, key: FunctionKey, context: Option<&Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
+        SyncOdoo::ensure_func_evaluations(session, key);
+        let evaluations = session.sync_odoo.symbol_table[key].evaluations.clone();
+        Self::next_refs_of_evaluations(session, evaluations, context, symbol_context)
+    }
+
+    fn next_refs_of_evaluations(session: &mut SessionInfo, evaluations: Vec<Evaluation>, context: Option<&Context>, symbol_context: &Context) -> Vec<EvaluationSymbolPtr> {
         let mut res = Vec::new();
-        let var_symbol = &session.sync_odoo.symbol_table[key];
-        let evaluations = var_symbol.evaluations.clone();
         let ctx = if let Some(context) = context {
             &Context::merge(symbol_context, context)
         } else {
@@ -1382,6 +1394,19 @@ impl SymbolTable {
         res
     }
 
+    /* /!\ we want to keep instance = True if the evaluation we are following was set to True! */
+    fn propagate_instance(next_refs: Vec<EvaluationSymbolPtr>, instance: Option<bool>) -> Vec<EvaluationSymbolPtr> {
+        if !instance.is_some_and(|instance| instance) {
+            return next_refs;
+        }
+        next_refs.into_iter().map(|mut next_ref| {
+            if let EvaluationSymbolPtr::WEAK(ref mut weak) | EvaluationSymbolPtr::SELF(ref mut weak) = next_ref {
+                weak.instance = Some(true);
+            }
+            next_ref
+        }).collect()
+    }
+
     /*given a Symbol, give all the Symbol that are evaluated as valid evaluation for it.
     example:
     ====
@@ -1398,6 +1423,7 @@ impl SymbolTable {
         match symbol_key {
             SymbolKey::Class(c) if !stop_on_type => Self::next_refs_class(session, c, context, symbol_context),
             SymbolKey::Variable(v) => Self::next_refs_variable(session, v, context, symbol_context),
+            SymbolKey::Function(f) if session.sync_odoo.symbol_table[f].is_property => Self::next_refs_property_function(session, f, context, symbol_context),
             _ => vec![],
         }
     }
@@ -1492,27 +1518,14 @@ impl SymbolTable {
                             SyncOdoo::build_now(session, file_symbol, BuildSteps::ARCH_EVAL);
                         }
                     }
-                    let mut next_sym_refs = Self::next_refs_variable(session, v, context, &next_ref_weak.context);
+                    let next_sym_refs = Self::next_refs_variable(session, v, context, &next_ref_weak.context);
                     if next_sym_refs.is_empty() {
                         // keep current evaluation
                         results.push(current_eval);
                         continue;
                     }
-                    // /!\ we want to keep instance = True if previous evaluation was set to True!
-                    if next_ref_weak_instance.is_some_and(|v| v) {
-                        next_sym_refs = next_sym_refs.into_iter().map(|mut next_results| {
-                           match next_results {
-                                EvaluationSymbolPtr::WEAK(ref mut weak)
-                                | EvaluationSymbolPtr::SELF(ref mut weak) =>  {
-                                    weak.instance = Some(true);
-                                },
-                                _ => {}
-                            }
-                            next_results
-                        }).collect();
-                    }
                     // enqueue evaluations to follow, replacing current evaluation
-                    work_queue.extend(next_sym_refs);
+                    work_queue.extend(Self::propagate_instance(next_sym_refs, next_ref_weak_instance));
                 },
                 SymbolKey::Class(c) if !stop_on_type => {
                     //On class, follow descriptor declarations
@@ -1524,6 +1537,16 @@ impl SymbolTable {
                         // enqueue evaluations to follow, replacing current evaluation
                         work_queue.extend(next_sym_refs);
                     }
+                },
+                SymbolKey::Function(f) if session.st()[f].is_property => {
+                    // A property reached mid-chain, e.g. through a variable holding it
+                    let next_sym_refs = Self::next_refs_property_function(session, f, context, &next_ref_weak.context);
+                    if next_sym_refs.is_empty() {
+                        // keep current evaluation
+                        results.push(current_eval);
+                        continue;
+                    }
+                    work_queue.extend(Self::propagate_instance(next_sym_refs, next_ref_weak_instance));
                 },
                 _ => {
                     results.push(current_eval);

--- a/server/tests/data/addons/module_1/models/__init__.py
+++ b/server/tests/data/addons/module_1/models/__init__.py
@@ -1,4 +1,5 @@
 from . import base_test_models
 from . import diagnostics
+from . import env_attr_probe
 from . import models
 from . import to_complete

--- a/server/tests/data/addons/module_1/models/env_attr_probe.py
+++ b/server/tests/data/addons/module_1/models/env_attr_probe.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class EnvAttrProbe(models.Model):
+    _name = "module_1.env_attr_probe"
+    _description = "Env Attr Probe"
+
+    def probe(self):
+        self.env.registry
+        self.env.user
+        self.env.user.has_group("base.group_user")
+        self.env.company
+        self.env.companies
+        self.env.lang
+        user = self.env.user
+        user
+        user.has_group("base.group_user")

--- a/server/tests/data/python/expressions/cached_property.py
+++ b/server/tests/data/python/expressions/cached_property.py
@@ -1,0 +1,27 @@
+import functools
+from functools import cached_property
+
+
+class Holder:
+    @functools.cached_property
+    def via_functools(self):
+        pass
+
+    @cached_property
+    def via_cached_bare(self):
+        pass
+
+    @tools.lazy_property
+    def via_lazy_attr(self):
+        pass
+
+    @lazy_property
+    def via_lazy_bare(self):
+        pass
+
+    def plain_method(self):
+        pass
+
+
+h = Holder()
+h.via_functools

--- a/server/tests/data/python/expressions/cached_property.py
+++ b/server/tests/data/python/expressions/cached_property.py
@@ -2,9 +2,18 @@ import functools
 from functools import cached_property
 
 
+class Inner:
+    def helper(self):
+        pass
+
+
 class Holder:
+    @property
+    def plain_prop(self) -> Inner:
+        pass
+
     @functools.cached_property
-    def via_functools(self):
+    def via_functools(self) -> Inner:
         pass
 
     @cached_property
@@ -25,3 +34,5 @@ class Holder:
 
 h = Holder()
 h.via_functools
+h.plain_prop.helper
+h.via_functools.helper

--- a/server/tests/test_cached_property.rs
+++ b/server/tests/test_cached_property.rs
@@ -6,6 +6,7 @@ use odoo_ls_server::core::symbols::symbol_keys::SymbolKey;
 use odoo_ls_server::utils::PathSanitizer;
 use std::env;
 use std::path::Path;
+use test_utils::get_resolved_symbols_at_position;
 
 /// `cached_property`/`lazy_property`, bare or attribute-accessed, must be handled as properties.
 /// Odoo declares `Environment.user`, `Environment.company`, ... with them.
@@ -25,6 +26,7 @@ fn test_cached_and_lazy_property_are_properties() {
         .expect("Failed to get file symbol");
 
     let cases = [
+        ("plain_prop", true),
         ("via_functools", true),
         ("via_cached_bare", true),
         ("via_lazy_attr", true),
@@ -44,10 +46,31 @@ fn test_cached_and_lazy_property_are_properties() {
     }
 
     // Hover presents a property, and not the signature of a method
-    let hover = test_utils::get_hover_markdown(&mut session, file_symbol, &file_info, 26, 4)
+    let hover = test_utils::get_hover_markdown(&mut session, file_symbol, &file_info, 35, 4)
         .unwrap_or_default();
     assert!(
         hover.contains("(property)") && !hover.contains("def via_functools"),
         "hover on h.via_functools should present it as a property, got: {hover:?}"
+    );
+
+    // An attribute chain through a property resolves to a member of the property's return type
+    let helper = session.sync_odoo.get_symbol(path.as_str(), (&[], &["Inner", "helper"]), u32::MAX);
+    assert!(!helper.is_empty(), "Inner.helper should be found in the test file");
+    let helper = helper[0];
+
+    // line 36: `h.plain_prop.helper`
+    let resolved = get_resolved_symbols_at_position(&mut session, file_symbol, &file_info, 36, 15);
+    assert!(
+        resolved.contains(&helper),
+        "h.plain_prop.helper should resolve to Inner.helper, got: {:?}",
+        resolved.iter().map(|&s| session.st().name(s).to_string()).collect::<Vec<_>>()
+    );
+
+    // line 37: `h.via_functools.helper`
+    let resolved = get_resolved_symbols_at_position(&mut session, file_symbol, &file_info, 37, 18);
+    assert!(
+        resolved.contains(&helper),
+        "h.via_functools.helper should resolve to Inner.helper, got: {:?}",
+        resolved.iter().map(|&s| session.st().name(s).to_string()).collect::<Vec<_>>()
     );
 }

--- a/server/tests/test_cached_property.rs
+++ b/server/tests/test_cached_property.rs
@@ -1,0 +1,53 @@
+mod setup;
+mod test_utils;
+
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::core::symbols::symbol_keys::SymbolKey;
+use odoo_ls_server::utils::PathSanitizer;
+use std::env;
+use std::path::Path;
+
+/// `cached_property`/`lazy_property`, bare or attribute-accessed, must be handled as properties.
+/// Odoo declares `Environment.user`, `Environment.company`, ... with them.
+#[test]
+fn test_cached_and_lazy_property_are_properties() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let path = env::current_dir()
+        .unwrap()
+        .join("tests/data/python/expressions/cached_property.py")
+        .sanitize();
+    setup::setup::prepare_custom_entry_point(&mut session, path.as_str());
+
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&path).unwrap();
+    let file_symbol = SyncOdoo::get_symbol_of_opened_file(&mut session, Path::new(&path))
+        .expect("Failed to get file symbol");
+
+    let cases = [
+        ("via_functools", true),
+        ("via_cached_bare", true),
+        ("via_lazy_attr", true),
+        ("via_lazy_bare", true),
+        ("plain_method", false),
+    ];
+    for (name, expected_property) in cases {
+        let syms = session.sync_odoo.get_symbol(path.as_str(), (&[], &["Holder", name]), u32::MAX);
+        assert!(!syms.is_empty(), "Holder.{name} should be found in the test file");
+        let SymbolKey::Function(func_key) = syms[0] else {
+            panic!("Holder.{name} should be a function symbol");
+        };
+        assert_eq!(
+            session.st()[func_key].is_property, expected_property,
+            "Holder.{name}: expected is_property = {expected_property}"
+        );
+    }
+
+    // Hover presents a property, and not the signature of a method
+    let hover = test_utils::get_hover_markdown(&mut session, file_symbol, &file_info, 26, 4)
+        .unwrap_or_default();
+    assert!(
+        hover.contains("(property)") && !hover.contains("def via_functools"),
+        "hover on h.via_functools should present it as a property, got: {hover:?}"
+    );
+}

--- a/server/tests/test_env_attributes.rs
+++ b/server/tests/test_env_attributes.rs
@@ -1,0 +1,130 @@
+mod setup;
+mod test_utils;
+
+use lsp_types::CompletionResponse;
+use odoo_ls_server::core::file_mgr::FileInfo;
+use odoo_ls_server::core::odoo::SyncOdoo;
+use odoo_ls_server::core::symbols::symbol_keys::SourceFileKey;
+use odoo_ls_server::features::completion::CompletionFeature;
+use odoo_ls_server::threads::SessionInfo;
+use odoo_ls_server::utils::PathSanitizer;
+use std::cell::RefCell;
+use std::env;
+use std::path::Path;
+use std::rc::Rc;
+use test_utils::get_resolved_symbols_at_position;
+
+fn resolved_names(
+    session: &mut SessionInfo,
+    file_symbol: SourceFileKey,
+    file_info: &Rc<RefCell<FileInfo>>,
+    line: u32,
+    character: u32,
+) -> Vec<String> {
+    get_resolved_symbols_at_position(session, file_symbol, file_info, line, character)
+        .iter()
+        .map(|&s| session.st().name(s).to_string())
+        .collect()
+}
+
+/// `self.env.user` / `company` / `companies` / `lang` must resolve to their real types, and an
+/// attribute chain through them (`self.env.user.has_group(...)`) to the model's member.
+#[test]
+fn test_env_attributes_resolve() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let test_addons_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("data").join("addons");
+    let test_file = test_addons_path
+        .join("module_1")
+        .join("models")
+        .join("env_attr_probe.py")
+        .sanitize();
+    assert!(Path::new(&test_file).exists(), "Test file does not exist: {test_file}");
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&test_file).unwrap();
+    let file_symbol = SyncOdoo::get_symbol_of_opened_file(&mut session, Path::new(&test_file))
+        .expect("Failed to get file symbol");
+
+    // self.env.user -> res.users (ResUsers on >=18.1, Users before)
+    let user = resolved_names(&mut session, file_symbol, &file_info, 9, 18);
+    assert!(!user.is_empty(), "self.env.user should resolve to the res.users class, got nothing");
+
+    // self.env.user.has_group -> res.users method `has_group`, through the cached_property
+    let has_group = resolved_names(&mut session, file_symbol, &file_info, 10, 23);
+    assert!(
+        has_group.iter().any(|n| n == "has_group"),
+        "self.env.user.has_group should resolve to the res.users method has_group, got: {has_group:?}"
+    );
+
+    // self.env.company and self.env.companies -> res.company
+    let company = resolved_names(&mut session, file_symbol, &file_info, 11, 18);
+    let companies = resolved_names(&mut session, file_symbol, &file_info, 12, 18);
+    assert!(!company.is_empty(), "self.env.company should resolve to the res.company class");
+    assert_eq!(
+        company, companies,
+        "self.env.companies should resolve to the same class as self.env.company"
+    );
+    assert_ne!(
+        user, company,
+        "self.env.user and self.env.company should resolve to different model classes"
+    );
+
+    // self.env.lang -> str
+    let lang = resolved_names(&mut session, file_symbol, &file_info, 13, 18);
+    assert!(
+        lang.iter().any(|n| n == "str"),
+        "self.env.lang should resolve to str, got: {lang:?}"
+    );
+}
+
+/// A property reached through a variable (`user = self.env.user; user.has_group(...)`) must resolve
+/// just like the direct chain, by following the property mid-chain in `follow_ref`.
+#[test]
+fn test_env_user_through_variable_resolves() {
+    let (mut odoo, config) = setup::setup::setup_server(true);
+    let test_addons_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("data").join("addons");
+    let test_file = test_addons_path
+        .join("module_1")
+        .join("models")
+        .join("env_attr_probe.py")
+        .sanitize();
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let file_mgr = session.sync_odoo.get_file_mgr();
+    let file_info = file_mgr.borrow().get_file_info(&test_file).unwrap();
+    let file_symbol = SyncOdoo::get_symbol_of_opened_file(&mut session, Path::new(&test_file))
+        .expect("Failed to get file symbol");
+
+    // (a) the `user` variable resolves to the res.users class, and not to the property function
+    let user_var = resolved_names(&mut session, file_symbol, &file_info, 15, 8);
+    assert!(
+        !user_var.is_empty() && !user_var.iter().any(|n| n == "user"),
+        "the `user` variable should resolve to the res.users class, got: {user_var:?}"
+    );
+
+    // (b) its hover type presents the model class, and not `Any`
+    let hover = test_utils::get_hover_markdown(&mut session, file_symbol, &file_info, 15, 8)
+        .unwrap_or_default();
+    assert!(
+        hover.contains(&format!("(variable) user: {}", user_var[0])) && !hover.contains(": Any"),
+        "hover on the `user` variable should show its model type, got: {hover:?}"
+    );
+
+    // (c) `user.has_group` resolves to the res.users method through the variable
+    let has_group = resolved_names(&mut session, file_symbol, &file_info, 16, 15);
+    assert!(
+        has_group.iter().any(|n| n == "has_group"),
+        "user.has_group should resolve to the res.users method has_group, got: {has_group:?}"
+    );
+
+    // (d) completion on `user.` lists members of the resolved model
+    let response = CompletionFeature::autocomplete(&mut session, file_symbol, &file_info, None, 16, 13);
+    let labels: Vec<String> = match response {
+        Some(CompletionResponse::Array(items)) => items.into_iter().map(|i| i.label).collect(),
+        Some(CompletionResponse::List(list)) => list.items.into_iter().map(|i| i.label).collect(),
+        None => vec![],
+    };
+    assert!(
+        labels.iter().any(|l| l == "has_group"),
+        "completion on `user.` should list res.users members such as has_group, got: {labels:?}"
+    );
+}


### PR DESCRIPTION
`self.env.user` and other properties on `env` resolved to nothing: hovering them showed a function, and chains through them (`self.env.user.has_group(...)`, or through a variable) resolved to nothing at all.

Three things were in the way, one per commit: 
- `@functools.cached_property` was not recognized as a property, so Odoo's `Environment.user`/`company`/`companies`/`lang` were plain methods
- `follow_ref` never descended into a property, so reading one as an attribute gave the function instead of the type it returns, for every property and not only Odoo's
- Their annotations are useless anyway (`BaseModel`, `str | None`), so `user`/`company` now resolve their model from the model index at evaluation time, like `self.env["res.users"]` already does.

Unrelated but noticed on the way: the `Environment.registry` file hook no longer does anything from 18.1 on. `registry` became a property there, and a file hook on a function is overwritten by `handle_func_evaluations` from the return annotation, which is why it kept looking fine (`-> Registry` does the job on its own). It is still what types `registry` on 17.0, where it is a plain attribute without annotation, so I left it alone.