### PR TITLE
[FIX] Recover lost FileInfo

### DIFF
--- a/server/src/core/csv_validation.rs
+++ b/server/src/core/csv_validation.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use crate::{
     Sy, constants::{BuildStatus, BuildSteps, DEBUG_STEPS, DiagnosticSource, MissingDataSource, OYarn}, core::{
-        diagnostics::{DiagnosticCode, create_diagnostic}, evaluation_utils::DeepFieldEvalWalker, file_mgr::FileInfo, symbols::{Buildable as _, SymbolTable, symbol_keys::{CsvFileKey, ModuleKey}}
+        diagnostics::{DiagnosticCode, create_diagnostic}, evaluation_utils::DeepFieldEvalWalker, file_mgr::{FileInfo, FileMgr}, symbols::{Buildable as _, symbol_keys::{CsvFileKey, ModuleKey}}
     }, features::csv_ast_utils::CsvFieldIter, oyarn, threads::SessionInfo
 };
 use std::{cell::RefCell, rc::Rc};
@@ -37,10 +37,11 @@ impl CsvValidator {
         if DEBUG_STEPS {
             info!("VALIDATION - CSV: {}", path);
         }
-        let Some(file_info) = SymbolTable::get_file_info_for_validation(session, csv_symbol.into()) else {
+        let (file_info, loaded) = FileMgr::get_or_recreate_file_info(session, csv_symbol.into());
+        if !loaded {
             session.st_mut()[csv_symbol].set_build_status(BuildSteps::VALIDATION, BuildStatus::INVALID);
             return;
-        };
+        }
         let Some(data) = file_info.borrow().file_info_ast.borrow().text_document.as_ref().map(|td| td.contents().to_string()) else {
             // File can be invalid (not valid UTF-8 and so text_document is empty)
             return;

--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -379,10 +379,9 @@ impl FileInfo {
         // See https://github.com/Microsoft/language-server-protocol/issues/177
         // Return true if the update has been done and not discarded
         match version {
-            // -100, we set FileInfo to -100 if it was not opened yet. Otherwise, we do not change the version
-            Some(-100) => if !self.opened {
-                self.version = Some(-100);
-            } else if !force { // If opened, with -100, we do not update
+            // -100, Set version to -100 later only if no failure occurs
+            Some(-100) => if self.opened && !force {
+                // Opened files can only receive version -100 if forced, abort
                 return false;
             },
             // normal version number, we update if higher, and set to opened anyway
@@ -419,10 +418,16 @@ impl FileInfo {
             if let Some(preloaded) = SyncOdoo::take_preloaded(session, &sanitized_path) {
                 // no need to gate on hash change: pre-parser only runs on first build
                 self.apply_preloaded(session, preloaded);
+                if version == Some(-100) && !self.opened {
+                    self.version = Some(-100);
+                }
                 return true;
             }
             match fs::read_to_string(path) {
                 Ok(content) => {
+                    if version == Some(-100) && !self.opened {
+                        self.version = Some(-100);
+                    }
                     self.file_info_ast.borrow_mut().text_document = Some(TextDocument::new(content, self.version.unwrap_or(-1)));
                 },
                 Err(e) => {

--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -20,6 +20,7 @@ use crate::core::{config::{DiagnosticFilter, DiagnosticFilterPathType}, js_arch_
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode, DiagnosticSetting};
 use crate::core::text_document::TextDocument;
 use crate::features::node_index_ast::IndexedModule;
+use crate::core::symbols::symbol_keys::SourceFileKey;
 use crate::threads::SessionInfo;
 use crate::utils::PathSanitizer;
 use std::rc::Rc;
@@ -1020,6 +1021,29 @@ impl FileMgr {
             drop(file_info_mut);
         }
         (updated, return_info)
+    }
+
+    /// Get the cached file info for `symbol`, recreating it from disk if it was
+    /// evicted from the cache. The `bool` is false if that recreate attempt
+    /// failed to load real content (e.g. the file doesn't exist) - the
+    /// returned `FileInfo` is still a valid, usable (if empty) entry either
+    /// way. Callers that require actual content should check the flag and
+    /// treat a failure as invalid/pending; callers that can tolerate an
+    /// absent file (e.g. arch building a module that has no `__init__.py`)
+    /// can ignore it.
+    pub fn get_or_recreate_file_info(session: &mut SessionInfo, symbol: SourceFileKey) -> (Rc<RefCell<FileInfo>>, bool) {
+        let path = session.sync_odoo.symbol_table.file_path(symbol).to_string();
+        let maybe_file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path);
+        match maybe_file_info {
+            Some(file_info) => (file_info, true),
+            None => {
+                let (loaded, file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, &path, None, Some(-100), true);
+                if !loaded {
+                    warn!("File info not found for {} at path {}", session.sync_odoo.symbol_table.name(symbol), path);
+                }
+                (file_info, loaded)
+            }
+        }
     }
 
     pub fn update_all_file_diagnostic_filters(&mut self, session: &SessionInfo) {

--- a/server/src/core/js_validator.rs
+++ b/server/src/core/js_validator.rs
@@ -1,7 +1,7 @@
 use lsp_types::{Diagnostic, Position, Range};
 use tracing::trace;
 
-use crate::{Sy, constants::{BuildStatus, DiagnosticSource, MissingDataSource}, core::{diagnostics::{DiagnosticCode, create_diagnostic}, symbols::SymbolTable}, features::xml_ast_utils::XmlAstUtils};
+use crate::{Sy, constants::{BuildStatus, DiagnosticSource, MissingDataSource}, core::{diagnostics::{DiagnosticCode, create_diagnostic}, file_mgr::FileMgr}, features::xml_ast_utils::XmlAstUtils};
 use crate::{
     constants::{BuildSteps, OYarn, DEBUG_STEPS},
     core::{
@@ -32,10 +32,11 @@ impl JsValidator {
         }
         session.st_mut().set_build_status(self.js_symbol.into(), BuildSteps::VALIDATION, BuildStatus::IN_PROGRESS);
         let mut diagnostics = vec![];
-        let Some(file_info) = SymbolTable::get_file_info_for_validation(session, self.js_symbol.into()) else {
+        let (file_info, loaded) = FileMgr::get_or_recreate_file_info(session, self.js_symbol.into());
+        if !loaded {
             session.st_mut().set_build_status(self.js_symbol.into(), BuildSteps::VALIDATION, BuildStatus::INVALID);
             return;
-        };
+        }
         if !file_info.borrow().file_info_ast.borrow().ast.is_built() {
             // JS Symbols do not go through the arch step,
             // Custom JS files may not have been built yet, so we need to build the AST first before validating

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -26,7 +26,7 @@ use crate::{oyarn, S};
 
 use super::entry_point::EntryPoint;
 use super::evaluation::{EvaluationSymbolPtr, EvaluationSymbolWeak};
-use super::file_mgr::{combine_noqa_info, FileInfo};
+use super::file_mgr::{combine_noqa_info, FileInfo, FileMgr};
 use super::import_resolver::ImportResult;
 use super::odoo::SyncOdoo;
 use super::python_utils::AssignTargetType;
@@ -83,24 +83,10 @@ impl PythonArchBuilder {
             let odoo_addons = session.st()[m].parent();
             ModuleSymbol::load_module_arch(m, session, odoo_addons);
         }
-        let file_info_rc = match self.file_mode {
-            true => {
-                let maybe_file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path).clone();
-                match maybe_file_info {
-                    Some(file_info) => {
-                        if !file_info.borrow().file_info_ast.borrow().ast.is_built() {
-                            file_info.borrow_mut().prepare_ast(session);
-                        }
-                        file_info
-                    },
-                    None => {
-                        let (_, file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, &path, None, None, false); //create ast if not in cache
-                        file_info
-                    }
-                }
-                },
-            false => {session.sync_odoo.get_file_mgr().borrow().get_file_info(&path).unwrap()}
-        };
+        let (file_info_rc, _) = FileMgr::get_or_recreate_file_info(session, self.file);
+        if self.file_mode && !file_info_rc.borrow().file_info_ast.borrow().ast.is_built() {
+            file_info_rc.borrow_mut().prepare_ast(session);
+        }
         self.file_info = Some(file_info_rc.clone());
         if self.file_mode {
             //diagnostics for functions are stored directly on funcs

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -68,11 +68,7 @@ impl PythonArchEval {
             trace!("ARCH_EVAL  - PYTHON {} - {}", session.st().path(self.file), session.st().name(symbol));
         }
         session.st_mut().set_build_status(symbol.unwrap_buildable_key(), BuildSteps::ARCH_EVAL, BuildStatus::IN_PROGRESS);
-        let path = session.st().file_path(self.file);
-        let Some(file_info_rc) = session.sync_odoo.get_file_mgr().borrow().get_file_info(path).clone() else {
-            warn!("File info not found for {}", path);
-            return;
-        };
+        let (file_info_rc, _) = FileMgr::get_or_recreate_file_info(session, self.file);
         if !file_info_rc.borrow().file_info_ast.borrow().ast.is_built() {
             file_info_rc.borrow_mut().prepare_ast(session);
         }

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -57,14 +57,11 @@ impl PythonValidator {
         if !session.st().ready_for_step(symbol.unwrap_buildable_key(), BuildSteps::VALIDATION) {
             return;
         }
-        let file_info_rc = SymbolTable::get_file_info_for_validation(session, self.file).clone();
-        let file_info_rc = match file_info_rc {
-            Some(f) => f,
-            None => {
-                session.st_mut().set_build_status(symbol.unwrap_buildable_key(), BuildSteps::VALIDATION, BuildStatus::INVALID);
-                return;
-            }
-        };
+        let (file_info_rc, loaded) = FileMgr::get_or_recreate_file_info(session, self.file);
+        if !loaded {
+            session.st_mut().set_build_status(symbol.unwrap_buildable_key(), BuildSteps::VALIDATION, BuildStatus::INVALID);
+            return;
+        }
         self.file_info = Some(file_info_rc.clone());
         match symbol {
             SymbolKey::File(_) | SymbolKey::PythonPackage(_) | SymbolKey::Module(_) => {

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -9,14 +9,13 @@ use crate::{
 
 use lsp_types::{Diagnostic, DiagnosticTag, Range, SymbolKind};
 use ruff_text_size::TextRange;
-use tracing::warn;
 
 use crate::{
     constants::{BuildStatus, BuildSteps, OYarn, PackageType, SymType}, core::{
         diagnostics::{DiagnosticCode, create_diagnostic},
         entry_point::EntryPoint,
         evaluation::{Evaluation, EvaluationSymbolPtr},
-        file_mgr::{FileInfo, FileMgr, NoqaInfo},
+        file_mgr::{FileMgr, NoqaInfo},
         model::Model,
         odoo::SyncOdoo,
         symbols::{
@@ -2374,38 +2373,6 @@ impl SymbolTable {
     /// Util for debug logs
     pub fn debug_path(&self, target: SymbolKey) -> String {
         self.paths(target).first().cloned().unwrap_or(self.name(target).to_string())
-    }
-
-    pub fn get_file_info_for_validation(
-        session: &mut SessionInfo,
-        symbol: SourceFileKey,
-    ) -> Option<Rc<RefCell<FileInfo>>> {
-        let tree_path = session.sync_odoo.symbol_table.path(symbol).to_owned();
-        let file_info = session
-            .sync_odoo
-            .get_file_mgr()
-            .borrow()
-            .get_file_info(session.sync_odoo.symbol_table.file_path(symbol));
-        match file_info {
-            Some(file_info) => Some(file_info),
-            None => {
-                let (updated, result) = session
-                    .sync_odoo
-                    .get_file_mgr()
-                    .borrow_mut()
-                    .update_file_info(session, &tree_path, None, Some(-100), true);
-                if updated {
-                    Some(result)
-                } else {
-                    warn!(
-                        "File info not found for validating symbol: {} at path {}",
-                        session.sync_odoo.symbol_table.name(symbol),
-                        tree_path
-                    );
-                    None
-                }
-            }
-        }
     }
 
     pub fn get_xml_defined_model(session: &SessionInfo, xml_record_key: XmlRecordKey) -> Option<Rc<RefCell<Model>>> {

--- a/server/src/core/xml_validation.rs
+++ b/server/src/core/xml_validation.rs
@@ -2,7 +2,7 @@ use std::{
     cell::RefCell,
     rc::Rc,
 };
-use crate::{constants::BuildStatus, core::{odoo::SyncOdoo, symbols::{ModuleSymbol, storage::xml::xml_field_symbol::XmlFieldName}}, utils::{HashMap, HashSet}};
+use crate::{constants::BuildStatus, core::{file_mgr::FileMgr, odoo::SyncOdoo, symbols::{ModuleSymbol, storage::xml::xml_field_symbol::XmlFieldName}}, utils::{HashMap, HashSet}};
 
 use lsp_types::{Diagnostic, Position, Range};
 use tracing::info;
@@ -66,9 +66,10 @@ impl XmlValidator {
         }
         session.st_mut()[self.xml_symbol].not_found_models.extend(missing_model_dependencies.into_iter().map(|m| (m, BuildSteps::VALIDATION)));
         session.sync_odoo.get_main_entry().borrow_mut().not_found_symbols_for_models.insert(self.xml_symbol.into());
-        let Some(file_info) = SymbolTable::get_file_info_for_validation(session, self.xml_symbol.into()) else {
+        let (file_info, loaded) = FileMgr::get_or_recreate_file_info(session, self.xml_symbol.into());
+        if !loaded {
             return;
-        };
+        }
         file_info.borrow_mut().replace_diagnostics(DiagnosticSource::XML_VALIDATION, diagnostics);
         file_info.borrow_mut().publish_diagnostics(session);
         session.st_mut().set_build_status(self.xml_symbol.into(), BuildSteps::VALIDATION, BuildStatus::DONE);

--- a/server/tests/data/queued_import_race/pkg/__init__.py
+++ b/server/tests/data/queued_import_race/pkg/__init__.py
@@ -1,0 +1,3 @@
+from .b import Thing
+
+Thing().method()

--- a/server/tests/data/queued_import_race/pkg/b.py
+++ b/server/tests/data/queued_import_race/pkg/b.py
@@ -1,0 +1,3 @@
+class Thing:
+    def method(self):
+        return 1

--- a/server/tests/data/queued_import_race/pkg/c.py
+++ b/server/tests/data/queued_import_race/pkg/c.py
@@ -1,0 +1,1 @@
+from .b import Thing

--- a/server/tests/test_queued_dependency_missing_file_info.rs
+++ b/server/tests/test_queued_dependency_missing_file_info.rs
@@ -1,0 +1,55 @@
+use std::env;
+use std::path::Path;
+use odoo_ls_server::core::build_scheduler::BuildScheduler;
+use odoo_ls_server::core::entry_point::EntryPointMgr;
+use odoo_ls_server::utils::PathSanitizer;
+
+mod setup;
+
+// Regression test: `PythonArchBuilder::load_arch` used to unwrap a `FileMgr` cache
+// entry that could already be evicted, panicking.
+//
+// Why: the same on-disk path can back two symbols (a relative import resolves
+// against the importer's own entry root, so a separate entry over the same
+// directory gets its own duplicate). Finishing one duplicate's ARCH_EVAL evicts the
+// shared cached AST; if the other, internal duplicate still has a deferred method
+// build pending, that build later hits the missing cache.
+//
+// Fixture: `pkg/b.py` (`Thing.method`), `pkg/__init__.py` (imports + calls it,
+// internal), `pkg/c.py` (same import, but its own entry, so it's an external
+// duplicate of `b.py`). Queuing both entries before `process_rebuilds()` lets the
+// scheduler build the duplicate first, evict the cache, and skip the real `b.py`'s
+// turn as a duplicate-looking no-op ("Already arch eval rebuilt, skipping") — so
+// when `pkg.__init__` later forces `b.py`'s method to build, the cache is gone.
+// Mirrors an editor batching several `.venv` file creates into one
+// `didChangeWatchedFiles`. Not reproducible via `Odoo::handle_did_create` directly
+// — its per-file loop finishes each file before the next starts.
+#[test]
+fn test_dependency_queued_alongside_its_external_duplicate_does_not_panic() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let root = env::current_dir().unwrap().join("tests/data/queued_import_race").sanitize();
+    let pkg_dir = Path::new(&root).join("pkg").sanitize();
+    let pkg_init = Path::new(&pkg_dir).join("__init__.py").sanitize();
+    let c_path = Path::new(&pkg_dir).join("c.py").sanitize();
+
+    // Register c.py's entry BEFORE pkg's, and both before any process_rebuilds()
+    // call, so both land in the ARCH queue together and get drained by the single
+    // process_rebuilds() call below — nothing here pokes build state directly,
+    // this is the same EntryPointMgr::create_new_custom_entry_for_path call
+    // handle_did_create itself makes per file.
+    EntryPointMgr::create_new_custom_entry_for_path(&mut session, &c_path, &c_path);
+    EntryPointMgr::create_new_custom_entry_for_path(&mut session, &pkg_dir, &pkg_init);
+    BuildScheduler::process_rebuilds(&mut session, false);
+
+    let method = session
+        .sync_odoo
+        .get_symbol(&pkg_dir, (&["b"], &["Thing", "method"]), u32::MAX)
+        .first()
+        .expect("expected a function symbol for pkg.b.Thing.method")
+        .unwrap_function_key();
+
+    assert!(!session.st().is_external(method.into()), "pkg.b is a real, internal module");
+    assert!(!session.st()[method].evaluations.is_empty(), "method should have been built successfully");
+}


### PR DESCRIPTION
In a rare scenario with multiple custom entrypoints that interact with each other, one FileInfo can be deleted because it is external, while the main file is still queued, but in ARCH_EVAL, so it does not recover and lead to a panic, and also leaves a wrong in_progress status on the symbol.

The test also triggers this scenario, before this fix, you get a panic

This might be fixed by #675 as a side effect, but still the test might be valuable to keep

fixes crash report 2272