### PR TITLE
[FIX] follow_ref crash on 16-17

### DIFF
--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -838,6 +838,9 @@ impl PythonArchEval {
                         for eval_iter in eval_iter_node.iter() {
                             let eval_symbol = eval_iter.symbol.get_symbol(session, None, &mut vec![], None);
                             let symbol_eval = SymbolTable::follow_ref(&eval_symbol, session, None, false, false, None, None);
+                            if symbol_eval.is_empty() { //usually we expect follow_ref to return something, but that's not the case right now. This guard prevents crashes.
+                                continue;
+                            }
                             let Some(symbol_type) = symbol_eval[0].upgrade_weak(session.st()) else {continue};
                             let context = Context::from_iter([(ContextKey::ParentFor, ContextValue::SYMBOL(symbol_type.into()))]);
                             let symbol = eval_iter.symbol.get_symbol_as_weak(session, Some(&context), &mut vec![], None);


### PR DESCRIPTION
Crash fix to be merged in 1.5.1.
NOT SOLVING THE REAL ISSUE, but reverting the behavior to the 1.4.0, that was allowing this 'bug' without crashing.

Need to fix in 1.5.2: Follow_ref should always return a value, and cycle detection is wrong, as
field -> many2one (with 'related' context) -> related field -> Many2one (with 'model' context) -> field
is triggering the cycle detection and aborting, but that's a valid flow