### PR TITLE
[IMP] Emit line tables in the Windows PDB

### DIFF
--- a/.github/workflows/Build-release.yml
+++ b/.github/workflows/Build-release.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Build
         working-directory: server
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: ${{ contains(matrix.target, 'windows') && 'line-tables-only' || '0' }}
         run: cargo build --bin odoo_ls_server --release --target ${{ matrix.target }}
 
       - name: Build schema
@@ -214,4 +216,3 @@ jobs:
             ./artifacts/*.tar.gz \
             ./artifacts/config_schema/config_schema.json \
             ./typeshed.zip
-


### PR DESCRIPTION
The release profile does not set `debug`, so the PDB we ship has no function records, line tables or inline sites for our own code. dbghelp then falls back to the nearest preceding public symbol, which is why Windows crash reports show impossible stacks with no file/line on any of our frames.

Set CARGO_PROFILE_RELEASE_DEBUG=line-tables-only, for the Windows targets only. The debug info lands in the PDB, which we already ship, so the .exe and its runtime performance are unchanged.

Tested:
- the override reaches rustc as -C debuginfo=line-tables-only, while the '0' branch emits no flag at all, leaving the six non-Windows jobs byte-identical;
- compiled for x86_64-pc-windows-msvc, the flag emits S_GPROC32_ID, Lines, InlineeLines and S_INLINESITE records -- exactly the subsections missing from our compiland in the 1.5.1 PDB but already present, in that same PDB, for the precompiled Rust standard library.