### PR TITLE
[REF] lifecycle: parent enum

### DIFF
--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::{cell::RefCell, cmp, path::PathBuf, rc::Rc};
 use crate::constants::MissingDataSource;
+use crate::core::symbols::storage::FileSystemSymbolParent;
 use crate::utils::HashMap;
 
 use slotmap::Key;
@@ -74,14 +75,14 @@ impl EntryPointMgr {
      * /!\ path must point to a directory on disk */
     pub fn create_dir_symbols_from_path_to_entry(session: &mut SessionInfo, path: &Path, entry: Rc<RefCell<EntryPoint>>) -> Option<SymbolKey> {
         let mut iter_path = PathBuf::new();
-        let mut current_sym: SymbolKey = entry.borrow().root.into();
+        let mut current_sym: FileSystemSymbolParent = entry.borrow().root.into();
         let component_count = path.components().count();
         for component in path.components().take(component_count - 1) {
             iter_path.push(component);
             if let Some(name) = component.as_os_str().to_str() {
-                let sym = session.st().get_module_symbol(current_sym, name);
+                let sym = current_sym.get_child(session.st(), name);
                 if let Some(existing_sym) = sym {
-                    current_sym = existing_sym;
+                    current_sym = existing_sym.try_into().expect("Expected existing_sym to be a DiskDirKey");
                 } else {
                     let disk_dir = session.st_mut().add_new_disk_dir(current_sym, name, iter_path.to_str().unwrap());
                     current_sym = disk_dir.into();

--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -539,7 +539,8 @@ impl Evaluation {
     * should be equal to vec![vec![], vec![]] to be able to get arch and arch_eval deps at index 0 and 1. It means that if validation is
     * not build but required during the eval_from_ast, it will NOT be built
     */
-    pub fn eval_from_ast(session: &mut SessionInfo, ast: &Expr, parent: SymbolKey, max_infer: &TextSize, for_annotation: bool, required_dependencies: &mut Vec<Vec<SourceFileKey>>) -> (Vec<Evaluation>, Vec<Diagnostic>) {
+    pub fn eval_from_ast(session: &mut SessionInfo, ast: &Expr, parent: impl Into<SymbolKey>, max_infer: &TextSize, for_annotation: bool, required_dependencies: &mut Vec<Vec<SourceFileKey>>) -> (Vec<Evaluation>, Vec<Diagnostic>) {
+        let parent = parent.into();
         let from_module;
         if let Some(module) = session.sync_odoo.symbol_table.find_module(parent) {
             from_module = ContextValue::MODULE(module.into());

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use ruff_text_size::TextRange;
 use ruff_python_ast::{Alias, AtomicNodeIndex, Identifier};
-use crate::core::symbols::storage::SymbolTable;
+use crate::core::symbols::storage::{FileSystemSymbolParent, SymbolTable};
 use crate::core::symbols::symbol_keys::{ModuleKey, NamespaceKey, SourceFileKey, SymbolKey};
 use crate::{constants::*, oyarn, Sy, S};
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
@@ -295,11 +295,12 @@ fn get_or_create_symbol(
             Some(ref symbols) => {
                 let mut next_symbol = vec![];
                 for &s in symbols.iter() {
-                    let mut current_batch_symbol = session.st().get_module_symbol(s, branch);
-                    if current_batch_symbol.is_none() && matches!(s, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
-                        current_batch_symbol = resolve_new_symbol(session, s, branch, asname).ok()
+                    if let Ok(parent) = FileSystemSymbolParent::try_from(s) {
+                        let current_batch_symbol = parent
+                            .get_child(session.st(), branch)
+                            .or_else(|| resolve_new_symbol(session, parent, branch, asname).ok());
+                        next_symbol.extend(current_batch_symbol);
                     }
-                    next_symbol.extend(current_batch_symbol);
                 }
                 if next_symbol.is_empty() {
                     syms = None;
@@ -339,10 +340,12 @@ fn get_or_create_symbol(
                     if ((entry.borrow().is_public() && level == 0) || entry.borrow().is_valid_for(from_path)) && entry.borrow().addon_to_odoo_path.is_none() {
                         let entry_point = entry.borrow().get_symbol(session.st());
                         if let Some(entry_point) = entry_point {
-                            let mut next_symbol = session.st().get_module_symbol(entry_point, branch);
-                            if next_symbol.is_none() && matches!(entry_point, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::Compiled(_) | SymbolKey::DiskDir(_)) {
-                                next_symbol = resolve_new_symbol(session, entry_point, branch, asname).ok()
-                            }
+                            let Ok(parent) = FileSystemSymbolParent::try_from(entry_point) else {
+                                continue;
+                            };
+                            let next_symbol = parent
+                                .get_child(session.st(), branch)
+                                .or_else(|| resolve_new_symbol(session, parent, branch, asname).ok());
                             let Some(next_symbol) = next_symbol else {
                                 continue;
                             };
@@ -384,17 +387,17 @@ fn get_or_create_symbol(
 
 /// Resolve a new symbol from disk, creating it if found, or just creating a COMPILED symbol if a parent is COMPILED
 /// parent : parent symbol where to search, either ROOT, NAMESPACE, PACKAGE, COMPILED or DISK_DIR
-fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_name: &OYarn, asname: Option<&str>) -> Result<SymbolKey, &'static str> {
+fn resolve_new_symbol(session: &mut SessionInfo, parent: FileSystemSymbolParent, imported_name: &OYarn, asname: Option<&str>) -> Result<SymbolKey, &'static str> {
     if imported_name.is_empty() {
         return Err("Empty name");
     }
     let sym_name = asname.unwrap_or(imported_name.as_str());
     // COMPILED: we can only create a COMPILED symbol
-    if matches!(parent, SymbolKey::Compiled(_)) {
+    if matches!(parent, FileSystemSymbolParent::Compiled(_)) {
         return Ok(session.st_mut().add_new_compiled(parent, sym_name, "").into());
     }
     // ROOT, NAMESPACE, PACKAGE or DISK_DIR: we can search on disk
-    'paths: for path in session.st().paths(parent) {
+    'paths: for path in session.st().paths(parent.into()) {
         let is_stub = session.sync_odoo.stubs_dirs.contains(&path);
         let mut full_path = PathBuf::from(path);
         full_path.push(imported_name.as_str());
@@ -434,7 +437,7 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: SymbolKey, imported_nam
             continue;
         }
         // Try as compiled
-        if !is_stub && !matches!(parent, SymbolKey::Root(_)) {
+        if !is_stub && !matches!(parent, FileSystemSymbolParent::Root(_)) {
             // Probe the suffixes CPython itself accepts for extension modules,
             // in the order it would try them (see importlib.machinery.EXTENSION_SUFFIXES).
             let base = &full_path_str;

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1291,8 +1291,7 @@ impl SyncOdoo {
                 if file.self_import {
                     session.sync_odoo.must_reload_paths.push((SymbolKey::from(file.parent()).into(), file.path.clone()));
                 }
-                let js_file = symbol.as_source_file_key().unwrap();
-                ModuleSymbol::on_js_file_unload(session, js_file);
+                ModuleSymbol::on_js_file_unload(session, file_key);
             },
             SymbolKey::Module(module_key) => {
                 let module = &session.sync_odoo.symbol_table[module_key];

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -9,7 +9,7 @@ use crate::core::js_validator::JsValidator;
 use crate::core::module_load_order::sort_by_load_order;
 use crate::core::pre_parser::{PreParseCache, PreParser};
 use crate::core::symbols::ModuleSymbol;
-use crate::core::symbols::storage::SymbolTable;
+use crate::core::symbols::storage::{FileSystemSymbolParent, JsFileParent, SymbolTable};
 use crate::core::symbols::storage::metrics::{log_slotmap_capacities, log_symbol_counts, log_memory_usage};
 use crate::core::symbols::symbol_keys::{FunctionKey, ModuleKey, SourceFileKey, SymbolKey, Wk, XmlId, XmlTemplateKey};
 use crate::core::tsserver_bridge::{TsServerBridge};
@@ -152,7 +152,7 @@ pub struct SyncOdoo {
     rebuild_arch_eval: FifoWeakHashSet<SymbolKey>,
     rebuild_validation: FifoWeakHashSet<SymbolKey>,
     pub state_init: InitState,
-    pub must_reload_paths: Vec<(Wk<SymbolKey>, String)>, // formerly Weak refs
+    pub must_reload_paths: Vec<(Wk<FileSystemSymbolParent>, String)>, // formerly Weak refs
     pub load_odoo_addons: bool, //indicate if we want to load odoo addons or not
     pub need_rebuild: bool, //if true, the next process_rebuilds will drop everything and rebuild everything
     pub import_cache: Option<ImportCache>,
@@ -520,7 +520,8 @@ impl SyncOdoo {
         if disk_dir_builtins.is_empty() {
             panic!("Unable to find builtins disk dir symbol");
         }
-        let _builtins_rc_symbol = SymbolTable::create_from_path(session, &builtins_path, disk_dir_builtins[0], false);
+        let parent = disk_dir_builtins[0].try_into().expect("Expected disk_dir_builtins[0] to be a DiskDirKey");
+        let _builtins_rc_symbol = SymbolTable::create_from_path(session, &builtins_path, parent, false);
         session.sync_odoo.add_to_rebuild_arch(_builtins_rc_symbol.unwrap());
         SyncOdoo::process_rebuilds(session, false)
     }
@@ -601,10 +602,9 @@ impl SyncOdoo {
         session.sync_odoo.version = version;
         //build base
         let config_odoo_path = Path::new(&odoo_path);
-        let Some(odoo_sym) = odoo_sym else {
-            panic!("Odoo root symbol not found")
-        };
+        let odoo_sym = odoo_sym.expect("Expected odoo root symbol to be found");
         session.st_mut().set_is_external(odoo_sym, false);
+        let odoo_sym: FileSystemSymbolParent = odoo_sym.try_into().expect("odoo root symbol to be a DiskDir");
         let odoo_odoo = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo"), odoo_sym, false);
         let Some(odoo_odoo) = odoo_odoo else {
             panic!("Not able to find odoo with given path. Aborting...");
@@ -614,9 +614,9 @@ impl SyncOdoo {
                 session.st_mut()[p].self_import = true;
                 session.sync_odoo.add_to_rebuild_arch(odoo_odoo);
             },
-            SymbolKey::Namespace(_) => {
+            SymbolKey::Namespace(ns) => {
                 //starting from > 18.0, odoo is now a namespace. Start import project from odoo/__main__.py
-                let main_file = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo").join("__main__.py"),  odoo_odoo, false);
+                let main_file = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo").join("__main__.py"),  ns.into(), false);
                 let Some(main_file) = main_file else {
                     panic!("Not able to find odoo/__main__.py. Aborting...");
                 };
@@ -642,7 +642,8 @@ impl SyncOdoo {
                 return false;
             }
             //if we are > 18.1, odoo.addons is not imported automatically anymore. Let's try to import it manually
-            let addons_folder = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo").join("addons"), odoo_odoo, false);
+            let parent = odoo_odoo.try_into().expect("Expected odoo to be a package or namespace");
+            let addons_folder = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo").join("addons"), parent, false);
             if let Some(SymbolKey::Namespace(addons_ns)) = addons_folder {
                 addons_ns
             } else {
@@ -1274,22 +1275,24 @@ impl SyncOdoo {
             //check if we should not reimport automatically
             SymbolKey::PythonPackage(package_key) => {
                 let package = &session.st()[package_key];
-                let parent: SymbolKey = package.parent().into();
                 if package.self_import {
-                    session.sync_odoo.must_reload_paths.push((Wk::from(parent), package.path.clone()));
+                    session.sync_odoo.must_reload_paths.push((Wk::from(package.parent()), package.path.clone()));
                 }
             },
             SymbolKey::File(file_key) => {
                 let file = &session.st()[file_key];
-                let parent: SymbolKey = file.parent().into();
                 if file.self_import {
-                    session.sync_odoo.must_reload_paths.push((Wk::from(parent), file.path.clone()));
+                    session.sync_odoo.must_reload_paths.push((Wk::from(file.parent()), file.path.clone()));
                 }
             },
             SymbolKey::JsFile(file_key) => {
                 let file = &session.st()[file_key];
                 if file.self_import {
-                    session.sync_odoo.must_reload_paths.push((SymbolKey::from(file.parent()).into(), file.path.clone()));
+                    let parent: FileSystemSymbolParent = match file.parent() {
+                        JsFileParent::Module(module_key) => module_key.into(),
+                        JsFileParent::DiskDir(disk_dir_key) => disk_dir_key.into(),
+                    };
+                    session.sync_odoo.must_reload_paths.push((Wk::from(parent), file.path.clone()));
                 }
                 ModuleSymbol::on_js_file_unload(session, file_key);
             },

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1236,7 +1236,7 @@ impl SyncOdoo {
             let sym_in_data = entry.borrow().data_symbols.get(path_str.as_ref()).copied();
             if let Some(sym) = sym_in_data {
                 if let Some(sym) = sym.upgrade(session.st()) {
-                    SymbolTable::unload(session, sym.into());
+                    SymbolTable::unload(session, sym);
                 }
                 continue;
             }
@@ -1253,7 +1253,10 @@ impl SyncOdoo {
                 let Some(&path_symbol) = path_symbols.first() else {
                     continue;
                 };
-                SymbolTable::unload(session, path_symbol);
+                let Some(source_file) = path_symbol.as_source_file_key() else {
+                    continue;
+                };
+                SymbolTable::unload(session, source_file);
             }
         }
     }
@@ -1271,14 +1274,16 @@ impl SyncOdoo {
             //check if we should not reimport automatically
             SymbolKey::PythonPackage(package_key) => {
                 let package = &session.st()[package_key];
+                let parent: SymbolKey = package.parent().into();
                 if package.self_import {
-                    session.sync_odoo.must_reload_paths.push((package.parent().into(), package.path.clone()));
+                    session.sync_odoo.must_reload_paths.push((Wk::from(parent), package.path.clone()));
                 }
             },
             SymbolKey::File(file_key) => {
                 let file = &session.st()[file_key];
+                let parent: SymbolKey = file.parent().into();
                 if file.self_import {
-                    session.sync_odoo.must_reload_paths.push((file.parent().into(), file.path.clone()));
+                    session.sync_odoo.must_reload_paths.push((Wk::from(parent), file.path.clone()));
                 }
             },
             SymbolKey::JsFile(file_key) => {

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -477,7 +477,7 @@ impl PythonArchEval {
                         if let Some((val_eval, _diags)) = &value_evaluations {
                             if val_eval.len() == 1 {
                                 let evaluation = &val_eval[0];
-                                let sym_weak = evaluation.symbol.get_symbol_as_weak(session, None, &mut vec![], Some(parent));
+                                let sym_weak = evaluation.symbol.get_symbol_as_weak(session, None, &mut vec![], Some(parent.into()));
                                 if let Some(sym_key) = sym_weak.weak.upgrade(session.st())
                                     && SymbolTable::is_field_class(session, sym_key) {
                                         take_value = true;
@@ -508,7 +508,7 @@ impl PythonArchEval {
                             if let Some(sym) = evaluation.symbol.get_symbol_as_weak(session, None, &mut self.diagnostics, None).weak.upgrade(session.st()) {
                                 if sym == variable_key {
                                     // TODO: investigate deps, and fix cyclic evals
-                                    let file_path = session.st().get_file(parent).map(|file| session.st().path(file));
+                                    let file_path = session.st().get_file(parent.into()).map(|file| session.st().path(file));
                                     warn!("Found cyclic evaluation symbol: {}, parent: {}, file: {}", var_name, session.st().name(parent), file_path.unwrap_or("N/A"));
                                     to_remove.push(ix);
                                     continue;

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -23,7 +23,7 @@ impl ModuleSymbol {
             let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
             let path_string = path.sanitize();
             //check if already exists
-            if session.st()[symbol_key].data_symbols().contains_key(&path_string) {
+            if session.st()[symbol_key].data_file_symbols().contains_key(&path_string) {
                 continue;
             }
             //load data from file
@@ -145,7 +145,7 @@ impl ModuleSymbol {
         for file_path in files_to_imports.iter().filter(|p| p.extension().map(|ext| ext == "xml").unwrap_or(false)) {
             let file_path_str = file_path.sanitize_cow();
             let file_name = file_path.file_name().unwrap().to_str().unwrap().to_string();
-            if session.st()[module].data_symbols().contains_key(file_path_str.as_ref()) { //already imported. can happen if the file is in multiple bundle or caught by multiple regex
+            if session.st()[module].data_file_symbols().contains_key(file_path_str.as_ref()) { //already imported. can happen if the file is in multiple bundle or caught by multiple regex
                 continue;
             }
             let xml_sym = session.st_mut().add_new_xml_file(module, &file_name, file_path_str.as_ref());

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use lsp_types::{Diagnostic, Position, Range};
 use tracing::info;
 
+use crate::core::symbols::symbol_keys::JsFileKey;
 use crate::{constants::{BuildSteps, DEBUG_STEPS, DiagnosticSource}, core::{csv_arch_builder::CsvArchBuilder, data_hooks, diagnostics::{DiagnosticCode, create_diagnostic}, file_mgr::FileInfo, symbols::{ModuleSymbol, SymbolTable, XmlFileSymbol, symbol_keys::{ModuleKey, SourceFileKey, XmlFileKey}}, xml_arch_builder::XmlArchBuilder}, threads::SessionInfo, utils::PathSanitizer};
 
 
@@ -89,8 +90,14 @@ impl ModuleSymbol {
         data_hooks::on_file_unload(session, data_file);
     }
 
-    pub fn on_js_file_unload(session: &mut SessionInfo, js_file: SourceFileKey) {
-        let path = session.st().path(js_file);
+    pub fn on_js_file_load(symbol_table: &SymbolTable, js_file: JsFileKey) {
+        let path = symbol_table.path(js_file.into());
+        let entry = symbol_table.get_entry(js_file);
+        entry.borrow_mut().js_symbols.insert(path.to_string(), js_file.into());
+    }
+
+    pub fn on_js_file_unload(session: &mut SessionInfo, js_file: JsFileKey) {
+        let path = session.st().path(js_file.into());
         let entry = session.st().get_entry(js_file);
         entry.borrow_mut().js_symbols.remove(path);
     }

--- a/server/src/core/symbols/storage.rs
+++ b/server/src/core/symbols/storage.rs
@@ -141,27 +141,6 @@ macro_rules! impl_index {
     };
 }
 
-impl_index!(RootKey, RootSymbol, roots);
-impl_index!(DiskDirKey, DiskDirSymbol, disk_dirs);
-impl_index!(NamespaceKey, NamespaceSymbol, namespaces);
-impl_index!(PythonPackageKey, PythonPackageSymbol, python_packages);
-impl_index!(ModuleKey, ModuleSymbol, modules);
-impl_index!(FileKey, FileSymbol, files);
-impl_index!(CompiledKey, CompiledSymbol, compiled);
-impl_index!(FunctionKey, FunctionSymbol, functions);
-impl_index!(ClassKey, ClassSymbol, classes);
-impl_index!(VariableKey, VariableSymbol, variables);
-impl_index!(XmlFileKey, XmlFileSymbol, xml_files);
-impl_index!(XmlRecordKey, XmlRecordSymbol, xml_records);
-impl_index!(XmlFieldKey, XmlFieldSymbol, xml_fields);
-impl_index!(XmlMenuItemKey, XmlMenuItemSymbol, xml_menuitems);
-impl_index!(XmlTemplateKey, XmlTemplateSymbol, xml_templates);
-impl_index!(XmlAssetKey, XmlAssetSymbol, xml_assets);
-impl_index!(XmlDeleteKey, XmlDeleteSymbol, xml_deletes);
-impl_index!(CsvFileKey, CsvFileSymbol, csv_files);
-impl_index!(JsFileKey, JsFileSymbol, js_files);
-
-
 /*
     Implement KeyValidator for each symbol type, to check if a key is valid.
     This allows us to pass the symbol table as argument to methods that expect a
@@ -187,22 +166,56 @@ macro_rules! impl_key_validator {
     };
 }
 
-impl_key_validator!(RootKey, roots);
-impl_key_validator!(DiskDirKey, disk_dirs);
-impl_key_validator!(NamespaceKey, namespaces);
-impl_key_validator!(PythonPackageKey, python_packages);
-impl_key_validator!(ModuleKey, modules);
-impl_key_validator!(FileKey, files);
-impl_key_validator!(CompiledKey, compiled);
-impl_key_validator!(ClassKey, classes);
-impl_key_validator!(FunctionKey, functions);
-impl_key_validator!(VariableKey, variables);
-impl_key_validator!(XmlFileKey, xml_files);
-impl_key_validator!(XmlRecordKey, xml_records);
-impl_key_validator!(XmlFieldKey, xml_fields);
-impl_key_validator!(XmlMenuItemKey, xml_menuitems);
-impl_key_validator!(XmlTemplateKey, xml_templates);
-impl_key_validator!(XmlAssetKey, xml_assets);
-impl_key_validator!(XmlDeleteKey, xml_deletes);
-impl_key_validator!(CsvFileKey, csv_files);
-impl_key_validator!(JsFileKey, js_files);
+/// One row per slotmap of [`SymbolTable`], in the same order as the fields.
+macro_rules! impl_symbol_storage {
+    ($($field:ident: $key:ident => $symbol:ident),+ $(,)?) => {
+        $(
+            impl_index!($key, $symbol, $field);
+            impl_key_validator!($key, $field);
+        )+
+
+        #[cfg(test)]
+        impl SymbolTable {
+            /// Assert that no symbol outlived its parent, i.e. that a removal took its whole
+            /// subtree with it. Generated from the rows above, so a new slotmap is swept
+            /// without being listed anywhere else.
+            ///
+            /// Reads each symbol's own parent field and never `children()`, so that a family
+            /// missing from `register_parent_families!` cannot hide from this.
+            pub(super) fn assert_no_orphans(&self) {
+                $(
+                    for (key, _) in self.$field.iter() {
+                        if let Some(parent) = self.parent(key) {
+                            assert!(
+                                self.is_key_valid(parent),
+                                "{key:?} outlived its parent {parent:?}",
+                            );
+                        }
+                    }
+                )+
+            }
+        }
+    };
+}
+
+impl_symbol_storage! {
+    roots: RootKey => RootSymbol,
+    disk_dirs: DiskDirKey => DiskDirSymbol,
+    namespaces: NamespaceKey => NamespaceSymbol,
+    python_packages: PythonPackageKey => PythonPackageSymbol,
+    modules: ModuleKey => ModuleSymbol,
+    files: FileKey => FileSymbol,
+    compiled: CompiledKey => CompiledSymbol,
+    classes: ClassKey => ClassSymbol,
+    functions: FunctionKey => FunctionSymbol,
+    variables: VariableKey => VariableSymbol,
+    xml_files: XmlFileKey => XmlFileSymbol,
+    csv_files: CsvFileKey => CsvFileSymbol,
+    xml_records: XmlRecordKey => XmlRecordSymbol,
+    xml_fields: XmlFieldKey => XmlFieldSymbol,
+    xml_menuitems: XmlMenuItemKey => XmlMenuItemSymbol,
+    xml_templates: XmlTemplateKey => XmlTemplateSymbol,
+    xml_assets: XmlAssetKey => XmlAssetSymbol,
+    xml_deletes: XmlDeleteKey => XmlDeleteSymbol,
+    js_files: JsFileKey => JsFileSymbol,
+}

--- a/server/src/core/symbols/storage.rs
+++ b/server/src/core/symbols/storage.rs
@@ -15,6 +15,7 @@ pub mod lifecycle;
 pub mod symbol_mgr;
 pub mod dependency_mgr;
 pub mod metrics;
+pub mod parents;
 mod ext_symbol_store;
 
 use crate::{constants::OYarn, core::symbols::{
@@ -25,6 +26,7 @@ use crate::{constants::OYarn, core::symbols::{
 use ext_symbol_store::ExtSymbolStore;
 use slotmap::{SlotMap, SparseSecondaryMap};
 use std::ops::{Index, IndexMut};
+pub use parents::{FileContentParent, FileSystemSymbolParent, JsFileParent, XmlDataParent, XmlFieldParent};
 
 #[derive(Debug)]
 pub struct SymbolTable {

--- a/server/src/core/symbols/storage/class_symbol.rs
+++ b/server/src/core/symbols/storage/class_symbol.rs
@@ -1,4 +1,5 @@
 use ruff_text_size::{TextRange, TextSize};
+use crate::core::symbols::storage::FileContentParent;
 use crate::utils::{HashMap, HashSet};
 use std::cell::RefCell;
 
@@ -28,14 +29,14 @@ pub struct ClassSymbol {
     pub sections: Vec<SectionRange>,
 
     // parent / child symbols
-    parent: SymbolKey,
+    parent: FileContentParent,
     //--- Body symbols
     pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
 }
 
 impl ClassSymbol {
 
-    pub fn new(name: &str, parent: SymbolKey, range: TextRange, body_start: TextSize, is_external: bool) -> Self {
+    pub fn new(name: &str, parent: FileContentParent, range: TextRange, body_start: TextSize, is_external: bool) -> Self {
         let mut res = Self {
             name: oyarn!("{}", name),
             is_external,
@@ -85,15 +86,7 @@ impl ClassSymbol {
         false
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileContentParent {
         self.parent
     }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.symbols.values()
-            .flat_map(|section| section.values())
-            .flatten()
-            .copied().collect()
-    }
-
 }

--- a/server/src/core/symbols/storage/compiled_symbol.rs
+++ b/server/src/core/symbols/storage/compiled_symbol.rs
@@ -1,5 +1,5 @@
+use crate::core::symbols::storage::FileSystemSymbolParent;
 use crate::utils::HashMap;
-
 
 use crate::{constants::OYarn, oyarn};
 use crate::core::symbols::symbol_keys::SymbolKey;
@@ -11,28 +11,23 @@ pub struct CompiledSymbol {
     pub path: String,
     
     // parent / child symbols
-    parent: SymbolKey,
-    pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
+    parent: FileSystemSymbolParent,
+    pub(super) fs_symbols: HashMap<OYarn, SymbolKey>,
 }
 
 impl CompiledSymbol {
 
-    pub fn new(name: &str, path: &str, parent: SymbolKey, is_external: bool) -> Self {
+    pub fn new(name: &str, path: &str, parent: FileSystemSymbolParent, is_external: bool) -> Self {
         Self {
             name: oyarn!("{}", name),
             is_external,
             path: path.to_string(),
-            module_symbols: HashMap::default(),
+            fs_symbols: HashMap::default(),
             parent,
         }
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileSystemSymbolParent {
         self.parent
     }
-    
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.module_symbols.values().copied().collect()
-    }
-
 }

--- a/server/src/core/symbols/storage/csv_file_symbol.rs
+++ b/server/src/core/symbols/storage/csv_file_symbol.rs
@@ -4,7 +4,7 @@ use crate::constants::MissingDataSource;
 use crate::core::symbols::Buildable;
 use crate::core::symbols::storage::dependency_mgr::{DependenciesTable, DependentsTable};
 use crate::core::symbols::symbol_keys::{ModuleKey, XmlDataKey};
-use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::symbol_keys::SymbolKey}, oyarn};
+use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model}, oyarn};
 use crate::utils::{HashMap, HashSet};
 use std::{cell::RefCell, rc::Weak};
 
@@ -18,7 +18,6 @@ pub struct CsvFileSymbol {
     pub not_found_paths: Vec<(BuildSteps, Vec<OYarn>)>,
     pub not_found_data_ids: HashMap<MissingDataSource, BuildSteps>,
     pub (super) in_workspace: bool,
-    pub (super) symbols: HashSet<XmlDataKey>,
     pub model_name: OYarn,
     pub headers: Vec<OYarn>,
     pub self_import: bool,
@@ -28,8 +27,9 @@ pub struct CsvFileSymbol {
     pub processed_text_hash: u64,
     pub noqas: NoqaInfo,
 
-    // parent symbol (no child symbols)
+    // parent/child symbols
     parent: ModuleKey,
+    pub(in crate::core::symbols::storage) data_symbols: HashSet<XmlDataKey>,
 }
 
 impl CsvFileSymbol {
@@ -48,7 +48,7 @@ impl CsvFileSymbol {
             in_workspace: false,
             model_name: OYarn::default(),
             headers: Vec::new(),
-            symbols: HashSet::default(),
+            data_symbols: HashSet::default(),
             self_import: false,
             model_dependencies: PtrWeakHashSet::new(),
             dependencies: DependenciesTable::default(),
@@ -62,14 +62,9 @@ impl CsvFileSymbol {
         self.parent
     }
 
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.symbols.iter().copied().map(SymbolKey::from).collect()
+    pub fn data_symbols(&self) -> &HashSet<XmlDataKey> {
+        &self.data_symbols
     }
-
-    pub fn symbols(&self) -> &HashSet<XmlDataKey> {
-        &self.symbols
-    }
-
 }
 
 impl Buildable for CsvFileSymbol {

--- a/server/src/core/symbols/storage/disk_dir_symbol.rs
+++ b/server/src/core/symbols/storage/disk_dir_symbol.rs
@@ -1,5 +1,6 @@
 
 use std::path::Path;
+use crate::core::symbols::storage::FileSystemSymbolParent;
 use crate::core::symbols::symbol_keys::JsFileKey;
 use crate::utils::HashMap;
 
@@ -17,40 +18,31 @@ pub struct DiskDirSymbol {
     pub in_workspace: bool,
 
     // parent / child symbols
-    parent: SymbolKey,
-    pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
+    parent: FileSystemSymbolParent,
+    pub(super) fs_symbols: HashMap<OYarn, SymbolKey>,
     pub(super) js_symbols: HashMap<String, JsFileKey>,
 }
 
+
 impl DiskDirSymbol {
 
-    pub fn new(name: &str, path: &str, parent: SymbolKey, is_external: bool) -> Self {
+    pub fn new(name: &str, path: &str, parent: FileSystemSymbolParent, is_external: bool) -> Self {
         Self {
             name: oyarn!("{}", name),
             path: Path::new(path).sanitize(),
             is_external,
             parent,
             in_workspace: false,
-            module_symbols: HashMap::default(),
+            fs_symbols: HashMap::default(),
             js_symbols: HashMap::default(),
         }
     }
 
     pub fn module_symbols(&self) -> &HashMap<OYarn, SymbolKey> {
-        &self.module_symbols
+        &self.fs_symbols
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileSystemSymbolParent {
         self.parent
     }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.module_symbols.values().copied()
-            .chain(self.js_symbols.values().map(|&key| key.into()))
-            .collect()
-    }
-
-    /*pub fn load(sesion: &mut SessionInfo, dir: &Rc<RefCell<Symbol>>) -> Rc<RefCell<Symbol>> {
-        let path = dir.borrow().as_disk_dir_sym().path.clone();
-    }*/
 }

--- a/server/src/core/symbols/storage/file_symbol.rs
+++ b/server/src/core/symbols/storage/file_symbol.rs
@@ -1,6 +1,6 @@
 use weak_table::PtrWeakHashSet;
 
-use crate::{constants::{BuildStatus, BuildSteps, MissingDataSource, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn};
+use crate::{constants::{BuildStatus, BuildSteps, MissingDataSource, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::{dependency_mgr::{DependenciesTable, DependentsTable}, FileSystemSymbolParent}, symbol_keys::SymbolKey}}, oyarn};
 use std::{cell::RefCell, rc::Weak};
 use crate::utils::HashMap;
 
@@ -29,13 +29,13 @@ pub struct FileSymbol {
     pub sections: Vec<SectionRange>,
 
     // parent / child symbols
-    parent: SymbolKey,
+    parent: FileSystemSymbolParent,
     pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
 }
 
 impl FileSymbol {
 
-    pub fn new(name: &str, path: &str, parent: SymbolKey, is_external: bool) -> Self {
+    pub fn new(name: &str, path: &str, parent: FileSystemSymbolParent, is_external: bool) -> Self {
         let mut res = Self {
             name: oyarn!("{}", name),
             path: path.to_string(),
@@ -61,15 +61,7 @@ impl FileSymbol {
         res
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileSystemSymbolParent {
         self.parent
     }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.symbols.values()
-            .flat_map(|section| section.values())
-            .flatten()
-            .copied().collect()
-    }
-
 }

--- a/server/src/core/symbols/storage/function_symbol.rs
+++ b/server/src/core/symbols/storage/function_symbol.rs
@@ -1,4 +1,4 @@
-use crate::utils::HashMap;
+use crate::{core::symbols::storage::FileContentParent, utils::HashMap};
 
 use lsp_types::Diagnostic;
 use ruff_python_ast::{AtomicNodeIndex, Expr, ExprCall};
@@ -53,14 +53,14 @@ pub struct FunctionSymbol {
     pub sections: Vec<SectionRange>,
 
     // parent / child symbols
-    parent: SymbolKey,
+    parent: FileContentParent,
     //--- Body content
     pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
 }
 
 impl FunctionSymbol {
 
-    pub fn new(name: &str, parent: SymbolKey, range: TextRange, body_start: TextSize, is_external: bool) -> Self {
+    pub fn new(name: &str, parent: FileContentParent, range: TextRange, body_start: TextSize, is_external: bool) -> Self {
         let mut res = Self {
             name: oyarn!("{}", name),
             is_external,
@@ -115,7 +115,7 @@ impl FunctionSymbol {
         if func.is_overloaded {
             return true;
         }
-        let previous_defs = symbol_table.get_content_symbol(func.parent(), &func.name, func.range.start().to_u32()).symbols;
+        let previous_defs = symbol_table.get_content_symbol(func.parent().into(), &func.name, func.range.start().to_u32()).symbols;
         if let Some(&SymbolKey::Function(k)) = previous_defs.last() {
             return symbol_table[k].is_overloaded;
         }
@@ -176,15 +176,7 @@ impl FunctionSymbol {
         None
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileContentParent {
         self.parent
     }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.symbols.values()
-            .flat_map(|section| section.values())
-            .flatten()
-            .copied().collect()
-    }
-
 }

--- a/server/src/core/symbols/storage/js_file_symbol.rs
+++ b/server/src/core/symbols/storage/js_file_symbol.rs
@@ -1,6 +1,6 @@
 use weak_table::PtrWeakHashSet;
 
-use crate::{constants::{BuildStatus, BuildSteps, MissingDataSource, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{Buildable, storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::{JsFileParent, SymbolKey}}}, oyarn, utils::HashMap};
+use crate::{constants::{BuildStatus, BuildSteps, MissingDataSource, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{Buildable, storage::{dependency_mgr::{DependenciesTable, DependentsTable}, JsFileParent}}}, oyarn, utils::HashMap};
 use std::{cell::RefCell, rc::Weak};
 
 #[derive(Debug)]
@@ -48,11 +48,6 @@ impl JsFileSymbol {
     pub fn parent(&self) -> JsFileParent {
         self.parent
     }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        vec![]
-    }
-
 }
 
 impl Buildable for JsFileSymbol {

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -23,7 +23,7 @@ use crate::{
             }, symbol_keys::{
                 ClassKey, CompiledKey, CsvFileKey, DiskDirKey, FileKey, FunctionKey, JsFileKey,
                 ModuleKey, NamespaceKey, PythonPackageKey, RootKey, SourceFileKey, SymbolKey,
-                VariableKey, Wk, XmlAssetKey, XmlDeleteKey, XmlFieldKey, XmlFileKey,
+                VariableKey, XmlAssetKey, XmlDeleteKey, XmlFieldKey, XmlFileKey,
                 XmlMenuItemKey, XmlRecordKey, XmlTemplateKey,
             }
         },
@@ -195,15 +195,12 @@ impl SymbolTable {
         csv_file_key
     }
 
-    pub fn add_new_js_file(&mut self, parent_key: JsFileParent, name: &str, path: &str) -> JsFileKey {
-        let symbol_key: SymbolKey = parent_key.into();
-        let mut js_file_symbol = JsFileSymbol::new(name, path, parent_key, self.is_external(symbol_key));
-        js_file_symbol.set_in_workspace(self.in_workspace(symbol_key));
+    pub fn add_new_js_file(&mut self, parent: JsFileParent, name: &str, path: &str) -> JsFileKey {
+        let mut js_file_symbol = JsFileSymbol::new(name, path, parent, self.is_external(parent.into()));
+        js_file_symbol.set_in_workspace(self.in_workspace(parent.into()));
         let js_file_key = self.js_files.insert(js_file_symbol);
-        let rc_entry = self.get_entry(symbol_key);
-        let mut entry_bw = rc_entry.borrow_mut();
-        self.add_to_parent_js_symbols(parent_key, path, js_file_key);
-        self.add_to_js_entry_symbols(&mut entry_bw, path, js_file_key);
+        self.add_to_parent_js_symbols(parent, path, js_file_key);
+        ModuleSymbol::on_js_file_load(self, js_file_key);
         js_file_key
     }
 
@@ -282,11 +279,6 @@ impl SymbolTable {
     fn remove_from_parent_js_symbols(&mut self, parent: JsFileParent, path: &str) {
         parent.js_symbols_mut(self).remove(path);
     }
-
-    fn add_to_js_entry_symbols(&mut self, entry: &mut EntryPoint, path: &str, js_file: JsFileKey) {
-        entry.js_symbols.insert(path.to_string(), Wk::from(js_file));
-    }
-
     // ====== Symbol removal ======
 
     /// Remove `symbol` and its descendants, and clean up.

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -41,9 +41,8 @@ impl SymbolTable {
         self.roots.insert(root_symbol)
     }
     // Create a sub-symbol that is representing a file
-    pub fn add_new_file(&mut self, parent: SymbolKey, name: &str, path: &str) -> FileKey {
-        let is_external = self.is_external(parent);
-        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
+    pub fn add_new_file(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> FileKey {
+        let is_external = self.is_external(parent.into());
         let file_symbol = FileSymbol::new(name, path, parent, is_external);
         let file_key = self.files.insert(file_symbol);
         self.add_to_parent_module_symbols(parent, file_key.into(), name, path);
@@ -51,36 +50,32 @@ impl SymbolTable {
     }
 
     //Create a sub-symbol that is representing a package
-    pub fn add_new_python_package(&mut self, parent: SymbolKey, name: &str, path: &str, i_ext: &'static str) -> PythonPackageKey {
-        let is_external = self.is_external(parent);
-        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
+    pub fn add_new_python_package(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str, i_ext: &'static str) -> PythonPackageKey {
+        let is_external = self.is_external(parent.into());
         let package_symbol = PythonPackageSymbol::new(name, path, parent, is_external, i_ext);
         let package_key = self.python_packages.insert(package_symbol);
         self.add_to_parent_module_symbols(parent, package_key.into(), name, path);
         package_key
     }
 
-    pub fn add_new_namespace(&mut self, parent: SymbolKey, name: &str, path: &str) -> NamespaceKey {
-        let is_external = self.is_external(parent);
-        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
+    pub fn add_new_namespace(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> NamespaceKey {
+        let is_external = self.is_external(parent.into());
         let namespace_symbol = NamespaceSymbol::new(name, vec![path.to_string()], parent, is_external);
         let namespace_key = self.namespaces.insert(namespace_symbol);
         self.add_to_parent_module_symbols(parent, namespace_key.into(), name, path);
         namespace_key
     }
 
-    pub fn add_new_disk_dir(&mut self, parent: SymbolKey, name: &str, path: &str) -> DiskDirKey {
-        let is_external = self.is_external(parent);
-        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
+    pub fn add_new_disk_dir(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> DiskDirKey {
+        let is_external = self.is_external(parent.into());
         let disk_dir_symbol = DiskDirSymbol::new(name, path, parent, is_external);
         let disk_dir_key = self.disk_dirs.insert(disk_dir_symbol);
         self.add_to_parent_module_symbols(parent, disk_dir_key.into(), name, path);
         disk_dir_key
     }
 
-    pub fn add_new_compiled(&mut self, parent: SymbolKey, name: &str, path: &str) -> CompiledKey {
-        let is_external = self.is_external(parent);
-        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
+    pub fn add_new_compiled(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> CompiledKey {
+        let is_external = self.is_external(parent.into());
         let compiled_symbol = CompiledSymbol::new(name, path, parent, is_external);
         let compiled_key = self.compiled.insert(compiled_symbol);
         self.add_to_parent_module_symbols(parent, compiled_key.into(), name, path);
@@ -234,7 +229,6 @@ impl SymbolTable {
     }
 
     // ====== Helpers for symbol creation ======
-    // 
     /// Evict a child displaced by a map insert with a colliding name/path. This
     /// prevents a leak, but `unload` side effects are NOT run. Callers should
     /// properly unload the symbol first.

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -501,6 +501,7 @@ mod tests {
             assert!(!f.st.is_key_valid(key), "{key:?} outlived its file");
         }
         assert!(f.st.is_key_valid(f.module), "removing a file took its module down");
+        f.st.assert_no_orphans();
     }
 
     #[test]
@@ -528,6 +529,42 @@ mod tests {
             assert!(!f.st.is_key_valid(key), "{key:?} outlived its xml file");
         }
         assert!(f.st.is_key_valid(csv_record), "removing the xml file took the csv records down");
+        f.st.assert_no_orphans();
+    }
+
+    /// Every family at once, plus the ext symbols hanging off the module's files — the one
+    /// child-like relation `children()` does not cover. Removing the module has to leave
+    /// nothing behind.
+    #[test]
+    fn unloading_a_module_leaves_no_orphan() {
+        let mut f = Fixture::new();
+        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py");
+        let class = f.st.add_new_class(file.into(), "AClass", range_at(0), TextSize::new(0));
+        let method = f.st.add_new_function(class.into(), "method", range_at(10), TextSize::new(10));
+        f.st.add_new_variable(method, "local", range_at(20));
+        f.st.add_new_variable(f.module, "MODULE_CONSTANT", range_at(0));
+
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
+        let record = f.st.add_new_xml_record(XmlDataParent::XmlFile(xml_file), (oyarn!("res.partner"), 0..1), None, range_at(0));
+        f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), oyarn!("name"), range_at(1), None, None, None);
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+        f.st.add_new_xml_record(XmlDataParent::CsvFile(csv_file), (oyarn!("res.partner"), 0..1), None, range_at(0));
+        f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
+
+        // injected into a file outside the module, but owned by one of its files: it dies with
+        // the owner, through `ext_symbols` rather than through any holder.
+        let host = f.st.add_new_file(f.root.into(), "host", "/root/host.py");
+        let injected = f.st.add_new_ext_symbol(host.into(), "injected", range_at(30), file.into());
+
+        f.st.assert_no_orphans();
+
+        f.st.unlink_from_parent(f.module.into());
+        f.st.remove(f.module.into());
+
+        assert!(!f.st.is_key_valid(f.module), "the module survived its own removal");
+        assert!(!f.st.is_key_valid(injected), "the ext symbol outlived its owner");
+        assert!(f.st.is_key_valid(host), "removing the module took the injection target down");
+        f.st.assert_no_orphans();
     }
 
     /// `ModuleSymbol` implements four holder traits, which is why `children` is a sequence of

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -10,16 +10,24 @@
 //! checks, unlike keys stored elsewhere (as Weak).
 
 use crate::{
-    constants::{OYarn, PackageType, SymType},
-    core::{
-        entry_point::{EntryPoint, EntryPointCleanupToken}, odoo::SyncOdoo, symbols::{
-            ClassSymbol, CompiledSymbol, CsvFileSymbol, Dependencies, DiskDirSymbol, FileSymbol, FunctionSymbol, JsFileSymbol, ModuleSymbol, NamespaceSymbol, PythonPackageSymbol, RootSymbol, SymbolTable, VariableSymbol, XmlFileSymbol, storage::xml::{xml_asset_symbol::XmlAssetSymbol, xml_delete_symbol::XmlDeleteSymbol, xml_field_symbol::XmlFieldSymbol, xml_menuitem_symbol::XmlMenuItemSymbol, xml_record_symbol::XmlRecordSymbol, xml_template_symbol::XmlTemplateSymbol}, symbol_keys::{
-                ClassKey, CompiledKey, CsvFileKey, DiskDirKey, FileKey, FunctionKey, JsFileKey, JsFileParent, ModuleKey, NamespaceKey, PythonPackageKey, RootKey, SourceFileKey, SymbolKey, VariableKey, Wk, XmlAssetKey, XmlDataKey, XmlDeleteKey, XmlFieldKey, XmlFileKey, XmlMenuItemKey, XmlRecordKey, XmlTemplateKey
-            }, symbol_mgr::SymbolMgr
-        }
-    },
-    oyarn,
-    threads::SessionInfo,
+    constants::{OYarn, PackageType, SymType}, core::{
+        entry_point::{EntryPoint, EntryPointCleanupToken},
+        odoo::SyncOdoo,
+        symbols::{
+            ClassSymbol, CompiledSymbol, CsvFileSymbol, Dependencies, DiskDirSymbol, FileSymbol, FunctionSymbol, JsFileSymbol, ModuleSymbol, NamespaceSymbol, PythonPackageSymbol, RootSymbol, SymbolTable, VariableSymbol, XmlFileSymbol, storage::{
+                FileContentParent, FileSystemSymbolParent, JsFileParent, XmlDataParent, XmlFieldParent, xml::{
+                    xml_asset_symbol::XmlAssetSymbol, xml_delete_symbol::XmlDeleteSymbol,
+                    xml_field_symbol::XmlFieldSymbol, xml_menuitem_symbol::XmlMenuItemSymbol,
+                    xml_record_symbol::XmlRecordSymbol, xml_template_symbol::XmlTemplateSymbol,
+                }
+            }, symbol_keys::{
+                ClassKey, CompiledKey, CsvFileKey, DiskDirKey, FileKey, FunctionKey, JsFileKey,
+                ModuleKey, NamespaceKey, PythonPackageKey, RootKey, SourceFileKey, SymbolKey,
+                VariableKey, Wk, XmlAssetKey, XmlDeleteKey, XmlFieldKey, XmlFileKey,
+                XmlMenuItemKey, XmlRecordKey, XmlTemplateKey,
+            }
+        },
+    }, oyarn, threads::SessionInfo
 };
 use ruff_text_size::{TextRange, TextSize};
 use std::{cell::RefCell, ops::Range, path::Path, rc::Rc};
@@ -35,6 +43,7 @@ impl SymbolTable {
     // Create a sub-symbol that is representing a file
     pub fn add_new_file(&mut self, parent: SymbolKey, name: &str, path: &str) -> FileKey {
         let is_external = self.is_external(parent);
+        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
         let file_symbol = FileSymbol::new(name, path, parent, is_external);
         let file_key = self.files.insert(file_symbol);
         self.add_to_parent_module_symbols(parent, file_key.into(), name, path);
@@ -44,6 +53,7 @@ impl SymbolTable {
     //Create a sub-symbol that is representing a package
     pub fn add_new_python_package(&mut self, parent: SymbolKey, name: &str, path: &str, i_ext: &'static str) -> PythonPackageKey {
         let is_external = self.is_external(parent);
+        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
         let package_symbol = PythonPackageSymbol::new(name, path, parent, is_external, i_ext);
         let package_key = self.python_packages.insert(package_symbol);
         self.add_to_parent_module_symbols(parent, package_key.into(), name, path);
@@ -52,6 +62,7 @@ impl SymbolTable {
 
     pub fn add_new_namespace(&mut self, parent: SymbolKey, name: &str, path: &str) -> NamespaceKey {
         let is_external = self.is_external(parent);
+        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
         let namespace_symbol = NamespaceSymbol::new(name, vec![path.to_string()], parent, is_external);
         let namespace_key = self.namespaces.insert(namespace_symbol);
         self.add_to_parent_module_symbols(parent, namespace_key.into(), name, path);
@@ -60,6 +71,7 @@ impl SymbolTable {
 
     pub fn add_new_disk_dir(&mut self, parent: SymbolKey, name: &str, path: &str) -> DiskDirKey {
         let is_external = self.is_external(parent);
+        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
         let disk_dir_symbol = DiskDirSymbol::new(name, path, parent, is_external);
         let disk_dir_key = self.disk_dirs.insert(disk_dir_symbol);
         self.add_to_parent_module_symbols(parent, disk_dir_key.into(), name, path);
@@ -68,6 +80,7 @@ impl SymbolTable {
 
     pub fn add_new_compiled(&mut self, parent: SymbolKey, name: &str, path: &str) -> CompiledKey {
         let is_external = self.is_external(parent);
+        let parent = FileSystemSymbolParent::try_from(parent).expect("parent should be FileSystemItemParent");
         let compiled_symbol = CompiledSymbol::new(name, path, parent, is_external);
         let compiled_key = self.compiled.insert(compiled_symbol);
         self.add_to_parent_module_symbols(parent, compiled_key.into(), name, path);
@@ -87,24 +100,27 @@ impl SymbolTable {
     pub fn add_new_variable(&mut self, parent: impl Into<SymbolKey>, name: &str, range: TextRange) -> VariableKey {
         let parent = parent.into();
         let is_external = self.is_external(parent);
+        let parent = FileContentParent::try_from(parent).expect("parent should be FileContentParent");
         let variable_symbol = VariableSymbol::new(name, parent, range, is_external);
         let variable_key = self.variables.insert(variable_symbol);
-        self.add_to_parent_symbols(parent, variable_key.into(), name, range.start().to_u32());
+        parent.add_child(self, name, variable_key.into(), range.start().to_u32());
         variable_key
     }
     pub fn add_new_function(&mut self, parent: SymbolKey, name: &str, range: TextRange, body_start: TextSize) -> FunctionKey {
         let is_external = self.is_external(parent);
+        let parent = FileContentParent::try_from(parent).expect("parent should be FileContentParent");
         let function_symbol = FunctionSymbol::new(name, parent, range, body_start, is_external);
         let function_key = self.functions.insert(function_symbol);
-        self.add_to_parent_symbols(parent, function_key.into(), name, range.start().to_u32());
+        parent.add_child(self, name, function_key.into(), range.start().to_u32());
         function_key
     }
 
     pub fn add_new_class(&mut self, parent: SymbolKey, name: &str, range: TextRange, body_start: TextSize) -> ClassKey {
         let is_external = self.is_external(parent);
+        let parent = FileContentParent::try_from(parent).expect("parent should be FileContentParent");
         let class_symbol = ClassSymbol::new(name, parent, range, body_start, is_external);
         let class_key = self.classes.insert(class_symbol);
-        self.add_to_parent_symbols(parent, class_key.into(), name, range.start().to_u32());
+        parent.add_child(self, name, class_key.into(), range.start().to_u32());
         class_key
     }
 
@@ -117,8 +133,8 @@ impl SymbolTable {
         xml_file_key
     }
 
-    pub fn add_new_xml_record(&mut self, parent: SymbolKey, model: (OYarn, Range<usize>) , xml_id: Option<OYarn>, range: TextRange) -> XmlRecordKey {
-        let is_external = self.is_external(parent);
+    pub fn add_new_xml_record(&mut self, parent: XmlDataParent, model: (OYarn, Range<usize>) , xml_id: Option<OYarn>, range: TextRange) -> XmlRecordKey {
+        let is_external = self.is_external(parent.into());
         let xml_record_sym = XmlRecordSymbol::new(
             model,
             xml_id,
@@ -126,7 +142,7 @@ impl SymbolTable {
             parent,
             is_external);
         let xml_record_key = self.xml_records.insert(xml_record_sym);
-        self.add_xml_data_to_file(parent, xml_record_key.into());
+        parent.data_symbols_mut(self).insert(xml_record_key.into());
         xml_record_key
     }
 
@@ -134,7 +150,7 @@ impl SymbolTable {
         let is_external = self.is_external(parent.into());
         let xml_menuitem_sym = XmlMenuItemSymbol::new(xml_id, range, parent.into(), is_external);
         let xml_menuitem_key = self.xml_menuitems.insert(xml_menuitem_sym);
-        self.add_xml_data_to_file(parent.into(), xml_menuitem_key.into());
+        self[parent].data_symbols.insert(xml_menuitem_key.into());
         xml_menuitem_key
     }
 
@@ -142,7 +158,7 @@ impl SymbolTable {
         let is_external = self.is_external(parent.into());
         let xml_asset_sym = XmlAssetSymbol::new(xml_id, range, parent.into(), is_external);
         let xml_asset_key = self.xml_assets.insert(xml_asset_sym);
-        self.add_xml_data_to_file(parent.into(), xml_asset_key.into());
+        self[parent].data_symbols.insert(xml_asset_key.into());
         xml_asset_key
     }
 
@@ -150,13 +166,12 @@ impl SymbolTable {
         let is_external = self.is_external(parent.into());
         let xml_delete_sym = XmlDeleteSymbol::new(xml_id, range, model, parent.into(), is_external);
         let xml_delete_key = self.xml_deletes.insert(xml_delete_sym);
-        self.add_xml_data_to_file(parent.into(), xml_delete_key.into());
+        self[parent].data_symbols.insert(xml_delete_key.into());
         xml_delete_key
     }
 
-    //parent should be either XmlRecord or XmlAsset
-    pub fn add_new_xml_field(&mut self, parent: SymbolKey, field_name: OYarn, range: TextRange, text: Option<String>, text_range: Option<TextRange>, ref_key: Option<(String, TextRange)>) -> XmlFieldKey {
-        let is_external = self.is_external(parent);
+    pub fn add_new_xml_field(&mut self, parent: XmlFieldParent, field_name: OYarn, range: TextRange, text: Option<String>, text_range: Option<TextRange>, ref_key: Option<(String, TextRange)>) -> XmlFieldKey {
+        let is_external = self.is_external(parent.into());
         let xml_field_sym = XmlFieldSymbol::new(field_name.clone(), range, text, text_range, ref_key, parent, is_external);
         let xml_field_key = self.xml_fields.insert(xml_field_sym);
         self.add_field_to_xml_record(parent, xml_field_key, field_name.as_str());
@@ -167,7 +182,7 @@ impl SymbolTable {
         let is_external = self.is_external(parent.into());
         let xml_template_sym = XmlTemplateSymbol::new(name, t_name, range, parent.into(), is_web, is_external);
         let xml_template_key = self.xml_templates.insert(xml_template_sym);
-        self.add_xml_data_to_file(parent.into(), xml_template_key.into());
+        self[parent].data_symbols.insert(xml_template_key.into());
         xml_template_key
     }
 
@@ -207,201 +222,85 @@ impl SymbolTable {
         ) {
             panic!("Impossible to add an external symbol to a {}", target.typ());
         }
+        let parent = FileContentParent::try_from(owner).expect("ext symbol owner should be file-content parent");
         let variable_symbol = VariableSymbol::new(
             name,
-            target,
+            parent,
             range,
             self.is_external(target),
         );
         let variable_key = self.variables.insert(variable_symbol);
-        let section = self.get_section_for_key(owner, range.start().to_u32());
+        let section = parent.as_symbol_mgr(self).get_section_for(range.start().to_u32()).index;
 
         self.ext_symbols.add(target, owner, name, section, variable_key);
         variable_key
     }
 
     // ====== Helpers for symbol creation ======
-
-    // If replacing an existing entry, the old one gets removed from the symbol table to prevent leaks,
-    // but `unload` side effects are not run. Callers should properly unload the symbol first.
-    fn add_to_parent_module_symbols(&mut self, parent: SymbolKey, child: SymbolKey, name: &str, path: &str) {
-        let replaced_key = match parent {
-            SymbolKey::Namespace(n) => {
-                self.add_file_to_namespace(n, child, name, path)
-            },
-            SymbolKey::PythonPackage(p) => {
-                self.python_packages[p].module_symbols.insert(oyarn!("{}", name), child)
-            },
-            SymbolKey::Module(m) => {
-                self.modules[m].module_symbols.insert(oyarn!("{}", name), child)
-            },
-            SymbolKey::Root(r) => {
-                self.roots[r].module_symbols.insert(oyarn!("{}", name), child)
-            },
-            SymbolKey::DiskDir(d) => {
-                self.disk_dirs[d].module_symbols.insert(oyarn!("{}", name), child)
-            },
-            SymbolKey::Compiled(c) if child.typ() == SymType::COMPILED => {
-                // A compiled can only be a parent to another compiled
-                self.compiled[c].module_symbols.insert(oyarn!("{}", name), child)
-            }
-            _ => {
-                panic!("Impossible to add a {} to a {}", child.typ(), parent.typ());
-            }
-        };
-        if let Some(replaced_key) = replaced_key {
-            self.remove(replaced_key);
+    // 
+    /// Evict a child displaced by a map insert with a colliding name/path. This
+    /// prevents a leak, but `unload` side effects are NOT run. Callers should
+    /// properly unload the symbol first.
+    fn remove_replaced(&mut self, replaced: Option<impl Into<SymbolKey>>) {
+        if let Some(replaced) = replaced {
+            self.remove(replaced.into());
         }
     }
-
-    fn add_file_to_namespace(&mut self, parent: NamespaceKey, file: SymbolKey, name: &str, path: &str) -> Option<SymbolKey> {
-        let ns = &mut self.namespaces[parent];
-        let best = ns.directories.iter()
-            .enumerate()
-            .filter(|(_, dir)| Path::new(path).starts_with(&dir.path))
-            .max_by_key(|(_, dir)| dir.path.len())
-            .unwrap_or_else(|| panic!("Not valid path found to add the file ({}) to namespace {} with directories {:?}", path, ns.name, ns.directories))
-            .0;
-        ns.directories[best].module_symbols.insert(oyarn!("{}", name), file)
-    }
-
-    fn add_field_to_xml_record(&mut self, parent: SymbolKey, field: XmlFieldKey, name: &str) {
-        match parent {
-            SymbolKey::XmlRecord(r) => {
-                let xml_record = &mut self.xml_records[r];
-                if let Some(replaced_key) = xml_record.fields.insert(oyarn!("{}", name), field) {
-                    self.remove(replaced_key.into());
-                }
-            },
-            SymbolKey::XmlAsset(k) => {
-                let xml_asset = &mut self.xml_assets[k];
-                if let Some(replaced_key) = xml_asset.fields.insert(oyarn!("{}", name), field) {
-                    self.remove(replaced_key.into());
-                }
-            }
-            _ => {
-                panic!("Impossible to add an XmlFieldKey to a {}", parent.typ());
-            }
+    
+    fn add_to_parent_module_symbols(&mut self, parent: FileSystemSymbolParent, child: SymbolKey, name: &str, path: &str) {
+        // A compiled can only be a parent to another compiled
+        if let FileSystemSymbolParent::Compiled(_) = parent && !matches!(child, SymbolKey::Compiled(_)) {
+            panic!("Impossible to add a {} to a CompiledSymbol parent", child.typ());
         }
+        let replaced_key = parent.add_fs_symbol(self, name, child, path);
+        self.remove_replaced(replaced_key);
     }
 
-    fn add_xml_data_to_file(&mut self, parent: SymbolKey, content: XmlDataKey) {
-        match parent {
-            SymbolKey::XmlFile(f) => {
-                let xml_file = &mut self.xml_files[f];
-                xml_file.symbols.insert(content);
-            },
-            SymbolKey::CsvFile(f) => {
-                let csv_file = &mut self.csv_files[f];
-                csv_file.symbols.insert(content);
-            },
-            _ => {
-                panic!("Impossible to add an xml data key to a {}", parent.typ());
-            }
-        }
+    fn remove_from_parent_module_symbols(&mut self, parent: FileSystemSymbolParent, name: &str) {
+        parent.remove_fs_symbol(self, name);
     }
 
-    fn add_to_parent_symbols(&mut self, parent: SymbolKey, content: SymbolKey, name: &str, position: u32) {
-         match parent {
-            SymbolKey::File(f) => {
-                let file = &mut self.files[f];
-                let section = file.get_section_for(position).index;
-                file.symbols.entry(oyarn!("{}",name)).or_default()
-                    .entry(section).or_default()
-                    .push(content);
-            },
-            SymbolKey::Module(m) => {
-                let module = &mut self.modules[m];
-                let section = module.get_section_for(position).index;
-                module.symbols.entry(oyarn!("{}",name)).or_default()
-                    .entry(section).or_default()
-                    .push(content);
-            },
-            SymbolKey::PythonPackage(p) => {
-                let package = &mut self.python_packages[p];
-                let section = package.get_section_for(position).index;
-                package.symbols.entry(oyarn!("{}",name)).or_default()
-                    .entry(section).or_default()
-                    .push(content);
-            },
-            SymbolKey::Class(c) => {
-                let class = &mut self.classes[c];
-                let section = class.get_section_for(position).index;
-                class.symbols.entry(oyarn!("{}",name)).or_default()
-                    .entry(section).or_default()
-                    .push(content);
-            },
-            SymbolKey::Function(f) => {
-                let function = &mut self.functions[f];
-                let section = function.get_section_for(position).index;
-                function.symbols.entry(oyarn!("{}",name)).or_default()
-                    .entry(section).or_default()
-                    .push(content);
-            },
-            _ => {
-                panic!("Impossible to add a {} to a {}", content.typ(), parent.typ());
-            }
-        }
+    fn add_field_to_xml_record(&mut self, parent: XmlFieldParent, field: XmlFieldKey, name: &str) {
+        let replaced_key = parent.fields_mut(self).insert(oyarn!("{}", name), field);
+        self.remove_replaced(replaced_key);
     }
 
-    // If replacing an exisiting entry, the old one gets removed from the symbol table to prevent leaks,
-    // but `unload` side effects are not run. Callers should properly unload the symbol first.
     fn add_to_module_data_symbols(&mut self, parent: ModuleKey, path: &str, data_file: SourceFileKey) {
-        let replaced_key = self.modules[parent].data_symbols.insert(path.to_string(), data_file);
-        if let Some(replaced_key) = replaced_key {
-            self.remove(replaced_key.into());
-        }
+        let replaced_key = self.modules[parent].data_file_symbols.insert(path.to_string(), data_file);
+        self.remove_replaced(replaced_key);
+    }
+    
+    fn remove_from_module_data_symbols(&mut self, parent: ModuleKey, path: &str) {
+        self[parent].data_file_symbols.remove(path);
     }
 
     fn add_to_parent_js_symbols(&mut self, parent: JsFileParent, path: &str, js_key: JsFileKey) {
-        match parent {
-            JsFileParent::Module(m) => {
-                let module = &mut self.modules[m];
-                let replaced_key = module.js_symbols.insert(path.to_string(), js_key);
-                if let Some(replaced_key) = replaced_key {
-                    self.remove(replaced_key.into());
-                }
-            },
-            JsFileParent::DiskDir(d) => {
-                let disk_dir = &mut self.disk_dirs[d];
-                let replaced_key = disk_dir.js_symbols.insert(path.to_string(), js_key);
-                if let Some(replaced_key) = replaced_key {
-                    self.remove(replaced_key.into());
-                }
-            }
-        }
+        let replaced_key = parent.js_symbols_mut(self).insert(path.to_string(), js_key);
+        self.remove_replaced(replaced_key);
+    }
+
+    fn remove_from_parent_js_symbols(&mut self, parent: JsFileParent, path: &str) {
+        parent.js_symbols_mut(self).remove(path);
     }
 
     fn add_to_js_entry_symbols(&mut self, entry: &mut EntryPoint, path: &str, js_file: JsFileKey) {
         entry.js_symbols.insert(path.to_string(), Wk::from(js_file));
     }
 
-    /* used by add_new_ext_symbol. Do not call directly */
-    fn get_section_for_key(&self, owner: SymbolKey, position: u32) -> u32 {
-        match owner {
-            SymbolKey::File(f) => self[f].get_section_for(position).index,
-            SymbolKey::Module(m) => self[m].get_section_for(position).index,
-            SymbolKey::PythonPackage(p) => self[p].get_section_for(position).index,
-            SymbolKey::Class(c) => self[c].get_section_for(position).index,
-            SymbolKey::Function(f) => self[f].get_section_for(position).index,
-            _ => panic!("Impossible to add a declaration of external symbol to a {}", owner.typ()),
-        }
-    }
-
     // ====== Symbol removal ======
 
     /// Remove `symbol` and its descendants, and clean up.
     /// WARNING: After this call, `symbol` and its descendants are no longer valid keys.
-    pub fn unload(session: &mut SessionInfo, symbol: SymbolKey) {
+    pub fn unload(session: &mut SessionInfo, symbol: SourceFileKey) {
         fn unload_recursively(session: &mut SessionInfo, symbol: SymbolKey) {
             for child in session.st().children(symbol) {
                 unload_recursively(session, child);
             }
             SyncOdoo::on_unload(session, symbol);
         }
-        unload_recursively(session, symbol);
+        unload_recursively(session, symbol.into());
         session.st_mut().unlink_from_parent(symbol);
-        session.st_mut().remove(symbol);
+        session.st_mut().remove(symbol.into());
     }
 
     /// Only accessible from entry point module
@@ -444,86 +343,68 @@ impl SymbolTable {
         }
     }
 
-    fn children(&self, key: SymbolKey) -> Vec<SymbolKey> {
-        match key {
-            SymbolKey::Root(r) => self[r].children(),
-            SymbolKey::DiskDir(d) => self[d].children(),
-            SymbolKey::Namespace(n) => self[n].children(),
-            SymbolKey::Module(m) => self[m].children(),
-            SymbolKey::PythonPackage(p) => self[p].children(),
-            SymbolKey::File(f) => self[f].children(),
-            SymbolKey::Compiled(c) => self[c].children(),
-            SymbolKey::Class(c) => self[c].children(),
-            SymbolKey::Function(f) => self[f].children(),
-            SymbolKey::Variable(v) => self[v].children(),
-            SymbolKey::XmlFile(x) => self[x].children(),
-            SymbolKey::XmlRecord(x) => self[x].children(),
-            SymbolKey::XmlField(x) => self[x].children(),
-            SymbolKey::XmlAsset(x) => self[x].children(),
-            SymbolKey::XmlMenuItem(x) => self[x].children(),
-            SymbolKey::XmlTemplate(x) => self[x].children(),
-            SymbolKey::XmlDelete(x) => self[x].children(),
-            SymbolKey::CsvFile(c) => self[c].children(),
-            SymbolKey::JsFile(j) => self[j].children(),
+    fn children(&self, key:SymbolKey) -> Vec<SymbolKey> {
+        let mut result = vec![];
+        if let Ok(parent) =  <FileContentParent>::try_from(key){
+            result.extend(parent.children(self));
         }
+        if let Ok(parent) = <FileSystemSymbolParent>::try_from(key){
+            result.extend(parent.children(self));
+        }
+        // Data file parent: Module only
+        if let SymbolKey::Module(module_key) = key {
+            result.extend(self[module_key].data_file_symbols().values().copied().map(SymbolKey::from));
+        }
+        if let Ok(parent) = <JsFileParent>::try_from(key){
+            result.extend(parent.js_symbols(self).values().copied().map(SymbolKey::from));
+        }
+        if let Ok(parent) = <XmlDataParent>::try_from(key){
+            result.extend(parent.data_symbols(self).iter().copied().map(SymbolKey::from));
+        }
+        if let Ok(parent) = <XmlFieldParent>::try_from(key) {
+            result.extend(parent.fields(self).values().copied().map(SymbolKey::from));
+        }
+        result
     }
 
-    fn unlink_from_parent(&mut self, child: SymbolKey) {
-        let child_name = self.name(child).clone();
-        let parent = self.parent(child).expect("symbol should have a parent");
-        match parent {
-            SymbolKey::Root(r) => { self.roots[r].module_symbols.remove(&child_name); },
-            SymbolKey::DiskDir(d) => { 
-                match child {
-                    SymbolKey::JsFile(j) => { self.disk_dirs[d].js_symbols.remove(&self.js_files[j].path); },
-                    _ => { self.disk_dirs[d].module_symbols.remove(&child_name); }
-                }
+    fn unlink_from_parent(&mut self, child: SourceFileKey) {
+        match child {
+            SourceFileKey::File(f) => {
+                let file_symbol = &self[f];
+                let name = file_symbol.name.to_string();
+                let parent = file_symbol.parent();
+                self.remove_from_parent_module_symbols(parent, &name);
             },
-            SymbolKey::Namespace(n) => {
-                for directory in self.namespaces[n].directories.iter_mut() {
-                    directory.module_symbols.remove(&child_name);
-                }
+            SourceFileKey::Module(m) => {
+                let module_symbol = &self[m];
+                let name = module_symbol.name.to_string();
+                let parent = module_symbol.parent();
+                self.remove_from_parent_module_symbols(parent.into(), &name);
             },
-            SymbolKey::Module(m) => match child {
-                SymbolKey::XmlFile(x) => {
-                    self.modules[m].data_symbols.remove(&self.xml_files[x].path);
-                },
-                SymbolKey::CsvFile(c) => {
-                    self.modules[m].data_symbols.remove(&self.csv_files[c].path);
-                },
-                SymbolKey::JsFile(f) => {
-                    self.modules[m].js_symbols.remove(&self.js_files[f].path);
-                }
-                _ => {
-                    if self.is_file_content(child) {
-                        self.modules[m].symbols.remove(&child_name);
-                    } else {
-                        self.modules[m].module_symbols.remove(&child_name);
-                    }
-                },
+            SourceFileKey::PythonPackage(p) => {
+                let package_symbol = &self[p];
+                let name = package_symbol.name.to_string();
+                let parent = package_symbol.parent();
+                self.remove_from_parent_module_symbols(parent, &name);
             },
-            SymbolKey::PythonPackage(p) => {
-                if self.is_file_content(child) {
-                     self.python_packages[p].symbols.remove(&child_name);
-                } else {
-                    self.python_packages[p].module_symbols.remove(&child_name);
-                }
+            SourceFileKey::XmlFile(x) => {
+                let xml_symbol = &self[x];
+                let parent = xml_symbol.parent();
+                let path = xml_symbol.path.clone();
+                self.remove_from_module_data_symbols(parent, &path);
             },
-            SymbolKey::File(f) => { self.files[f].symbols.remove(&child_name); },
-            SymbolKey::Compiled(c) => { self.compiled[c].module_symbols.remove(&child_name); },
-            SymbolKey::Class(c) => { self.classes[c].symbols.remove(&child_name); },
-            SymbolKey::Function(f) => { self.functions[f].symbols.remove(&child_name); },
-            SymbolKey::Variable(_) => { panic!("A variable cannot be a parent") },
-            SymbolKey::XmlFile(f) => { self.xml_files[f].symbols.remove(&child.as_xml_data_key().expect("Content of xmlfile should be an xml_data_key")); },
-            SymbolKey::XmlRecord(r) => { self.xml_records[r].fields.remove(&child_name); },
-            SymbolKey::XmlField(_) => { panic!("An XML field cannot be a parent") },
-            SymbolKey::XmlAsset(a) => { self.xml_assets[a].fields.remove(&child_name); },
-            SymbolKey::XmlMenuItem(_) => { panic!("An XML menu item cannot be a parent") },
-            SymbolKey::XmlTemplate(_) => { panic!("An XML template cannot be a parent") },
-            SymbolKey::XmlDelete(_) => { panic!("An XML delete cannot be a parent") },
-            SymbolKey::CsvFile(_) => { panic!("A CSV file symbol cannot be a parent") },
-            SymbolKey::JsFile(_) => { panic!("A JS file symbol cannot be a parent") },
+            SourceFileKey::CsvFile(c) => {
+                let csv_symbol = &self[c];
+                let parent = csv_symbol.parent();
+                let path = csv_symbol.path.clone();
+                self.remove_from_module_data_symbols(parent, &path);
+            },
+            SourceFileKey::JsFile(j) => {
+                let js_symbol = &self[j];
+                let parent = js_symbol.parent();
+                let path = js_symbol.path.clone();
+                self.remove_from_parent_js_symbols(parent, &path);
+            },
         }
     }
-
 }

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -394,3 +394,158 @@ impl SymbolTable {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::entry_point::EntryPointType;
+    use crate::core::symbols::symbol_keys::KeyValidator;
+    use crate::oyarn;
+
+    fn range_at(start: u32) -> TextRange {
+        TextRange::new(TextSize::new(start), TextSize::new(start + 1))
+    }
+
+    /// Parent-linking half of `add_new_module_package`. The other half,
+    /// `load_manifest_content`, needs a `SessionInfo` and reads the manifest from disk.
+    fn add_module(st: &mut SymbolTable, parent: NamespaceKey, name: &str, path: &str) -> ModuleKey {
+        let is_external = st.is_external(parent.into());
+        let module = ModuleSymbol::new(name, Path::new(path), parent, is_external);
+        let module_key = st.modules.insert(module);
+        st.add_to_parent_module_symbols(parent.into(), module_key.into(), name, path);
+        module_key
+    }
+
+    /// One symbol of every kind used as a parent below. `NamespaceSymbol` files its children by
+    /// path, so everything given `namespace` as parent must live under `/root/ns`.
+    struct Fixture {
+        st: SymbolTable,
+        root: RootKey,
+        namespace: NamespaceKey,
+        disk_dir: DiskDirKey,
+        module: ModuleKey,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let mut st = SymbolTable::new();
+            let entry = EntryPoint::new(&mut st, "/root".to_string(), vec![], EntryPointType::MAIN, None, None);
+            let root = entry.borrow().root;
+            let namespace = st.add_new_namespace(root.into(), "ns", "/root/ns");
+            let disk_dir = st.add_new_disk_dir(root.into(), "dd", "/root/dd");
+            let module = add_module(&mut st, namespace, "mod", "/root/ns/mod");
+            Self { st, root, namespace, disk_dir, module }
+        }
+
+        fn holds(&mut self, parent: SymbolKey, child: impl Into<SymbolKey>) -> bool {
+            self.st.children(parent).contains(&child.into())
+        }
+    }
+
+    #[test]
+    fn source_files_round_trip_through_their_parent() {
+        let mut f = Fixture::new();
+        // One child per `SourceFileKey` variant. `File` and `JsFile` appear twice, to cover both
+        // of their parent kinds; the namespace is the only hand-written `FileSystemItemHolder`.
+        let in_root = f.st.add_new_file(f.root.into(), "in_root", "/root/in_root.py");
+        let in_namespace = f.st.add_new_file(f.namespace.into(), "in_namespace", "/root/ns/in_namespace.py");
+        let package = f.st.add_new_python_package(f.root.into(), "a_package", "/root/a_package", "");
+        let module = add_module(&mut f.st, f.namespace, "another_module", "/root/ns/another_module");
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+        let js_in_module = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
+        let js_in_disk_dir = f.st.add_new_js_file(JsFileParent::DiskDir(f.disk_dir), "lib.js", "/root/dd/lib.js");
+        let sibling = f.st.add_new_file(f.module.into(), "sibling", "/root/ns/mod/sibling.py");
+
+        let cases: Vec<(SymbolKey, SourceFileKey)> = vec![
+            (f.root.into(), in_root.into()),
+            (f.namespace.into(), in_namespace.into()),
+            (f.root.into(), package.into()),
+            (f.namespace.into(), module.into()),
+            (f.module.into(), xml_file.into()),
+            (f.module.into(), csv_file.into()),
+            (f.module.into(), js_in_module.into()),
+            (f.disk_dir.into(), js_in_disk_dir.into()),
+        ];
+
+        for (parent, child) in cases {
+            assert!(f.holds(parent, child), "{child:?} is not a child of {parent:?}");
+            assert_eq!(f.st.parent(child), Some(parent), "{child:?} does not point back at {parent:?}");
+
+            f.st.unlink_from_parent(child);
+            assert!(!f.holds(parent, child), "{child:?} is still a child of {parent:?} after unlink");
+        }
+
+        assert!(f.holds(f.module.into(), sibling), "an unlink evicted an unrelated sibling");
+    }
+
+    #[test]
+    fn file_content_round_trips_and_dies_with_its_file() {
+        let mut f = Fixture::new();
+        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py");
+        let class = f.st.add_new_class(file.into(), "AClass", range_at(0), TextSize::new(0));
+        let method = f.st.add_new_function(class.into(), "method", range_at(10), TextSize::new(10));
+        let local = f.st.add_new_variable(method, "local", range_at(20));
+
+        assert!(f.holds(file.into(), class));
+        assert!(f.holds(class.into(), method));
+        assert!(f.holds(method.into(), local));
+        assert_eq!(f.st.parent(local), Some(SymbolKey::from(method)));
+
+        // what `unload` does, minus `SyncOdoo::on_unload`
+        f.st.unlink_from_parent(file.into());
+        f.st.remove(file.into());
+
+        assert!(!f.holds(f.module.into(), file));
+        for key in [SymbolKey::from(file), class.into(), method.into(), local.into()] {
+            assert!(!f.st.is_key_valid(key), "{key:?} outlived its file");
+        }
+        assert!(f.st.is_key_valid(f.module), "removing a file took its module down");
+    }
+
+    #[test]
+    fn xml_data_round_trips_and_dies_with_its_file() {
+        let mut f = Fixture::new();
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+
+        let record = f.st.add_new_xml_record(XmlDataParent::XmlFile(xml_file), (oyarn!("res.partner"), 0..1), Some(oyarn!("a_partner")), range_at(0));
+        let menuitem = f.st.add_new_xml_menuitem(xml_file, Some(oyarn!("a_menu")), range_at(10));
+        let field = f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), oyarn!("name"), range_at(1), None, None, None);
+        let csv_record = f.st.add_new_xml_record(XmlDataParent::CsvFile(csv_file), (oyarn!("res.partner"), 0..1), Some(oyarn!("a_csv_partner")), range_at(0));
+
+        assert!(f.holds(xml_file.into(), record));
+        assert!(f.holds(xml_file.into(), menuitem));
+        assert!(f.holds(record.into(), field));
+        assert!(f.holds(csv_file.into(), csv_record));
+        assert_eq!(f.st.parent(field), Some(SymbolKey::from(record)));
+
+        f.st.unlink_from_parent(xml_file.into());
+        f.st.remove(xml_file.into());
+
+        assert!(!f.holds(f.module.into(), xml_file));
+        for key in [SymbolKey::from(record), menuitem.into(), field.into()] {
+            assert!(!f.st.is_key_valid(key), "{key:?} outlived its xml file");
+        }
+        assert!(f.st.is_key_valid(csv_record), "removing the xml file took the csv records down");
+    }
+
+    /// `ModuleSymbol` implements four holder traits, which is why `children` is a sequence of
+    /// `if let`s over the parent enums instead of a match.
+    #[test]
+    fn module_children_join_every_family_it_holds() {
+        let mut f = Fixture::new();
+        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py");
+        let constant = f.st.add_new_variable(f.module, "MODULE_CONSTANT", range_at(0));
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+        let js_file = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
+
+        let children = f.st.children(f.module.into());
+        for expected in [SymbolKey::from(file), constant.into(), xml_file.into(), csv_file.into(), js_file.into()] {
+            assert!(children.contains(&expected), "{expected:?} missing from the module's children");
+            assert_eq!(f.st.parent(expected), Some(SymbolKey::from(f.module)));
+        }
+        assert_eq!(children.len(), 5, "the module reports children it was not given: {children:?}");
+    }
+}

--- a/server/src/core/symbols/storage/module_symbol.rs
+++ b/server/src/core/symbols/storage/module_symbol.rs
@@ -3,7 +3,7 @@ use crate::core::file_mgr::NoqaInfo;
 use crate::core::model::Model;
 use crate::core::symbols::SymbolTable;
 use crate::core::symbols::storage::dependency_mgr::{DependenciesTable, DependentsTable};
-use crate::core::symbols::symbol_keys::{ModuleKey, JsFileKey, NamespaceKey, SourceFileKey, SymbolKey, XmlId};
+use crate::core::symbols::symbol_keys::{JsFileKey, ModuleKey, NamespaceKey, SourceFileKey, SymbolKey, XmlId};
 use super::symbol_mgr::SymbolMgr;
 use crate::utils::{PathSanitizer};
 use crate::weak_collections::WeakSet;
@@ -50,8 +50,8 @@ pub struct ModuleSymbol {
     // parent / child symbols
     parent: NamespaceKey,
     pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
-    pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
-    pub(super) data_symbols: HashMap<String, SourceFileKey>,
+    pub(super) fs_symbols: HashMap<OYarn, SymbolKey>,
+    pub(super) data_file_symbols: HashMap<String, SourceFileKey>,
     pub(super) js_symbols: HashMap<String, JsFileKey>,
 }
 
@@ -85,7 +85,7 @@ impl ModuleSymbol {
             data: Vec::new(),
             assets: Vec::new(),
             parent,
-            module_symbols: HashMap::default(),
+            fs_symbols: HashMap::default(),
             arch_status: BuildStatus::PENDING,
             arch_eval_status: BuildStatus::PENDING,
             validation_status: BuildStatus::PENDING,
@@ -96,7 +96,7 @@ impl ModuleSymbol {
             dependents: DependentsTable::default(),
             processed_text_hash: 0,
             noqas: NoqaInfo::None,
-            data_symbols: HashMap::default(),
+            data_file_symbols: HashMap::default(),
             js_symbols: HashMap::default(),
         };
         module._init_symbol_mgr();
@@ -104,15 +104,15 @@ impl ModuleSymbol {
     }
 
     pub fn module_symbols(&self) -> &HashMap<OYarn, SymbolKey> {
-        &self.module_symbols
+        &self.fs_symbols
     }
 
     pub fn data(&self) -> &[(String, TextRange)] {
         &self.data
     }
 
-    pub fn data_symbols(&self) -> &HashMap<String, SourceFileKey> {
-        &self.data_symbols
+    pub fn data_file_symbols(&self) -> &HashMap<String, SourceFileKey> {
+        &self.data_file_symbols
     }
 
     pub fn js_symbols(&self) -> &HashMap<String, JsFileKey> {
@@ -121,14 +121,6 @@ impl ModuleSymbol {
 
     pub fn parent(&self) -> NamespaceKey {
         self.parent
-    }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.symbols.values().flat_map(|section| section.values()).flatten()
-            .chain(self.module_symbols.values()).copied()
-            .chain(self.data_symbols.values().map(|&key| key.into()))
-            .chain(self.js_symbols.values().map(|&key| key.into()))
-            .collect()
     }
 
     pub fn is_in_deps(symbol_table: &SymbolTable, module_key: ModuleKey, dir_name: &OYarn) -> bool {

--- a/server/src/core/symbols/storage/namespace_symbol.rs
+++ b/server/src/core/symbols/storage/namespace_symbol.rs
@@ -80,4 +80,13 @@ impl NamespaceSymbol {
             .flat_map(|d| d.module_symbols.values())
             .copied()
     }
+
+    pub fn get_child(&self, name: &str) -> Option<SymbolKey> {
+        for dir in self.directories.iter() {
+            if let Some(child) = dir.module_symbols.get(name) {
+                return Some(*child);
+            }
+        }
+        None
+    }
 }

--- a/server/src/core/symbols/storage/namespace_symbol.rs
+++ b/server/src/core/symbols/storage/namespace_symbol.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+use crate::core::symbols::storage::{FileSystemSymbolParent};
+use crate::core::symbols::symbol_keys::SymbolKey;
 use crate::utils::HashMap;
-use crate::{constants::OYarn, core::symbols::symbol_keys::SymbolKey, oyarn};
+use crate::{constants::OYarn, oyarn};
 
 #[derive(Debug)]
 pub struct NamespaceDirectory {
@@ -20,13 +23,13 @@ pub struct NamespaceSymbol {
     pub in_workspace: bool,
 
     // parent / child symbols
-    parent: SymbolKey,
-    pub(super) directories: Vec<NamespaceDirectory>,
+    parent: FileSystemSymbolParent,
+    directories: Vec<NamespaceDirectory>,
 }
 
 impl NamespaceSymbol {
 
-    pub fn new(name: &str, paths: Vec<String>, parent: SymbolKey, is_external: bool) -> Self {
+    pub fn new(name: &str, paths: Vec<String>, parent: FileSystemSymbolParent, is_external: bool) -> Self {
         let directories = paths.into_iter().map(|p| NamespaceDirectory {
             path: p,
             module_symbols: HashMap::default(),
@@ -52,14 +55,29 @@ impl NamespaceSymbol {
         &self.directories
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileSystemSymbolParent {
         self.parent
     }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
+    
+    pub(super) fn add_child(&mut self, name: &str, child: SymbolKey, path: &str) -> Option<SymbolKey> {
+        let best = self.directories.iter()
+            .enumerate()
+            .filter(|(_, dir)| Path::new(path).starts_with(&dir.path))
+            .max_by_key(|(_, dir)| dir.path.len())
+            .unwrap_or_else(|| panic!("Not valid path found to add the file ({}) to namespace {} with directories {:?}", path, self.name, self.directories))
+            .0;
+        self.directories[best].module_symbols.insert(oyarn!("{}", name), child)
+    }
+    
+    pub (super) fn remove_child(&mut self, child_name: &str) {
+        for directory in self.directories.iter_mut() {
+            directory.module_symbols.remove(child_name);
+        }
+    }
+    
+    pub fn children(&self) -> impl Iterator<Item = SymbolKey> {
         self.directories.iter()
             .flat_map(|d| d.module_symbols.values())
-            .copied().collect()
+            .copied()
     }
-
 }

--- a/server/src/core/symbols/storage/package_symbol.rs
+++ b/server/src/core/symbols/storage/package_symbol.rs
@@ -1,6 +1,6 @@
 use weak_table::PtrWeakHashSet;
 
-use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::dependency_mgr::{DependenciesTable, DependentsTable}, symbol_keys::SymbolKey}}, oyarn, utils::PathSanitizer};
+use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::NoqaInfo, model::Model, symbols::{storage::{dependency_mgr::{DependenciesTable, DependentsTable}, FileSystemSymbolParent}, symbol_keys::SymbolKey}}, oyarn, utils::PathSanitizer};
 use std::{cell::RefCell, path::Path, rc::Weak};
 use crate::utils::HashMap;
 
@@ -29,14 +29,14 @@ pub struct PythonPackageSymbol {
     pub sections: Vec<SectionRange>,
 
     // parent / child symbols
-    parent: SymbolKey,
+    parent: FileSystemSymbolParent,
     pub(super) symbols: HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>>,
-    pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
+    pub(super) fs_symbols: HashMap<OYarn, SymbolKey>,
 }
 
 impl PythonPackageSymbol {
 
-    pub fn new(name: &str, path: &str, parent: SymbolKey, is_external: bool, i_ext: &'static str) -> Self {
+    pub fn new(name: &str, path: &str, parent: FileSystemSymbolParent, is_external: bool, i_ext: &'static str) -> Self {
         let mut res = Self {
             name: oyarn!("{}", name),
             path: path.to_string(),
@@ -50,7 +50,7 @@ impl PythonPackageSymbol {
             not_found_paths: vec![],
             in_workspace: false,
             self_import: false, //indicates that if unloaded, the symbol should be added in the rebuild automatically as nothing depends on it (used for root packages)
-            module_symbols: HashMap::default(),
+            fs_symbols: HashMap::default(),
             sections: vec![],
             symbols: HashMap::default(),
             model_dependencies: PtrWeakHashSet::new(),
@@ -64,18 +64,11 @@ impl PythonPackageSymbol {
     }
 
     pub fn module_symbols(&self) -> &HashMap<OYarn, SymbolKey> {
-        &self.module_symbols
+        &self.fs_symbols
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileSystemSymbolParent {
         self.parent
-    }
-
-    /// symbols + module_symbols
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.symbols.values().flat_map(|section| section.values()).flatten()
-            .chain(self.module_symbols.values())
-            .copied().collect()
     }
 
 }

--- a/server/src/core/symbols/storage/parents.rs
+++ b/server/src/core/symbols/storage/parents.rs
@@ -75,7 +75,7 @@ pub enum FileSystemSymbolParent {
 }
 
 impl FileSystemSymbolParent {
-    /// Helper for Self::children
+    /// Helper for Self::children and get_child
     fn fs_symbols(self, st: &SymbolTable) -> &HashMap<OYarn, SymbolKey> {
         match self {
             Self::Root(r) => &st[r].fs_symbols,
@@ -112,7 +112,14 @@ impl FileSystemSymbolParent {
         }
         self.fs_symbols_mut(st).remove(name);
     }
-
+    
+    pub fn get_child(self, st: &SymbolTable, name: &str) -> Option<SymbolKey> {
+        if let Self::Namespace(ns) = self {
+            return st[ns].get_child(name);
+        }
+        self.fs_symbols(st).get(name).copied()
+    }
+    
     pub fn children(self, st: &SymbolTable) -> Vec<SymbolKey> {
         if let Self::Namespace(ns) = self {
             return st[ns].children().collect();

--- a/server/src/core/symbols/storage/parents.rs
+++ b/server/src/core/symbols/storage/parents.rs
@@ -1,0 +1,194 @@
+use odoo_ls_macros::{SymbolKeySubset};
+use crate::{
+    constants::OYarn,
+    core::symbols::{
+        symbol_keys::{
+            ClassKey, CompiledKey, CsvFileKey, DiskDirKey, FileKey, FunctionKey, JsFileKey,
+            ModuleKey, NamespaceKey, PythonPackageKey, RootKey, SymbolKey,
+            XmlAssetKey, XmlDataKey, XmlFieldKey, XmlFileKey, XmlRecordKey,
+        },
+        SymbolMgr,
+    },
+    oyarn,
+    utils::{HashMap, HashSet},
+};
+use super::SymbolTable;
+
+// ==== File content ====
+
+#[derive(Debug, Clone, Copy, SymbolKeySubset)]
+pub enum FileContentParent {
+    File(FileKey),
+    PythonPackage(PythonPackageKey),
+    Module(ModuleKey),
+    Class(ClassKey),
+    Function(FunctionKey),
+}
+
+impl FileContentParent {
+    pub fn as_symbol_mgr(self, st: &SymbolTable) -> &dyn SymbolMgr {
+        match self {
+            Self::File(f) => &st[f],
+            Self::PythonPackage(p) => &st[p],
+            Self::Module(m) => &st[m],
+            Self::Class(c) => &st[c],
+            Self::Function(f) => &st[f],
+        }
+    }
+    
+    pub(super) fn symbols_mut(self, st: &mut SymbolTable) -> &mut HashMap<OYarn, HashMap<u32, Vec<SymbolKey>>> {
+        match self {
+            Self::File(f) => &mut st[f].symbols,
+            Self::PythonPackage(p) => &mut st[p].symbols,
+            Self::Module(m) => &mut st[m].symbols,
+            Self::Class(c) => &mut st[c].symbols,
+            Self::Function(f) => &mut st[f].symbols,
+        }
+    }
+    
+    pub(super) fn add_child(self, st: &mut SymbolTable, name: &str, child: SymbolKey, position: u32) {
+        let section = self.as_symbol_mgr(st).get_section_for(position).index;
+        let name = oyarn!("{}", name);
+        self.symbols_mut(st).entry(name).or_default()
+            .entry(section).or_default()
+            .push(child);
+    } 
+    
+    pub fn children(&self, st: &SymbolTable) -> impl Iterator<Item = SymbolKey> {
+        self.as_symbol_mgr(st).symbols().values()
+            .flat_map(|section| section.values())
+            .flatten()
+            .copied()
+    }
+}
+
+// ==== Filesystem items (aka module symbols) ====
+
+#[derive(Debug, Clone, Copy, SymbolKeySubset)]
+pub enum FileSystemSymbolParent {
+    Root(RootKey),
+    DiskDir(DiskDirKey),
+    Namespace(NamespaceKey),
+    PythonPackage(PythonPackageKey),
+    Module(ModuleKey),
+    Compiled(CompiledKey),
+}
+
+impl FileSystemSymbolParent {
+    /// Helper for Self::children
+    fn fs_symbols(self, st: &SymbolTable) -> &HashMap<OYarn, SymbolKey> {
+        match self {
+            Self::Root(r) => &st[r].fs_symbols,
+            Self::DiskDir(d) => &st[d].fs_symbols,
+            Self::PythonPackage(p) => &st[p].fs_symbols,
+            Self::Module(m) => &st[m].fs_symbols,
+            Self::Compiled(c) => &st[c].fs_symbols,
+            Self::Namespace(_) => panic!("caller handles namespace separately")
+        }
+    }
+    
+    /// Helper for add/remove_fs_symbol
+    fn fs_symbols_mut(self, st: &mut SymbolTable) -> &mut HashMap<OYarn, SymbolKey> {
+        match self {
+            Self::Root(r) => &mut st[r].fs_symbols,
+            Self::DiskDir(d) => &mut st[d].fs_symbols,
+            Self::PythonPackage(p) => &mut st[p].fs_symbols,
+            Self::Module(m) => &mut st[m].fs_symbols,
+            Self::Compiled(c) => &mut st[c].fs_symbols,
+            Self::Namespace(_) => panic!("caller handles namespace separately")
+        }
+    }
+    
+    pub(super) fn add_fs_symbol(self, st: &mut SymbolTable, name: &str, child: SymbolKey, path: &str) -> Option<SymbolKey> {
+        if let Self::Namespace(ns) = self {
+            return st[ns].add_child(name, child, path);
+        }
+        self.fs_symbols_mut(st).insert(oyarn!("{}", name), child)
+    }
+
+    pub(super) fn remove_fs_symbol(self, st: &mut SymbolTable, name: &str) {
+        if let Self::Namespace(ns) = self {
+            return st[ns].remove_child(name);
+        }
+        self.fs_symbols_mut(st).remove(name);
+    }
+
+    pub fn children(self, st: &SymbolTable) -> Vec<SymbolKey> {
+        if let Self::Namespace(ns) = self {
+            return st[ns].children().collect();
+        }
+        self.fs_symbols(st).values().copied().collect()
+    }
+}
+
+// ==== Js symbols ====
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, SymbolKeySubset)]
+pub enum JsFileParent {
+    Module(ModuleKey),
+    DiskDir(DiskDirKey),
+}
+
+impl JsFileParent {
+    pub fn js_symbols(self, st: &SymbolTable) -> &HashMap<String, JsFileKey> {
+        match self {
+            Self::Module(m) => &st[m].js_symbols,
+            Self::DiskDir(d) => &st[d].js_symbols,
+        }
+    }
+    
+    pub(super) fn js_symbols_mut(self, st: &mut SymbolTable) -> &mut HashMap<String, JsFileKey> {
+        match self {
+            Self::Module(m) => &mut st[m].js_symbols,
+            Self::DiskDir(d) => &mut st[d].js_symbols,
+        }
+    }
+}
+
+// ==== Xml data ====
+
+#[derive(Debug, Clone, Copy, SymbolKeySubset)]
+pub enum XmlDataParent {
+    XmlFile(XmlFileKey),
+    CsvFile(CsvFileKey),
+}
+
+impl XmlDataParent {
+    pub fn data_symbols(self, st: &SymbolTable) -> &HashSet<XmlDataKey> {
+        match self {
+            Self::XmlFile(x) => &st[x].data_symbols,
+            Self::CsvFile(c) => &st[c].data_symbols,
+        }
+    }
+    
+    pub(super) fn data_symbols_mut(self, st: &mut SymbolTable) -> &mut HashSet<XmlDataKey> {
+        match self {
+            Self::XmlFile(x) => &mut st[x].data_symbols,
+            Self::CsvFile(c) => &mut st[c].data_symbols,
+        }
+    }
+}
+
+// ==== Xml Fields ====
+
+#[derive(Debug, Clone, Copy, SymbolKeySubset)]
+pub enum XmlFieldParent {
+    XmlRecord(XmlRecordKey),
+    XmlAsset(XmlAssetKey),
+}
+
+impl XmlFieldParent {
+    pub fn fields(self, st: &SymbolTable) -> &HashMap<OYarn, XmlFieldKey> {
+        match self {
+            Self::XmlRecord(x) => &st[x].fields,
+            Self::XmlAsset(x) => &st[x].fields,
+        }
+    }
+    
+    pub fn fields_mut(self, st: &mut SymbolTable) -> &mut HashMap<OYarn, XmlFieldKey> {
+        match self {
+            Self::XmlRecord(x) => &mut st[x].fields,
+            Self::XmlAsset(x) => &mut st[x].fields,
+        }
+    }
+}

--- a/server/src/core/symbols/storage/root_symbol.rs
+++ b/server/src/core/symbols/storage/root_symbol.rs
@@ -8,7 +8,7 @@ pub struct RootSymbol {
     entry_point: Rc<RefCell<EntryPoint>>,
 
     // child symbols (no parent)
-    pub(super) module_symbols: HashMap<OYarn, SymbolKey>,
+    pub(super) fs_symbols: HashMap<OYarn, SymbolKey>,
 }
 
 impl RootSymbol {
@@ -17,18 +17,14 @@ impl RootSymbol {
         Self {
             name: oyarn!("Root"),
             entry_point,
-            module_symbols: HashMap::default(),
+            fs_symbols: HashMap::default(),
         }
     }
 
     pub fn module_symbols(&self) -> &HashMap<OYarn, SymbolKey> {
-        &self.module_symbols
+        &self.fs_symbols
     }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.module_symbols.values().copied().collect()
-    }
-
+ 
     pub fn entry_point(&self) -> &Rc<RefCell<EntryPoint>> {
         &self.entry_point
     }

--- a/server/src/core/symbols/storage/symbol_mgr.rs
+++ b/server/src/core/symbols/storage/symbol_mgr.rs
@@ -114,5 +114,5 @@ impl_section_mgr_for!(FileSymbol, ClassSymbol, FunctionSymbol, ModuleSymbol, Pyt
 pub fn iter_symbol_keys(symbol: &impl SymbolMgr) -> impl Iterator<Item = & SymbolKey> {
     symbol.symbols().values()
         .flat_map(|section| section.values())
-        .flat_map(|symbol_list| symbol_list.iter())
+        .flatten()
 }

--- a/server/src/core/symbols/storage/variable_symbol.rs
+++ b/server/src/core/symbols/storage/variable_symbol.rs
@@ -3,10 +3,10 @@ use ruff_text_size::TextRange;
 use crate::{
     constants::OYarn,
     core::{
-        evaluation::{Evaluation},
+        evaluation::Evaluation,
         evaluation_context::{Context, ContextKey, ContextValue},
         symbols::{
-            storage::SymbolTable,
+            storage::{SymbolTable, FileContentParent},
             symbol_keys::{ModelSymbolKey, ModuleKey, SymbolKey, VariableKey},
         },
     },
@@ -24,12 +24,12 @@ pub struct VariableSymbol {
     pub range: TextRange,
 
     // parent symbol (no children)
-    parent: SymbolKey,
+    parent: FileContentParent,
 }
 
 impl VariableSymbol {
 
-    pub fn new(name: &str, parent: SymbolKey, range: TextRange, is_external: bool) -> Self {
+    pub fn new(name: &str, parent: FileContentParent, range: TextRange, is_external: bool) -> Self {
         Self {
             name: name.to_string().into(),
             is_external,
@@ -70,7 +70,7 @@ impl VariableSymbol {
         let evaluations = variable_symbol.evaluations.clone();
         for eval in evaluations.iter() {
             let symbol = eval.symbol.get_symbol(session, None, &mut vec![], None);
-            let parent = session.st()[target].parent();
+            let parent: SymbolKey = session.st()[target].parent().into();
             // To be able to follow related fields, we need to have the base_attr set in order to find the __get__ hook in next_refs
             // we update the context here for the case where we are coming from a decorator for example.
             let context = Context::from_iter([(ContextKey::BaseAttr, ContextValue::SYMBOL(parent.into()))]);
@@ -100,13 +100,7 @@ impl VariableSymbol {
         !self.evaluations.iter().any(|x| x.value.is_none())
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> FileContentParent {
         self.parent
     }
-
-    /// no child symbols
-    pub fn children(&self) -> Vec<SymbolKey> {
-        vec![]
-    }
-
 }

--- a/server/src/core/symbols/storage/xml/xml_asset_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_asset_symbol.rs
@@ -1,29 +1,25 @@
-use crate::utils::HashMap;
+use crate::{core::symbols::storage::XmlDataParent, utils::HashMap};
 
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::symbols::symbol_keys::{SymbolKey, XmlFieldKey}};
+use crate::{constants::OYarn, core::symbols::symbol_keys::XmlFieldKey};
 
 #[derive(Debug)]
 pub struct XmlAssetSymbol {
     pub xml_id: Option<OYarn>,
     pub is_external: bool,
-    pub (in crate::core::symbols::storage) fields: HashMap<OYarn, XmlFieldKey>,
     pub range: TextRange,
 
-    parent: SymbolKey,
+    parent: XmlDataParent,
+    pub(in crate::core::symbols::storage) fields: HashMap<OYarn, XmlFieldKey>,
 }
 
 impl XmlAssetSymbol {
-    pub fn new(xml_id: Option<OYarn>, range: TextRange, parent: SymbolKey, is_external: bool) -> Self {
+    pub fn new(xml_id: Option<OYarn>, range: TextRange, parent: XmlDataParent, is_external: bool) -> Self {
         Self { xml_id, range, parent, is_external, fields: HashMap::default() }
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> XmlDataParent {
         self.parent
-    }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.fields.values().map(|k| SymbolKey::XmlField(*k)).collect()
     }
 }

--- a/server/src/core/symbols/storage/xml/xml_delete_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_delete_symbol.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::{symbols::symbol_keys::SymbolKey}};
+use crate::{constants::OYarn, core::symbols::storage::XmlDataParent};
 
 #[derive(Debug)]
 pub struct XmlDeleteSymbol {
@@ -9,20 +9,15 @@ pub struct XmlDeleteSymbol {
     pub range: TextRange,
     pub model: OYarn,
 
-    parent: SymbolKey,
+    parent: XmlDataParent,
 }
 
 impl XmlDeleteSymbol {
-    pub fn new(xml_id: Option<OYarn>, range: TextRange, model: OYarn, parent: SymbolKey, is_external: bool) -> Self {
+    pub fn new(xml_id: Option<OYarn>, range: TextRange, model: OYarn, parent: XmlDataParent, is_external: bool) -> Self {
         Self { xml_id, range, parent, is_external, model }
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> XmlDataParent {
         self.parent
-    }
-
-    /// no child symbols
-    pub fn children(&self) -> Vec<SymbolKey> {
-        vec![]
     }
 }

--- a/server/src/core/symbols/storage/xml/xml_field_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_field_symbol.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::symbols::symbol_keys::SymbolKey};
+use crate::{constants::OYarn, core::symbols::storage::XmlFieldParent};
 use std::fmt::Display;
 
 
@@ -13,7 +13,7 @@ pub struct XmlFieldSymbol {
     pub ref_key: Option<(String, TextRange)>,
     pub is_external: bool,
 
-    parent: SymbolKey,
+    parent: XmlFieldParent,
 }
 
 impl XmlFieldSymbol {
@@ -23,7 +23,7 @@ impl XmlFieldSymbol {
         text: Option<String>,
         text_range: Option<TextRange>,
         ref_key: Option<(String, TextRange)>,
-        parent: SymbolKey,
+        parent: XmlFieldParent,
         is_external: bool,
     ) -> Self {
         Self {
@@ -37,13 +37,8 @@ impl XmlFieldSymbol {
         }
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> XmlFieldParent {
         self.parent
-    }
-
-    /// no child symbols
-    pub fn children(&self) -> Vec<SymbolKey> {
-        vec![]
     }
 }
 

--- a/server/src/core/symbols/storage/xml/xml_file_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_file_symbol.rs
@@ -4,7 +4,7 @@ use weak_table::PtrWeakHashSet;
 
 use crate::constants::MissingDataSource;
 use crate::core::symbols::storage::dependency_mgr::{DependenciesTable, DependentsTable};
-use crate::core::symbols::symbol_keys::{ModuleKey, SymbolKey, XmlDataKey};
+use crate::core::symbols::symbol_keys::{ModuleKey, XmlDataKey};
 use crate::core::symbols::Buildable;
 use crate::{core::diagnostics::DiagnosticCode, threads::SessionInfo};
 use crate::{constants::{BuildStatus, BuildSteps, OYarn}, core::{file_mgr::{FileInfo, NoqaInfo}, model::Model}, oyarn};
@@ -22,7 +22,6 @@ pub struct XmlFileSymbol {
     pub not_found_paths: Vec<(BuildSteps, Vec<OYarn>)>,
     pub not_found_models: HashMap<OYarn, BuildSteps>,
     pub not_found_data_ids: HashMap<MissingDataSource, BuildSteps>,
-    pub (in crate::core::symbols::storage) symbols: HashSet<XmlDataKey>,
     pub (in crate::core::symbols) in_workspace: bool,
     pub self_import: bool,
     pub model_dependencies: PtrWeakHashSet<Weak<RefCell<Model>>>, //always on validation level, as odoo step is always required
@@ -32,6 +31,7 @@ pub struct XmlFileSymbol {
     pub noqas: NoqaInfo,
 
     parent: ModuleKey,
+    pub(in crate::core::symbols::storage) data_symbols: HashSet<XmlDataKey>,
 }
 
 impl XmlFileSymbol {
@@ -47,7 +47,7 @@ impl XmlFileSymbol {
             not_found_paths: vec![],
             not_found_models: HashMap::default(),
             not_found_data_ids: HashMap::default(),
-            symbols: HashSet::default(),
+            data_symbols: HashSet::default(),
             in_workspace: false,
             self_import: false,
             model_dependencies: PtrWeakHashSet::new(),
@@ -62,12 +62,8 @@ impl XmlFileSymbol {
         self.parent
     }
 
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.symbols.iter().copied().map(SymbolKey::from).collect()
-    }
-
-    pub fn symbols(&self) -> &HashSet<XmlDataKey> {
-        &self.symbols
+    pub fn data_symbols(&self) -> &HashSet<XmlDataKey> {
+        &self.data_symbols
     }
 
 }

--- a/server/src/core/symbols/storage/xml/xml_menuitem_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_menuitem_symbol.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::{symbols::symbol_keys::SymbolKey}};
+use crate::{constants::OYarn, core::symbols::storage::XmlDataParent};
 
 #[derive(Debug)]
 pub struct XmlMenuItemSymbol {
@@ -8,20 +8,15 @@ pub struct XmlMenuItemSymbol {
     pub is_external: bool,
     pub range: TextRange,
 
-    parent: SymbolKey,
+    parent: XmlDataParent,
 }
 
 impl XmlMenuItemSymbol {
-    pub fn new(xml_id: Option<OYarn>, range: TextRange, parent: SymbolKey, is_external: bool) -> Self {
+    pub fn new(xml_id: Option<OYarn>, range: TextRange, parent: XmlDataParent, is_external: bool) -> Self {
         Self { xml_id, range, parent, is_external }
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> XmlDataParent {
         self.parent
-    }
-
-    /// no child symbols
-    pub fn children(&self) -> Vec<SymbolKey> {
-        vec![]
     }
 }

--- a/server/src/core/symbols/storage/xml/xml_record_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_record_symbol.rs
@@ -1,19 +1,19 @@
 use std::ops::Range;
-use crate::{core::symbols::{SymbolTable, storage::xml::xml_field_symbol::XmlFieldName, symbol_keys::XmlRecordKey}, utils::HashMap};
+use crate::{core::symbols::{SymbolTable, storage::{XmlDataParent, xml::xml_field_symbol::XmlFieldName}, symbol_keys::XmlRecordKey}, utils::HashMap};
 
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::symbols::symbol_keys::{SymbolKey, XmlFieldKey}};
+use crate::{constants::OYarn, core::symbols::symbol_keys::XmlFieldKey};
 
 #[derive(Debug)]
 pub struct XmlRecordSymbol {
     pub is_external: bool,
     pub model: (OYarn, Range<usize>),
     pub xml_id: Option<OYarn>,
-    pub (in crate::core::symbols::storage) fields: HashMap<OYarn, XmlFieldKey>,
     pub range: TextRange,
 
-    parent: SymbolKey,
+    parent: XmlDataParent,
+    pub(in crate::core::symbols::storage) fields: HashMap<OYarn, XmlFieldKey>,
 }
 
 impl XmlRecordSymbol {
@@ -21,7 +21,7 @@ impl XmlRecordSymbol {
         model: (OYarn, Range<usize>),
         xml_id: Option<OYarn>,
         range: TextRange,
-        parent: SymbolKey,
+        parent: XmlDataParent,
         is_external: bool,
     ) -> Self {
         Self {
@@ -34,12 +34,8 @@ impl XmlRecordSymbol {
         }
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> XmlDataParent {
         self.parent
-    }
-
-    pub fn children(&self) -> Vec<SymbolKey> {
-        self.fields.values().map(|k| SymbolKey::XmlField(*k)).collect()
     }
 
     pub fn fields(&self) -> &HashMap<OYarn, XmlFieldKey> {

--- a/server/src/core/symbols/storage/xml/xml_template_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_template_symbol.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::{symbols::symbol_keys::SymbolKey}};
+use crate::{constants::OYarn, core::symbols::storage::XmlDataParent};
 
 #[derive(Debug)]
 pub struct XmlTemplateSymbol {
@@ -15,20 +15,15 @@ pub struct XmlTemplateSymbol {
     /// A template element carries at most one `t-inherit`. The range excludes the quotes.
     pub t_inherit: Option<(OYarn, TextRange)>,
 
-    parent: SymbolKey,
+    parent: XmlDataParent,
 }
 
 impl XmlTemplateSymbol {
-    pub fn new(xml_id: Option<OYarn>, t_name: Option<OYarn>, range: TextRange, parent: SymbolKey, is_web: bool, is_external: bool) -> Self {
+    pub fn new(xml_id: Option<OYarn>, t_name: Option<OYarn>, range: TextRange, parent: XmlDataParent, is_web: bool, is_external: bool) -> Self {
         Self { xml_id, t_name, range, t_calls: vec![], t_inherit: None, parent, is_web, is_external }
     }
 
-    pub fn parent(&self) -> SymbolKey {
+    pub fn parent(&self) -> XmlDataParent {
         self.parent
-    }
-
-    /// no child symbols
-    pub fn children(&self) -> Vec<SymbolKey> {
-        vec![]
     }
 }

--- a/server/src/core/symbols/symbol_keys.rs
+++ b/server/src/core/symbols/symbol_keys.rs
@@ -22,9 +22,8 @@ new_key_type! {
     pub struct XmlAssetKey;
     pub struct XmlDeleteKey;
     pub struct CsvFileKey;
+    pub struct JsFileKey;
 }
-
-new_key_type! { pub struct JsFileKey; }
 
 /// A class symbol paired with its origin module's `dir_name`, set only when the
 /// class lives outside the queried module's dependencies (`None` when in-deps).

--- a/server/src/core/symbols/symbol_keys.rs
+++ b/server/src/core/symbols/symbol_keys.rs
@@ -404,9 +404,3 @@ impl ModelSymbolKey {
         }
     }
 }
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, SymbolKeySubset)]
-pub enum JsFileParent {
-    Module(ModuleKey),
-    DiskDir(DiskDirKey),
-}

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -3,7 +3,7 @@ use std::{
 };
 use crate::{
     Sy, constants::MissingDataSource, core::{
-        evaluation_context::ContextKey, python_arch_eval_hooks::get_base_model_symbol, symbols::{storage::xml::xml_field_symbol::XmlFieldName, symbol_keys::XmlRecordKey},
+        evaluation_context::ContextKey, python_arch_eval_hooks::get_base_model_symbol, symbols::{storage::{FileContentParent, xml::xml_field_symbol::XmlFieldName}, symbol_keys::XmlRecordKey},
     }, oyarn, utils::{HashMap, HashSet},
 };
 
@@ -46,14 +46,7 @@ impl SymbolTable {
     }
 
     fn try_as_symbol_mgr(&self, target: SymbolKey) -> Option<&dyn SymbolMgr> {
-        match target {
-            SymbolKey::File(f) => Some(&self[f]),
-            SymbolKey::Class(c) => Some(&self[c]),
-            SymbolKey::Function(f) => Some(&self[f]),
-            SymbolKey::Module(m) => Some(&self[m]),
-            SymbolKey::PythonPackage(p) => Some(&self[p]),
-            _ => None,
-        }
+        FileContentParent::try_from(target).map(|p| p.as_symbol_mgr(self)).ok()
     }
 
     pub fn as_mut_symbol_mgr(&mut self, target: SymbolKey) -> &mut dyn SymbolMgr {
@@ -264,22 +257,22 @@ impl SymbolTable {
     pub fn parent(&self, target: impl Into<SymbolKey>) -> Option<SymbolKey> {
         match target.into() {
             SymbolKey::Root(_) => None,
-            SymbolKey::DiskDir(k) => Some(self[k].parent()),
-            SymbolKey::Namespace(k) => Some(self[k].parent()),
-            SymbolKey::PythonPackage(k) => Some(self[k].parent()),
+            SymbolKey::DiskDir(k) => Some(self[k].parent().into()),
+            SymbolKey::Namespace(k) => Some(self[k].parent().into()),
+            SymbolKey::PythonPackage(k) => Some(self[k].parent().into()),
             SymbolKey::Module(k) => Some(self[k].parent().into()),
-            SymbolKey::File(k) => Some(self[k].parent()),
-            SymbolKey::Compiled(k) => Some(self[k].parent()),
-            SymbolKey::Class(k) => Some(self[k].parent()),
-            SymbolKey::Function(k) => Some(self[k].parent()),
-            SymbolKey::Variable(k) => Some(self[k].parent()),
+            SymbolKey::File(k) => Some(self[k].parent().into()),
+            SymbolKey::Compiled(k) => Some(self[k].parent().into()),
+            SymbolKey::Class(k) => Some(self[k].parent().into()),
+            SymbolKey::Function(k) => Some(self[k].parent().into()),
+            SymbolKey::Variable(k) => Some(self[k].parent().into()),
             SymbolKey::XmlFile(x) => Some(self[x].parent().into()),
-            SymbolKey::XmlRecord(x) => Some(self[x].parent()),
-            SymbolKey::XmlField(x) => Some(self[x].parent()),
-            SymbolKey::XmlMenuItem(x) => Some(self[x].parent()),
-            SymbolKey::XmlTemplate(x) => Some(self[x].parent()),
-            SymbolKey::XmlAsset(x) => Some(self[x].parent()),
-            SymbolKey::XmlDelete(x) => Some(self[x].parent()),
+            SymbolKey::XmlRecord(x) => Some(self[x].parent().into()),
+            SymbolKey::XmlField(x) => Some(self[x].parent().into()),
+            SymbolKey::XmlMenuItem(x) => Some(self[x].parent().into()),
+            SymbolKey::XmlTemplate(x) => Some(self[x].parent().into()),
+            SymbolKey::XmlAsset(x) => Some(self[x].parent().into()),
+            SymbolKey::XmlDelete(x) => Some(self[x].parent().into()),
             SymbolKey::CsvFile(c) => Some(self[c].parent().into()),
             SymbolKey::JsFile(j) => Some(self[j].parent().into()),
         }
@@ -1666,7 +1659,7 @@ impl SymbolTable {
                             continue;
                         }
                         let model_sym = &session.st()[model_key];
-                        let all_symbols = model_sym.children();
+                        let all_symbols: Vec<_> = iter_symbol_keys(model_sym).copied().collect();
                         for s in all_symbols {
                             if (only_fields && !Self::is_field(session, s)) || (only_methods && !matches!(s, SymbolKey::Function(_))) {
                                 continue;
@@ -1681,7 +1674,7 @@ impl SymbolTable {
                         }
                         let model_sym = &session.st()[model_key];
                         // for inherits symbols, we only add fields
-                        let all_symbols = model_sym.children();
+                        let all_symbols: Vec<_> = iter_symbol_keys(model_sym).copied().collect();
                         let fields = all_symbols.into_iter().filter(|&s| Self::is_field(session, s)).collect::<Vec<_>>();
                         for s in fields {
                             let name = session.st().name(s).clone();
@@ -1801,7 +1794,7 @@ impl SymbolTable {
         if !matches!(on_symbol_type, SymType::FILE | SymType::PACKAGE(_) | SymType::ROOT) {
             let mut parent = symbol_table.parent(on_symbol).unwrap();
             while let SymbolKey::Class(c) = parent {
-                parent = symbol_table[c].parent();
+                parent = symbol_table[c].parent().into();
             }
             // A function can reference another name from the full outer scope so no position is needed
             Self::infer_name(odoo, parent, name, None)
@@ -2312,8 +2305,8 @@ impl SymbolTable {
                 }
                 SymbolKey::XmlFile(xml_file) => {
                     let xml_file_sym = &table[xml_file];
-                    for child_key in xml_file_sym.children() {
-                        iter_recursive(session, child_key, res);
+                    for &child_key in xml_file_sym.data_symbols() {
+                        iter_recursive(session, child_key.into(), res);
                     }
                 }
                 SymbolKey::XmlRecord(xml_record_key) => {
@@ -2322,8 +2315,8 @@ impl SymbolTable {
                     {
                         res.push((model, session.st().find_module(xml_record_key)));
                     }
-                    for child_key in xml_record_sym.children() {
-                        iter_recursive(session, child_key, res);
+                    for &child_key in xml_record_sym.fields().values() {
+                        iter_recursive(session, child_key.into(), res);
                     }
                 }
                 SymbolKey::DiskDir(_)

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -3,7 +3,7 @@ use std::{
 };
 use crate::{
     Sy, constants::MissingDataSource, core::{
-        evaluation_context::ContextKey, python_arch_eval_hooks::get_base_model_symbol, symbols::{storage::{FileContentParent, xml::xml_field_symbol::XmlFieldName}, symbol_keys::XmlRecordKey},
+        evaluation_context::ContextKey, python_arch_eval_hooks::get_base_model_symbol, symbols::{storage::{FileContentParent, FileSystemSymbolParent, xml::xml_field_symbol::XmlFieldName}, symbol_keys::XmlRecordKey},
     }, oyarn, utils::{HashMap, HashSet},
 };
 
@@ -358,41 +358,6 @@ impl SymbolTable {
         }
     }
 
-    pub fn has_modules(&self, target: SymbolKey) -> bool {
-        matches!(target, SymbolKey::Root(_) | SymbolKey::Namespace(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) | SymbolKey::DiskDir(_))
-    }
-
-
-    pub fn all_module_symbol(&self, target: SymbolKey) -> Vec<SymbolKey> {
-        match target {
-            SymbolKey::Root(r) => self[r].module_symbols().values().copied().collect(),
-            SymbolKey::Namespace(n) => {
-                self[n].directories().iter()
-                    .flat_map(|x| x.module_symbols().values())
-                    .copied()
-                    .collect()
-            },
-            SymbolKey::DiskDir(d) => self[d].module_symbols().values().copied().collect(),
-            SymbolKey::Module(m) => self[m].module_symbols().values().copied().collect(),
-            SymbolKey::PythonPackage(p) => self[p].module_symbols().values().copied().collect(),
-            SymbolKey::File(_) => panic!("No module symbol on File"),
-            SymbolKey::Compiled(_) => panic!("No module symbol on Compiled"),
-            SymbolKey::Class(_c) => panic!("No module symbol on Class"),
-            SymbolKey::Function(_) => panic!("No module symbol on Function"),
-            SymbolKey::Variable(_) => panic!("No module symbol on Variable"),
-            SymbolKey::XmlFile(_) => panic!("No module symbol on XmlFileSymbol"),
-            SymbolKey::XmlRecord(_) => panic!("No module symbol on XmlRecordSymbol"),
-            SymbolKey::XmlField(_) => panic!("No module symbol on XmlFieldSymbol"),
-            SymbolKey::XmlMenuItem(_) => panic!("No module symbol on XmlMenuItemSymbol"),
-            SymbolKey::XmlTemplate(_) => panic!("No module symbol on XmlTemplateSymbol"),
-            SymbolKey::XmlAsset(_) => panic!("No module symbol on XmlAssetSymbol"),
-            SymbolKey::XmlDelete(_) => panic!("No module symbol on XmlDeleteSymbol"),
-            SymbolKey::CsvFile(_) => panic!("No module symbol on CsvFileSymbol"),
-            SymbolKey::JsFile(_) => panic!("No module symbol on JsFileSymbol"),
-        }
-    }
-
-
     pub fn in_workspace(&self, target: SymbolKey) -> bool {
         match target {
             SymbolKey::Root(_) => false,
@@ -649,9 +614,9 @@ impl SymbolTable {
     }
 
     ///Given a path, create the appropriated symbol and attach it to the given parent
-    pub fn create_from_path(session: &mut SessionInfo, path: &Path, parent: SymbolKey, require_module: bool) -> Option<SymbolKey> {
+    pub fn create_from_path(session: &mut SessionInfo, path: &Path, parent: FileSystemSymbolParent, require_module: bool) -> Option<SymbolKey> {
         if require_module {
-            let SymbolKey::Namespace(addons) = parent else {
+            let FileSystemSymbolParent::Namespace(addons) = parent else {
                 return None;
             };
             return Self::create_module_from_path(session, path, addons).map(SymbolKey::from)
@@ -666,7 +631,7 @@ impl SymbolTable {
             return Some(session.st_mut().add_new_file(parent, &name, &path_str).into());
         }
         if path_str.ends_with(".js") && !session.sync_odoo.config.is_javascript_disabled()
-            && let SymbolKey::DiskDir(d) = parent
+            && let FileSystemSymbolParent::DiskDir(d) = parent
         {
             //js file created here is because of js in a custom entrypoint, and that should be created under a diskdir.
             //JS files under a Module should be created by the module loading, through load_assets
@@ -674,7 +639,7 @@ impl SymbolTable {
         }
         let main_entry_tree = session.sync_odoo.get_main_entry_tree(parent);
         if main_entry_tree == (&["odoo", "addons"], &[]) && path.join("__manifest__.py").exists() {
-            if let SymbolKey::Namespace(addons) = parent {
+            if let FileSystemSymbolParent::Namespace(addons) = parent {
                 let module = Self::add_new_module_package(session, addons, &name, path);
                 let dir_name = session.st()[module].dir_name.clone();
                 session.sync_odoo.modules.insert(dir_name, module.into());
@@ -714,6 +679,10 @@ impl SymbolTable {
             return None;
         }
         let name = path.components().next_back().unwrap().as_os_str().to_str().unwrap();
+        if FileSystemSymbolParent::from(addons).get_child(session.st(), name).is_some() {
+            // Module already exists, do not create a new one
+            return None;
+        }
         let module = Self::add_new_module_package(session, addons, name, path);
         let dir_name = session.sync_odoo.symbol_table[module].dir_name.clone();
         session.sync_odoo.modules.insert(dir_name, module.into());
@@ -809,30 +778,7 @@ impl SymbolTable {
     Return a symbol that is in module symbols (symbol that represent something on disk - file, package, namespace)
      */
     pub fn get_module_symbol(&self, target: SymbolKey, name: &str) -> Option<SymbolKey> {
-        match target {
-            SymbolKey::Namespace(n) => {
-                for dir in self[n].directories().iter() {
-                    let result = dir.module_symbols().get(name);
-                    if result.is_some() {
-                        return result.copied();
-                    }
-                }
-                None
-            },
-            SymbolKey::Module(m) => {
-                self[m].module_symbols().get(name).copied()
-            },
-            SymbolKey::PythonPackage(p) => {
-                self[p].module_symbols().get(name).copied()
-            }
-            SymbolKey::Root(r) => {
-                self[r].module_symbols().get(name).copied()
-            },
-            SymbolKey::DiskDir(d) => {
-                self[d].module_symbols().get(name).copied()
-            }
-            _ => {None}
-        }
+        FileSystemSymbolParent::try_from(target).ok()?.get_child(self, name)
     }
 
     /**
@@ -1053,9 +999,9 @@ impl SymbolTable {
                     }
                 }
             }
-            if session.st().has_modules(ref_to_inv.into()) {
-                for sym in session.st().all_module_symbol(ref_to_inv.into()).iter()
-                        .filter_map(|&s| s.as_source_file_key()) {
+            if let Ok(parent) = FileSystemSymbolParent::try_from(SymbolKey::from(ref_to_inv)) {
+                let all_module_symbols = parent.children(session.st());
+                for sym in all_module_symbols.into_iter().filter_map(|s| s.as_source_file_key()) {
                     vec_to_invalidate.push_back(sym);
                 }
             }
@@ -2422,7 +2368,7 @@ mod get_symbol_tests {
     use ruff_text_size::TextSize;
 
     /// Build an empty symbol table with a single root and return `(table, root_key)`.
-    fn empty_table_with_root() -> (SymbolTable, SymbolKey) {
+    fn empty_table_with_root() -> (SymbolTable, RootKey) {
         let mut st = SymbolTable::new();
         let entry = EntryPoint::new(
             &mut st,
@@ -2432,7 +2378,7 @@ mod get_symbol_tests {
             None,
             None,
         );
-        let root = SymbolKey::Root(entry.borrow().root);
+        let root = entry.borrow().root;
         (st, root)
     }
 
@@ -2446,18 +2392,18 @@ mod get_symbol_tests {
         let (st, root) = empty_table_with_root();
         let files: &[&str] = &[];
         let content: &[&str] = &[];
-        assert!(st.get_symbol(root, (files, content), u32::MAX).is_empty());
+        assert!(st.get_symbol(root.into(), (files, content), u32::MAX).is_empty());
     }
 
     #[test]
     fn file_only() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &[];
         assert_eq!(
-            st.get_symbol(root, (files, content), u32::MAX),
+            st.get_symbol(root.into(), (files, content), u32::MAX),
             vec![SymbolKey::File(file)]
         );
     }
@@ -2465,13 +2411,13 @@ mod get_symbol_tests {
     #[test]
     fn file_plus_one_content() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         let class = st.add_new_class(file.into(), "MyClass", range_at(0), TextSize::new(0));
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &["MyClass"];
         assert_eq!(
-            st.get_symbol(root, (files, content), u32::MAX),
+            st.get_symbol(root.into(), (files, content), u32::MAX),
             vec![SymbolKey::Class(class)]
         );
     }
@@ -2479,14 +2425,14 @@ mod get_symbol_tests {
     #[test]
     fn file_plus_nested_content() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         let class = st.add_new_class(file.into(), "MyClass", range_at(0), TextSize::new(0));
         let method = st.add_new_function(class.into(), "method", range_at(1), TextSize::new(1));
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &["MyClass", "method"];
         assert_eq!(
-            st.get_symbol(root, (files, content), u32::MAX),
+            st.get_symbol(root.into(), (files, content), u32::MAX),
             vec![SymbolKey::Function(method)]
         );
     }
@@ -2495,7 +2441,7 @@ mod get_symbol_tests {
     fn deeply_nested_content() {
         // Content path longer than 2: file -> Outer -> Inner -> v
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         let outer = st.add_new_class(file.into(), "Outer", range_at(0), TextSize::new(0));
         let inner = st.add_new_class(outer.into(), "Inner", range_at(1), TextSize::new(1));
         let var = st.add_new_variable(SymbolKey::Class(inner), "v", range_at(2));
@@ -2503,7 +2449,7 @@ mod get_symbol_tests {
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &["Outer", "Inner", "v"];
         assert_eq!(
-            st.get_symbol(root, (files, content), u32::MAX),
+            st.get_symbol(root.into(), (files, content), u32::MAX),
             vec![SymbolKey::Variable(var)]
         );
     }
@@ -2512,14 +2458,14 @@ mod get_symbol_tests {
     fn nested_file_paths() {
         // File tree with several levels: package -> file -> class
         let (mut st, root) = empty_table_with_root();
-        let package = st.add_new_python_package(root, "pkg", "/test/pkg", "");
+        let package = st.add_new_python_package(root.into(), "pkg", "/test/pkg", "");
         let file = st.add_new_file(package.into(), "mod", "/test/pkg/mod.py");
         let class = st.add_new_class(file.into(), "Cls", range_at(0), TextSize::new(0));
 
         let files: &[&str] = &["pkg", "mod"];
         let content: &[&str] = &["Cls"];
         assert_eq!(
-            st.get_symbol(root, (files, content), u32::MAX),
+            st.get_symbol(root.into(), (files, content), u32::MAX),
             vec![SymbolKey::Class(class)]
         );
     }
@@ -2527,22 +2473,22 @@ mod get_symbol_tests {
     #[test]
     fn missing_file_returns_empty() {
         let (mut st, root) = empty_table_with_root();
-        st.add_new_file(root, "my_file", "/test/my_file.py");
+        st.add_new_file(root.into(), "my_file", "/test/my_file.py");
 
         let files: &[&str] = &["does_not_exist"];
         let content: &[&str] = &[];
-        assert!(st.get_symbol(root, (files, content), u32::MAX).is_empty());
+        assert!(st.get_symbol(root.into(), (files, content), u32::MAX).is_empty());
     }
 
     #[test]
     fn missing_content_returns_empty() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         st.add_new_class(file.into(), "MyClass", range_at(0), TextSize::new(0));
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &["Missing"];
-        assert!(st.get_symbol(root, (files, content), u32::MAX).is_empty());
+        assert!(st.get_symbol(root.into(), (files, content), u32::MAX).is_empty());
     }
 
     #[test]
@@ -2550,14 +2496,14 @@ mod get_symbol_tests {
         // Two variables with the same name in the same section: only the last
         // declaration visible before the position is returned.
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         let _first = st.add_new_variable(SymbolKey::File(file), "x", range_at(5));
         let second = st.add_new_variable(SymbolKey::File(file), "x", range_at(15));
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &["x"];
         assert_eq!(
-            st.get_symbol(root, (files, content), u32::MAX),
+            st.get_symbol(root.into(), (files, content), u32::MAX),
             vec![SymbolKey::Variable(second)]
         );
     }
@@ -2566,7 +2512,7 @@ mod get_symbol_tests {
     fn same_name_respects_position() {
         // Querying before the second declaration returns the first one.
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         let first = st.add_new_variable(SymbolKey::File(file), "x", range_at(5));
         let _second = st.add_new_variable(SymbolKey::File(file), "x", range_at(15));
 
@@ -2574,7 +2520,7 @@ mod get_symbol_tests {
         let content: &[&str] = &["x"];
         // position 10 is after `first` (at 5) but before `second` (at 15)
         assert_eq!(
-            st.get_symbol(root, (files, content), 10),
+            st.get_symbol(root.into(), (files, content), 10),
             vec![SymbolKey::Variable(first)]
         );
     }
@@ -2584,7 +2530,7 @@ mod get_symbol_tests {
         // A name defined in two mutually-exclusive branches (if / else) must
         // resolve to both symbols once the branches merge.
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         let file_key = SymbolKey::File(file);
 
         // sections: 0 base | 1 if-test | 2 if-body | 3 else-body | 4 merge(OR[2,3])
@@ -2606,7 +2552,7 @@ mod get_symbol_tests {
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &["x"];
-        let result = st.get_symbol(root, (files, content), u32::MAX);
+        let result = st.get_symbol(root.into(), (files, content), u32::MAX);
         assert_eq!(result.len(), 2);
         assert!(result.contains(&SymbolKey::Variable(x_if)));
         assert!(result.contains(&SymbolKey::Variable(x_else)));
@@ -2617,7 +2563,7 @@ mod get_symbol_tests {
         // The same name resolving to multiple symbols must keep walking every
         // branch for the remaining content path (tests the flat_map behaviour).
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root, "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
         let file_key = SymbolKey::File(file);
 
         {
@@ -2640,7 +2586,7 @@ mod get_symbol_tests {
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &["A", "m"];
-        let result = st.get_symbol(root, (files, content), u32::MAX);
+        let result = st.get_symbol(root.into(), (files, content), u32::MAX);
         assert_eq!(result.len(), 2);
         assert!(result.contains(&SymbolKey::Function(m_if)));
         assert!(result.contains(&SymbolKey::Function(m_else)));

--- a/server/src/core/xml_arch_builder_rng_validation.rs
+++ b/server/src/core/xml_arch_builder_rng_validation.rs
@@ -4,7 +4,7 @@ use lsp_types::{Diagnostic, Position, Range};
 use roxmltree::Node;
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::{Sy, constants::OYarn, core::{diagnostics::{DiagnosticCode, create_diagnostic}, model::Model, odoo::SyncOdoo, symbols::{storage::xml::xml_field_symbol::XmlFieldName, symbol_keys::{SymbolKey, XmlFieldKey, XmlId, XmlRecordKey}}}, oyarn, threads::SessionInfo, utils};
+use crate::{Sy, constants::OYarn, core::{diagnostics::{DiagnosticCode, create_diagnostic}, model::Model, odoo::SyncOdoo, symbols::{storage::{XmlFieldParent, xml::xml_field_symbol::XmlFieldName}, symbol_keys::{XmlFieldKey, XmlId, XmlRecordKey}}}, oyarn, threads::SessionInfo, utils};
 
 use super::xml_arch_builder::XmlArchBuilder;
 
@@ -255,7 +255,7 @@ impl XmlArchBuilder {
     }
 
     // load a field and add it to the parent symbol. Parent could be either XmlRecordKey or XmlAssetKey
-    fn load_field(&mut self, session: &mut SessionInfo, node: &Node, parent: SymbolKey, diagnostics: &mut Vec<Diagnostic>) -> Option<XmlFieldKey> {
+    fn load_field(&mut self, session: &mut SessionInfo, node: &Node, parent: XmlFieldParent, diagnostics: &mut Vec<Diagnostic>) -> Option<XmlFieldKey> {
         if node.tag_name().name() != "field" { return None; }
         let Some(node_name_node) = node.attribute_node("name") else {
             if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05016, &[]) {

--- a/server/src/core/xml_validation.rs
+++ b/server/src/core/xml_validation.rs
@@ -52,7 +52,7 @@ impl XmlValidator {
         let mut model_dependencies = vec![];
         let mut missing_model_dependencies = HashSet::default();
         let mut diagnostics = vec![];
-        for data_key in session.st()[self.xml_symbol].symbols().iter().cloned().collect::<Vec<_>>() {
+        for data_key in session.st()[self.xml_symbol].data_symbols().iter().cloned().collect::<Vec<_>>() {
             self.validate_data(session, data_key, &mut diagnostics, &mut dependencies, &mut model_dependencies, &mut missing_model_dependencies);
         }
         for dep in dependencies.into_iter() {

--- a/server/src/features/csv_ast_utils.rs
+++ b/server/src/features/csv_ast_utils.rs
@@ -226,7 +226,7 @@ impl CsvAstUtils {
         let relational_field = field_elts.get(1);
         //if the selected field is "id", return the xml_id record with the same id from the same csv file
         if field_name == "id" {
-            for data in session.st()[csv_symbol].symbols().iter() {
+            for data in session.st()[csv_symbol].data_symbols().iter() {
                 if let Some(record_key) = data.as_xml_record_key() {
                     let record = &session.st()[record_key];
                     let Some(record_xml_id) = &record.xml_id else {continue;};

--- a/server/src/features/js_references.rs
+++ b/server/src/features/js_references.rs
@@ -11,7 +11,8 @@ use ruff_source_file::PositionEncoding;
 
 use crate::core::file_mgr::FileInfo;
 use crate::core::js_import_graph;
-use crate::core::symbols::symbol_keys::{SymbolKey, XmlTemplateKey};
+use crate::core::symbols::storage::XmlDataParent;
+use crate::core::symbols::symbol_keys::XmlTemplateKey;
 use crate::core::tsserver_bridge::{TsLocation, ts_to_lsp_location};
 use crate::features::owl_virtual::{
     MappedRef, OwlVirtualDoc, build_virtual_docs, commit_staged_roots, is_owl_artifact_path,
@@ -460,7 +461,7 @@ fn xml_files_backing_js(
             continue;
         };
         for key in keys {
-            let SymbolKey::XmlFile(xml_file) = session.st()[key].parent() else {
+            let XmlDataParent::XmlFile(xml_file) = session.st()[key].parent() else {
                 continue;
             };
             let path = session.st()[xml_file].path.clone();

--- a/server/src/features/references.rs
+++ b/server/src/features/references.rs
@@ -4,6 +4,7 @@ use crate::core::file_mgr::Ast;
 use crate::core::odoo::SyncOdoo;
 use crate::core::symbols::Dependencies;
 use crate::core::symbols::ModuleSymbol;
+use crate::core::symbols::storage::XmlDataParent;
 use crate::core::symbols::symbol_keys::{ModuleKey, SourceFileKey, SymbolKey, XmlFileKey};
 use crate::core::symbols::storage::SymbolTable;
 use crate::features::definition::DefinitionFeature;
@@ -202,7 +203,7 @@ impl ReferenceFeature {
                         let Some(module) = module.upgrade(session.st()) else {continue;};
                         let name = &session.st()[current_module].name;
                         if ModuleSymbol::is_in_deps(session.st(), module, name) {
-                            for &data in session.st()[module].data_symbols().values() {
+                            for &data in session.st()[module].data_file_symbols().values() {
                                 files_to_process.insert(data);
                             }
                         }
@@ -330,7 +331,7 @@ impl ReferenceFeature {
         // workspace for every reference request. Then drop the
         // `iter_xml_templates` method and use the index here.
         for (_key, tmpl) in session.st().iter_xml_templates() {
-            let SymbolKey::XmlFile(xml_file) = tmpl.parent() else { continue; };
+            let XmlDataParent::XmlFile(xml_file) = tmpl.parent() else { continue; };
             for (name, range) in tmpl.t_calls.iter() {
                 if name.as_str() == template_name {
                     // `t_calls` stores the whole-attribute range, `t_inherit` the value-only

--- a/server/src/features/workspace_symbols.rs
+++ b/server/src/features/workspace_symbols.rs
@@ -2,7 +2,7 @@ use lsp_server::{ErrorCode, ResponseError};
 use lsp_types::{Location, SymbolKind, WorkspaceLocation, WorkspaceSymbol, WorkspaceSymbolResponse};
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::{S, constants::SymType, core::{entry_point::EntryPointType, file_mgr::{Ast, FileMgr}, symbols::{storage::SymbolTable, symbol_keys::{SourceFileKey, SymbolKey, XmlTemplateKey}}}, threads::SessionInfo, utils::string_fuzzy_contains};
+use crate::{S, constants::SymType, core::{entry_point::EntryPointType, file_mgr::{Ast, FileMgr}, symbols::{storage::{SymbolTable, XmlDataParent}, symbol_keys::{SourceFileKey, SymbolKey, XmlTemplateKey}}}, threads::SessionInfo, utils::string_fuzzy_contains};
 
 /// The prefix OWL template names are offered under, mirroring the `xmlid.` one already used for
 /// XML ids. It keeps a template distinguishable from the component class of the same name, and
@@ -102,7 +102,7 @@ impl WorkspaceSymbolFeature {
             matches.extend(templates.iter_valid(session.st()).map(|template| (name.clone(), template)));
         }
         for (name, template) in matches {
-            let SymbolKey::XmlFile(xml_file) = session.st()[template].parent() else {
+            let XmlDataParent::XmlFile(xml_file) = session.st()[template].parent() else {
                 continue;
             };
             let path = session.st()[xml_file].path.clone();

--- a/server/tests/test_get_symbol.rs
+++ b/server/tests/test_get_symbol.rs
@@ -423,7 +423,7 @@ fn test_definition_csv() {
     let base_module = base[0].unwrap_module_key();
     let base_path = session.st()[base_module].path.clone();
     let res_country_data_path = Path::new(&base_path).join("data").join("res_country_data.xml").sanitize();
-    let res_country_file = session.st()[base_module].data_symbols().get(&res_country_data_path).cloned();
+    let res_country_file = session.st()[base_module].data_file_symbols().get(&res_country_data_path).cloned();
     assert!(res_country_file.is_some());
     let res_country_file = res_country_file.unwrap();
     let base_au = test_utils::get_definition_locs(&mut session, mcsv_tf_file_symbol, &mcsv_tf_file_info, 1, 22);


### PR DESCRIPTION
No more Holder traits, no more compile-time checks (other than exhaustive pattern-matching).

Follow-up of this PR: ban symbol key replacement when adding to a map with map key (name, path) collision.