### PR TITLE
[FIX] assume text_document can be void

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:devblogs.microsoft.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)"
+    ]
+  }
+}

--- a/server/src/core/csv_validation.rs
+++ b/server/src/core/csv_validation.rs
@@ -41,7 +41,10 @@ impl CsvValidator {
             session.st_mut().set_build_status(csv_symbol.into(), BuildSteps::VALIDATION, BuildStatus::INVALID);
             return;
         };
-        let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+        let Some(data) = file_info.borrow().file_info_ast.borrow().text_document.as_ref().map(|td| td.contents().to_string()) else {
+            // File can be invalid (not valid UTF-8 and so text_document is empty)
+            return;
+        };
         let model_name_pb = Path::new(&path);
         let model_name = model_name_pb.file_stem().unwrap().to_str().unwrap();
         let csv_module = session.st().find_module(csv_symbol);

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -57,11 +57,10 @@ impl ModuleSymbol {
                 let csv_sym = session.st_mut().add_new_csv_file(symbol_key, &file_name, &path_string);
                 Self::on_data_file_load(session.st(), csv_sym.into());
                 session.st_mut().add_dependency(symbol_key.into(), csv_sym.into(), BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
-                if file_info.file_info_ast.borrow().text_document.as_ref().is_none() {
-                    //TODO do we want to add a diagnostic here?
+                let Some(data) = file_info.file_info_ast.borrow().text_document.as_ref().map(|td| td.contents().to_string()) else {
+                    // File can be invalid (not valid UTF-8 and so text_document is empty)
                     continue;
-                }
-                let data = file_info.file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+                };
                 let mut csv_builder = CsvArchBuilder::new();
                 let diagnostics = csv_builder.load_csv(session, csv_sym, &data);
                 file_info.replace_diagnostics(DiagnosticSource::CSV_SYNTAX, diagnostics);
@@ -155,8 +154,7 @@ impl ModuleSymbol {
             let (_, file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, file_path_str.as_ref(), None, None, false); //create ast if not in cache
             let mut file_info = file_info.borrow_mut();
             file_info.publish_diagnostics(session);
-            if file_info.file_info_ast.borrow().text_document.as_ref().is_none() {
-                //TODO do we want to add a diagnostic here?
+            if file_info.file_info_ast.borrow().text_document.as_ref().is_none() { // File can be invalid (not valid UTF-8 and so text_document is empty)
                 continue;
             }
             ModuleSymbol::load_xml_arch(session, xml_sym, &mut file_info, true);
@@ -164,8 +162,11 @@ impl ModuleSymbol {
     }
 
     fn load_xml_arch(session: &mut SessionInfo, xml_sym: XmlFileKey, file_info: &mut FileInfo, web_asset: bool) {
+        let Some(data) = file_info.file_info_ast.borrow().text_document.as_ref().map(|td| td.contents().to_string()) else {
+            // File can be invalid (not valid UTF-8 and so text_document is empty)
+            return;
+        };
         //That's a little bit crappy, but the SYNTAX step of XML files are done here, as lifetime of roXMLTree are not flexible enough to be separated from the Arch building
-        let data = file_info.file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
         let document = roxmltree::Document::parse(&data);
         if let Ok(document) = document {
             file_info.replace_diagnostics(DiagnosticSource::XML_SYNTAX, vec![]);

--- a/server/src/features/document_symbols.rs
+++ b/server/src/features/document_symbols.rs
@@ -34,7 +34,7 @@ impl DocumentSymbolFeature {
                 DocumentSymbolFeature::visit_stmt(session, stmt, &mut results, file_info);
             }
         } else if file_info_bw.uri.ends_with(".xml") {
-            let data = file_info_ast.text_document.as_ref().unwrap().contents();
+            let data = file_info_ast.text_document.as_ref()?.contents();
             let document = roxmltree::Document::parse(data);
             if let Ok(document) = document {
                 DocumentSymbolFeature::visit_xml_document(session, document, &mut results, file_info);

--- a/server/src/features/goto_utils.rs
+++ b/server/src/features/goto_utils.rs
@@ -209,7 +209,10 @@ impl GotoUtils {
         character: u32
     ) -> Vec<GotoSource> {
         let offset = file_info.borrow().position_to_offset(line, character, session.sync_odoo.encoding);
-        let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+        let Some(data) = file_info.borrow().file_info_ast.borrow().text_document.as_ref().map(|td| td.contents().to_string()) else {
+            // File can be invalid (not valid UTF-8 and so text_document is empty)
+            return vec![];
+        };
         let document = roxmltree::Document::parse(&data);
         let mut sources = vec![];
         if let Ok(document) = document {
@@ -237,7 +240,10 @@ impl GotoUtils {
         let model_name_pb = Path::new(session.st().path(file_symbol));
         let model_name = Sy!(model_name_pb.file_stem().unwrap().to_str().unwrap().to_string());
         let offset = file_info.borrow().position_to_offset(line, character, session.sync_odoo.encoding);
-        let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+        let Some(data) = file_info.borrow().file_info_ast.borrow().text_document.as_ref().map(|td| td.contents().to_string()) else {
+            // File can be invalid (not valid UTF-8 and so text_document is empty)
+            return vec![];
+        };
         let mut csv_reader = csv::ReaderBuilder::new().quoting(true).from_reader(data.as_bytes());
 
         CsvAstUtils::get_symbols(session, file_symbol.unwrap_csv_file_key(), &mut csv_reader, &model_name, offset, &data)

--- a/server/src/features/hover.rs
+++ b/server/src/features/hover.rs
@@ -42,7 +42,7 @@ impl HoverFeature {
 
     pub fn hover_xml(session: &mut SessionInfo, file_symbol: SourceFileKey, file_info: &Rc<RefCell<FileInfo>>, line: u32, character: u32) -> Option<Hover> {
         let offset = file_info.borrow().position_to_offset(line, character, session.sync_odoo.encoding);
-        let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+        let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref()?.contents().to_string();
         let document = match roxmltree::Document::parse(&data) {
             Ok(doc) => doc,
             Err(_) => {

--- a/server/src/features/references.rs
+++ b/server/src/features/references.rs
@@ -149,7 +149,7 @@ impl ReferenceFeature {
                                 locations.extend(ReferenceFeature::references_in_file(session, file, &dep_file_info, &ReferenceTarget::Symbol(definition_source)));
                             },
                             SourceFileKey::XmlFile(xml_file) => {
-                                let data = dep_file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+                                let data = dep_file_info.borrow().file_info_ast.borrow().text_document.as_ref()?.contents().to_string();
                                 let document = roxmltree::Document::parse(&data);
                                 if let Ok(document) = document {
                                     let root = document.root_element();
@@ -158,7 +158,7 @@ impl ReferenceFeature {
                             },
                             SourceFileKey::CsvFile(csv_file) => {
                                 if SymbolTable::is_field(session, definition_source) {
-                                    let data = dep_file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+                                    let data = dep_file_info.borrow().file_info_ast.borrow().text_document.as_ref()?.contents().to_string();
                                     let mut csv_reader = csv::ReaderBuilder::new().from_reader(data.as_bytes());
                                     let model_class = session.st().get_in_parents(definition_source, &[SymType::CLASS], true);
                                     if let Some(SymbolKey::Class(model_class)) = model_class
@@ -225,7 +225,7 @@ impl ReferenceFeature {
                                     locations.extend(ReferenceFeature::references_in_file(session, source_file, &file_info, &ReferenceTarget::String(full_xml_id)));
                                 },
                                 SourceFileKey::XmlFile(xml_file) => {
-                                    let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+                                    let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref()?.contents().to_string();
                                     let document = roxmltree::Document::parse(&data);
                                     if let Ok(document) = document {
                                         let root = document.root_element();
@@ -233,7 +233,7 @@ impl ReferenceFeature {
                                     }
                                 },
                                 SourceFileKey::CsvFile(csv_file) => {
-                                    let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+                                    let data = file_info.borrow().file_info_ast.borrow().text_document.as_ref()?.contents().to_string();
                                     let mut csv_reader = csv::ReaderBuilder::new().from_reader(data.as_bytes());
                                     locations.extend(CsvAstReferenceVisitor::search_target(session, csv_file, &mut csv_reader, None, &ReferenceTarget::String(full_xml_id), &data));
                                 },


### PR DESCRIPTION
text_document on file_info_ast can be empty (if file stream is invalid, ie not valid UTF-8), but some places in the code were assuming that text_document is always present