### PR TITLE
Fix config errors

### DIFF
--- a/server/src/core/config/build.rs
+++ b/server/src/core/config/build.rs
@@ -223,6 +223,12 @@ fn merge_child_wins(child: &Profile, parent: &Profile) -> Profile {
     // `abstract_` is intrinsic to a profile and is NOT inherited via `extends`
     // (a concrete child of a ${splitVersion} parent stays concrete).
     result.abstract_ = child.abstract_;
+    result.warnings = child
+        .warnings
+        .iter()
+        .chain(parent.warnings.iter())
+        .cloned()
+        .collect();
     for key in keys_union(child, parent) {
         if let Some(value) = merge_value(key, child.get(key), parent.get(key), child) {
             result.values.insert(key, value);
@@ -393,6 +399,7 @@ fn merge_ws_profile(a: &Profile, b: &Profile, name: &str) -> Result<Profile, Str
         (x, y) => y.or(x),
     };
     result.abstract_ = a.abstract_ || b.abstract_;
+    result.warnings = a.warnings.iter().chain(b.warnings.iter()).cloned().collect();
     for key in keys_union(a, b) {
         let merged = match (a.get(key), b.get(key)) {
             (Some(x), Some(y)) => merge_ws_value(key, x, y, name)?,

--- a/server/src/core/config/build.rs
+++ b/server/src/core/config/build.rs
@@ -83,6 +83,18 @@ fn build_profiles(session: &mut SessionInfo) -> Result<ProfileSet, String> {
         profile_sets.push(resolve_workspace(ws, &unique_ws)?);
     }
 
+    // No config file and no workspace folders: nothing to resolve from, but we
+    // still need a usable "default" profile (odoo_path/addons_paths stay unset
+    // rather than being auto-detected).
+    if profile_sets.is_empty() {
+        let mut seed: ProfileSet = HashMap::default();
+        seed.insert(
+            DEFAULT_PROFILE_NAME.to_string(),
+            Profile::new(DEFAULT_PROFILE_NAME),
+        );
+        profile_sets.push(seed);
+    }
+
     // Merge across sources: scalars must agree or error
     let mut acc: ProfileSet = HashMap::default();
     for profile_set in profile_sets {

--- a/server/src/core/config/parse.rs
+++ b/server/src/core/config/parse.rs
@@ -20,18 +20,19 @@ use super::value::{
 
 /// Parse one config file into its profiles, tagging every value with `path`.
 pub(super) fn parse_file(path: &Path) -> Result<Vec<Profile>, String> {
-    let contents = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let contents = fs::read_to_string(path).map_err(|e| format!("{}: {e}", path.sanitize()))?;
     let source = path.sanitize();
-    let root: toml::Value = toml::from_str(&contents).map_err(|e| e.to_string())?;
+    let root: toml::Value =
+        toml::from_str(&contents).map_err(|e| format!("{source}: {e}"))?;
 
     let mut profiles = Vec::new();
     let entries = match root.get("config") {
         // No `config` array at all: an empty file is valid (no profiles).
         None => return Ok(profiles),
         // A `config` key of the wrong shape is a mistake, not "no config".
-        Some(value) => value
-            .as_array()
-            .ok_or_else(|| "'config' must be an array of tables ([[config]])".to_string())?,
+        Some(value) => value.as_array().ok_or_else(|| {
+            format!("{source}: 'config' must be an array of tables ([[config]])")
+        })?,
     };
     for entry in entries {
         profiles.push(parse_entry(entry, &source)?);
@@ -42,18 +43,23 @@ pub(super) fn parse_file(path: &Path) -> Result<Vec<Profile>, String> {
 fn parse_entry(entry: &toml::Value, source: &str) -> Result<Profile, String> {
     let table = entry
         .as_table()
-        .ok_or_else(|| "a [[config]] entry must be a table".to_string())?;
+        .ok_or_else(|| format!("{source}: a [[config]] entry must be a table"))?;
 
-    let name = table
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(DEFAULT_PROFILE_NAME)
-        .to_string();
+    let name = match table.get("name") {
+        Some(v) => as_str_field(v, "name")
+            .map_err(|e| format!("{source}: {e}"))?
+            .to_string(),
+        None => DEFAULT_PROFILE_NAME.to_string(),
+    };
     let mut profile = Profile::new(name);
-    profile.extends = table
-        .get("extends")
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
+    profile.extends = match table.get("extends") {
+        Some(v) => Some(
+            as_str_field(v, "extends")
+                .map_err(|e| format!("{source}: profile '{}': {e}", profile.name))?
+                .to_string(),
+        ),
+        None => None,
+    };
 
     for (raw_key, value) in table {
         if raw_key == "name" || raw_key == "extends" {
@@ -62,11 +68,16 @@ fn parse_entry(entry: &toml::Value, source: &str) -> Result<Profile, String> {
         let Some(key) = ConfigKey::from_name(raw_key) else {
             // An unknown key is ignored rather than fatal: a typo, a forward- or
             // backward-compatibility key, or a panel-only field (e.g. `abstract`)
-            // must not discard the user's entire configuration.
-            warn!("ignoring unknown config key '{raw_key}' in {source}");
+            // must not discard the user's entire configuration. It is still
+            // reported (not just logged) so the user can spot the typo.
+            let msg = format!("unknown config key '{raw_key}' in {source} (ignored)");
+            warn!("{msg}");
+            profile.warnings.push(msg);
             continue;
         };
-        if let Some(parsed) = parse_value(key, value, source)? {
+        let parsed = parse_value(key, value, source)
+            .map_err(|e| format!("{source}: profile '{}': {e}", profile.name))?;
+        if let Some(parsed) = parsed {
             profile.values.insert(key, parsed);
         }
     }

--- a/server/src/core/config/render.rs
+++ b/server/src/core/config/render.rs
@@ -31,6 +31,8 @@ pub struct ProfileView {
     /// Settings the user gave explicitly but which failed resolution — shown in
     /// the panel (with their failure note) even though they are not used.
     rejected: HashMap<ConfigKey, Vec<Sourced<String>>>,
+    /// Parse-time notes not tied to a single field (e.g. an unknown key).
+    warnings: Vec<String>,
 }
 
 impl ProfileView {
@@ -61,7 +63,14 @@ impl ProfileView {
     /// 2 if none did. Profile is separate from the message so the client can
     /// scope display to whichever profile is selected.
     fn diagnostic_messages(&self) -> impl Iterator<Item = (u8, String, &str)> + '_ {
-        self.rejected.iter().flat_map(move |(key, rejected)| {
+        let warnings = self.warnings.iter().map(move |w| {
+            (
+                1,
+                format!("Config profile '{}': {w}", self.name),
+                self.name.as_str(),
+            )
+        });
+        let rejected = self.rejected.iter().flat_map(move |(key, rejected)| {
             let effective = self.values.get(key);
             let (level, outcome) = match effective {
                 // A list can survive the rejection with zero valid entries left —
@@ -93,7 +102,8 @@ impl ProfileView {
                     self.name.as_str(),
                 )
             })
-        })
+        });
+        warnings.chain(rejected)
     }
 
     /// JSON shape consumed by the renderer and by serialization:
@@ -276,6 +286,7 @@ impl ConfigView {
                 abstract_: p.abstract_,
                 values: p.values.clone(),
                 rejected: p.rejected.clone(),
+                warnings: p.warnings.clone(),
             })
             .collect();
         ConfigView { configs }

--- a/server/src/core/config/value.rs
+++ b/server/src/core/config/value.rs
@@ -411,6 +411,9 @@ pub(crate) struct Profile {
     pub values: ValuesMap,
     // Retained to be shown in the config panel, but not used by the runtime
     pub rejected: HashMap<ConfigKey, Vec<Sourced<String>>>,
+    /// Non-fatal parse-time notes not tied to a single field (e.g. an unknown
+    /// `[[config]]` key) — surfaced to the user via `ConfigView::diagnostic_messages`.
+    pub warnings: Vec<String>,
 }
 
 impl Profile {

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1790,6 +1790,14 @@ impl Odoo {
             },
             Err(e) => {
                 session.show_message(MessageType::ERROR, format!("Unable to load config: {}  \n\nPlease select a correct profile or fix the issues in the config", e));
+                // The popup is transient; also record it as a persistent diagnostic so
+                // it stays visible in the status bar/tooltip until the config is fixed.
+                session.send_config_diagnostic(ConfigDiagnosticAction::EXTEND, &[
+                    ConfigDiagnosticMessage {
+                        level: ConfigDiagnosticMessageLevel::ERROR,
+                        message: format!("Unable to load config: {e}"),
+                    }
+                ]);
                 error!(e);
             }
         }
@@ -2684,7 +2692,15 @@ impl Odoo {
                     // Invalid config, send a notification to the user and add the error to the logs
                     let msg = format!("Invalid configuration file: {err}.");
                     error!("{msg}");
-                    session.show_message(MessageType::ERROR, msg);
+                    session.show_message(MessageType::ERROR, msg.clone());
+                    // The popup is transient; also record it as a persistent diagnostic so
+                    // it stays visible in the status bar/tooltip until the config is fixed.
+                    session.send_config_diagnostic(ConfigDiagnosticAction::EXTEND, &[
+                        ConfigDiagnosticMessage {
+                            level: ConfigDiagnosticMessageLevel::ERROR,
+                            message: msg,
+                        }
+                    ]);
                 }
             }
             true

--- a/server/tests/config_tests.rs
+++ b/server/tests/config_tests.rs
@@ -1546,6 +1546,55 @@ fn invalid_merge_method_value_errors() {
         "unexpected error: {err}");
 }
 
+/// A field-type error names the offending file and profile, not just the field,
+/// so the user can find the mistake without guessing.
+#[test]
+fn field_type_error_names_file_and_profile() {
+    let mut c = Cfg::new();
+    let ws = c.ws("ws1");
+    write_odools(&ws, "[[config]]\nname = \"myprofile\"\npython_path = 123\n");
+
+    let err = c.err();
+    assert!(err.contains("odools.toml"), "error should name the config file: {err}");
+    assert!(err.contains("myprofile"), "error should name the profile: {err}");
+    assert!(err.contains("python_path"), "unexpected error: {err}");
+}
+
+/// A TOML syntax error names the offending file, not just the parser's
+/// line/column, so the user can find which `odools.toml` is broken.
+#[test]
+fn toml_syntax_error_names_the_file() {
+    let mut c = Cfg::new();
+    let ws = c.ws("ws1");
+    write_odools(&ws, "[[config]\nname = \"default\"\n");
+
+    let err = c.err();
+    assert!(err.contains("odools.toml"), "error should name the config file: {err}");
+}
+
+/// An unknown key does not fail resolution, but is surfaced as a status-bar
+/// warning (not just an internal log) so the user can spot the typo.
+#[test]
+fn unknown_config_key_is_reported_as_diagnostic() {
+    let mut cfg = Cfg::new();
+    let ws = cfg.ws("ws");
+    write_odools(&ws, r#"[[config]]
+name = "default"
+totally_unknown_key = "whatever"
+"#);
+
+    let messages: Vec<String> = cfg
+        .view()
+        .diagnostic_messages()
+        .iter()
+        .map(|v| v["message"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        messages.iter().any(|m| m.contains("totally_unknown_key") && m.contains("odools.toml")),
+        "expected a diagnostic naming the unknown key and file, got: {messages:?}"
+    );
+}
+
 /// The standalone extra config file (config_path) is merged with the workspace config:
 /// its scalars apply and its addons_paths merge with the workspace's.
 #[test]

--- a/server/tests/config_tests.rs
+++ b/server/tests/config_tests.rs
@@ -1560,6 +1560,33 @@ fn field_type_error_names_file_and_profile() {
     assert!(err.contains("python_path"), "unexpected error: {err}");
 }
 
+/// `name` must be a string — a non-string `name` (e.g. an integer) must not be
+/// silently swallowed into the "default" profile.
+#[test]
+fn non_string_name_errors() {
+    let mut c = Cfg::new();
+    let ws = c.ws("ws1");
+    write_odools(&ws, "[[config]]\nname = 123\n");
+
+    let err = c.err();
+    assert!(err.contains("odools.toml"), "error should name the config file: {err}");
+    assert!(err.contains("'name' must be a string"), "unexpected error: {err}");
+}
+
+/// `extends` must be a string — a non-string `extends` must not be silently
+/// dropped (which would leave the profile un-extended with no explanation).
+#[test]
+fn non_string_extends_errors() {
+    let mut c = Cfg::new();
+    let ws = c.ws("ws1");
+    write_odools(&ws, "[[config]]\nname = \"default\"\nextends = 123\n");
+
+    let err = c.err();
+    assert!(err.contains("odools.toml"), "error should name the config file: {err}");
+    assert!(err.contains("default"), "error should name the profile: {err}");
+    assert!(err.contains("'extends' must be a string"), "unexpected error: {err}");
+}
+
 /// A TOML syntax error names the offending file, not just the parser's
 /// line/column, so the user can find which `odools.toml` is broken.
 #[test]

--- a/server/tests/config_tests.rs
+++ b/server/tests/config_tests.rs
@@ -2301,6 +2301,18 @@ fn malformed_config_missing_required_fields_defaults_to_default() {
     assert!(cfg.ok().0.contains_key("default"));
 }
 
+/// No workspace folders and no config file: still yields a usable "default"
+/// entry (odoo_path/addons_paths simply stay unset, nothing to auto-detect from).
+#[test]
+fn no_workspace_no_config_falls_back_to_default() {
+    let cfg = Cfg::new();
+    let (map, _view) = cfg.ok();
+    assert!(map.contains_key("default"));
+    let config = cfg.default();
+    assert!(config.odoo_path().is_none());
+    assert!(config.addons_paths().is_empty());
+}
+
 #[test]
 fn auto_refresh_delay_clamped_to_bounds() {
     let mut cfg = Cfg::new();


### PR DESCRIPTION
1. Use default config if there are workspace folders or config file path
2. Log invalid names in config file to the client