### PR TITLE
[ADD] README to debug_tools

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,7 +43,7 @@
                 {
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
+                    "ignoreFailures": false
                 },
                 {
                     "description": "Load SymbolTable GDB script",
@@ -79,7 +79,7 @@
                 {
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
+                    "ignoreFailures": false
                 },
                 {
                     "description": "Load SymbolTable GDB script",

--- a/server/debug_tools/README.md
+++ b/server/debug_tools/README.md
@@ -1,0 +1,33 @@
+## Debug test with Rust Analyzer
+If you wish to use the Rust Analyzer debugger in VS Code, add this to your settings.json:
+
+```json
+ "rust-analyzer.debug.engine": "ms-vscode.cpptools",
+    "rust-analyzer.debug.engineSettings": {
+        "cppdbg": {
+            "miDebuggerPath": "/usr/bin/rust-gdb",
+            "setupCommands": [
+              {
+                  "description": "Enable pretty-printing for gdb",
+                  "text": "-enable-pretty-printing",
+                  "ignoreFailures": false
+              },
+              {
+                  "description": "Load SymbolTable GDB script",
+                  "text": "source ${workspaceFolder}/server/debug_tools/symbol_table_gdb_script.py",
+                  "ignoreFailures": false
+              },
+              {
+                  "description": "Load Reference printer script",
+                  "text": "source ${workspaceFolder}/server/debug_tools/rust_ref_printers.py",
+                  "ignoreFailures": false
+              },
+              {
+                  "description": "Set print depth limit to prevent infinite recursion",
+                  "text": "set print max-depth 3",
+                  "ignoreFailures": false
+              },
+          ]
+        },
+    },
+```


### PR DESCRIPTION
And toggle ignoreFailures to false in launch.json, so that if the pretty-print debug script doesn't load, we get an error.