### PR TITLE
[FIX] Fix panic on class arg for `super()`

### DIFF
--- a/server/src/core/evaluation.rs
+++ b/server/src/core/evaluation.rs
@@ -252,6 +252,34 @@ fn record_evaluation_hit(session: &mut SessionInfo, parent: SymbolKey, range: Te
     true
 }
 
+/// Resolve and filter super class args
+/// Only returns evaluations that are classes, and returns their instance values
+fn resolve_super_class_args(
+    class_evals: &[Evaluation],
+    session: &mut SessionInfo,
+    context: Option<&Context>,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Vec<(Wk<SymbolKey>, bool)> {
+    let mut hits = Vec::new();
+    for class_eval in class_evals {
+        let class_sym_weak_eval = class_eval.symbol.get_symbol_as_weak(session, context, diagnostics, None);
+        let Some(class_sym) = class_sym_weak_eval.weak.upgrade(session.st()) else { continue };
+        let resolved = SymbolTable::follow_ref(
+            &EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(class_sym, None, false)),
+            session, None, false, false, None, None,
+        );
+        hits.extend(resolved.iter().filter(|r| r.has_weak()).filter_map(|r| {
+            let w = r.get_weak();
+            if let Some(symbol) = w.weak.upgrade(session.st()) && matches!(symbol, SymbolKey::Class(_)) {
+                Some((w.weak, w.instance.unwrap_or(false)))
+            } else {
+                None
+            }
+        }));
+    }
+    hits
+}
+
 impl Evaluation {
 
     pub fn new_list(odoo: &mut SyncOdoo, values: Option<Vec<Expr>>, range: TextRange) -> Evaluation {
@@ -814,56 +842,52 @@ impl Evaluation {
                         } else {
                             if session.sync_odoo.match_tree_from_any_entry(base_sym, (&["builtins"], &["super"])) {
                                 //  - If 1st argument exists, we add that class with symbol_type Super
-                                let super_class = if !expr.arguments.is_empty() {
+                                let super_classes = if !expr.arguments.is_empty() {
                                     let (class_eval, diags) = Evaluation::eval_from_ast(session, &expr.arguments.args[0], parent, max_infer, false, required_dependencies);
                                     diagnostics.extend(diags);
-                                    if class_eval.len() != 1 {
-                                        return AnalyzeAstResult::from_only_diagnostics(diagnostics);
-                                    }
-                                    let class_sym_weak_eval= class_eval[0].symbol.get_symbol_as_weak(session, Some(context), &mut diagnostics, None);
-                                    
-                                    class_sym_weak_eval.weak.upgrade(session.st()).and_then(|class_sym|{
-                                        let class_sym_weak_eval = &SymbolTable::follow_ref(&EvaluationSymbolPtr::WEAK(EvaluationSymbolWeak::new(
-                                            class_sym, None, false
-                                        )), session, None, false, false, None, None)[0];
-                                        if !matches!(class_sym_weak_eval.upgrade_weak(session.st()).unwrap(), SymbolKey::Class(_)) {
-                                            return None;
+                                    let class_hits = resolve_super_class_args(&class_eval, session, Some(context), &mut diagnostics);
+                                    // Split into classes (instance=false) and instances
+                                    let (classes, instances): (Vec<_>, Vec<_>) = class_hits.into_iter().partition(|(_, instance)| !instance);
+                                    if classes.is_empty() {
+                                        // Only warn if every candidate was an instance; if some candidate resolved to a
+                                        // usable class, prefer it silently instead of flagging the ambiguous ones.
+                                        if !instances.is_empty()
+                                            && let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS01005, &[])
+                                        {
+                                            diagnostics.push(Diagnostic {
+                                                range: Range::new(Position::new(expr.arguments.args[0].range().start().to_u32(), 0),
+                                                Position::new(expr.arguments.args[0].range().end().to_u32(), 0)),
+                                                ..diagnostic_base
+                                            });
                                         }
-                                        let class_sym_weak_eval = class_sym_weak_eval.get_weak();
-                                        if class_sym_weak_eval.instance.unwrap_or(false) {
-                                            if let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS01005, &[]) {
-                                                diagnostics.push(Diagnostic {
-                                                    range: Range::new(Position::new(expr.arguments.args[0].range().start().to_u32(), 0),
-                                                    Position::new(expr.arguments.args[0].range().end().to_u32(), 0)),
-                                                    ..diagnostic_base
-                                                });
-                                            }
-                                            None
-                                        } else {
-                                            let mut is_instance = None;
-                                            let mut default_instance = true; //used if we can't evaluate the instance parameter
-                                            if let SymbolKey::Function(f) = parent && session.st()[f].is_class_method {
-                                                default_instance = false;
-                                            }
-                                            if expr.arguments.args.len() >= 2 {
-                                                let (object_or_type_eval, diags) = Evaluation::eval_from_ast(session, &expr.arguments.args[1], parent, max_infer, false, required_dependencies);
-                                                diagnostics.extend(diags);
-                                                if object_or_type_eval.len() != 1 {
-                                                    return Some((class_sym_weak_eval.weak, Some(default_instance)))
-                                                }
-                                                let object_or_type_weak_eval = &SymbolTable::follow_ref(
+                                        vec![]
+                                    } else {
+                                        let mut default_instance = true; //used if we can't evaluate the instance parameter
+                                        if let SymbolKey::Function(f) = parent && session.st()[f].is_class_method {
+                                            default_instance = false;
+                                        }
+                                        let is_instance = if expr.arguments.args.len() >= 2 {
+                                            let (object_or_type_eval, diags) = Evaluation::eval_from_ast(session, &expr.arguments.args[1], parent, max_infer, false, required_dependencies);
+                                            diagnostics.extend(diags);
+                                            if object_or_type_eval.len() != 1 {
+                                                Some(default_instance)
+                                            } else {
+                                                let object_or_type_weak_eval = SymbolTable::follow_ref(
                                                     &object_or_type_eval[0].symbol.get_symbol(
                                                         session, Some(context), &mut diagnostics, Some(parent)),
-                                                        session, None, false, false, None, None)[0];
-                                                if object_or_type_weak_eval.has_weak() {
-                                                    is_instance = Some(object_or_type_weak_eval.get_weak().instance.unwrap_or(default_instance));
-                                                } else {
-                                                    is_instance = Some(default_instance);
-                                                }
+                                                        session, None, false, false, None, None);
+                                                Some(
+                                                    object_or_type_weak_eval.first()
+                                                        .filter(|r| r.has_weak())
+                                                        .map(|r| r.get_weak().instance.unwrap_or(default_instance))
+                                                        .unwrap_or(default_instance)
+                                                )
                                             }
-                                            Some((class_sym_weak_eval.weak, is_instance))
-                                        }
-                                    })
+                                        } else {
+                                            None
+                                        };
+                                        classes.into_iter().map(|(class_weak, _)| (class_weak, is_instance)).collect()
+                                    }
                                 //  - Otherwise we get the encapsulating class
                                 } else {
                                     match session.st().get_in_parents(parent, &[SymType::CLASS], true) {
@@ -875,7 +899,7 @@ impl Evaluation {
                                                     ..diagnostic
                                                 });
                                             }
-                                            None
+                                            vec![]
                                         },
                                         Some(parent_class) => {
                                             let mut instance = Some(true);
@@ -888,11 +912,11 @@ impl Evaluation {
                                                     instance = None;
                                                 }
                                             }
-                                            Some((parent_class.into(), instance))
+                                            vec![(parent_class.into(), instance)]
                                         }
                                     }
                                 };
-                                if let Some((super_class, instance)) = super_class{
+                                for (super_class, instance) in super_classes {
                                     evals.push(Evaluation{
                                         symbol: EvaluationSymbol {
                                             sym: EvaluationSymbolPtr::SELF(EvaluationSymbolWeak{

--- a/server/tests/data/python/diagnostics/panic_super_arg_any.py
+++ b/server/tests/data/python/diagnostics/panic_super_arg_any.py
@@ -1,0 +1,15 @@
+class Base:
+    def method(self):
+        pass
+
+
+def get_class_stub():
+    ...
+
+
+ClassAny = get_class_stub()
+
+
+class FooAny(Base):
+    def method(self):
+        super(ClassAny, self).method()

--- a/server/tests/data/python/diagnostics/panic_super_arg_none.py
+++ b/server/tests/data/python/diagnostics/panic_super_arg_none.py
@@ -1,0 +1,15 @@
+class Base:
+    def method(self):
+        pass
+
+
+def get_class_no_return():
+    pass
+
+
+ClassNone = get_class_no_return()
+
+
+class FooNone(Base):
+    def method(self):
+        super(ClassNone, self).method()

--- a/server/tests/data/python/diagnostics/panic_super_arg_unbound.py
+++ b/server/tests/data/python/diagnostics/panic_super_arg_unbound.py
@@ -1,0 +1,14 @@
+class Base:
+    def method(self):
+        pass
+
+
+if int():
+    ClassMaybe = Base
+
+Alias = ClassMaybe
+
+
+class FooUnbound(Base):
+    def method(self):
+        super(Alias, self).method()

--- a/server/tests/diagnostics/mod.rs
+++ b/server/tests/diagnostics/mod.rs
@@ -21,3 +21,4 @@ pub mod ols04000_1_to_20;
 pub mod ols05000s;
 pub mod ols05073_74;
 pub mod implicit_class_method_no_ols_01007;
+pub mod panic_super_arg;

--- a/server/tests/diagnostics/panic_super_arg.rs
+++ b/server/tests/diagnostics/panic_super_arg.rs
@@ -1,0 +1,56 @@
+// Regression tests for a crash when resolving the class argument of super(cls, self):
+// SymbolTable::follow_ref(...) can legitimately hand back a non-class sentinel (ANY, NONE,
+// UNBOUND, DOMAIN...) instead of a resolvable class, or an empty Vec, or a reference that has
+// since expired -- resolve_super_class_args (evaluation.rs) now scans every candidate
+// evaluation and every follow_ref result instead of blindly indexing [0] and unwrapping,
+// falling back to no super-class evaluation attached when nothing usable is found. These
+// fixtures each used to panic before that fix; they must now build cleanly.
+use std::env;
+
+use odoo_ls_server::utils::PathSanitizer;
+
+use crate::setup::setup::*;
+
+fn diagnostics_path(name: &str) -> String {
+    env::current_dir()
+        .unwrap()
+        .join("tests/data/python/diagnostics")
+        .join(name)
+        .sanitize()
+}
+
+// ClassAny = get_class_stub() where get_class_stub() is a stub-only ("...") function, so its
+// return evaluation is Evaluation::new_any() (ANY sentinel). follow_ref on `ClassAny` then
+// terminates on that ANY entry instead of a class.
+#[test]
+fn test_super_first_arg_any_does_not_panic() {
+    let (mut odoo, config) = setup_server(false);
+    let mut session = create_init_session(&mut odoo, config);
+    let path = diagnostics_path("panic_super_arg_any.py");
+    prepare_custom_entry_point(&mut session, &path);
+}
+
+// ClassNone = get_class_no_return() where get_class_no_return() has a body but no return
+// statement, so its return evaluation is Evaluation::new_none() (NONE sentinel) instead of
+// new_any().
+#[test]
+fn test_super_first_arg_none_does_not_panic() {
+    let (mut odoo, config) = setup_server(false);
+    let mut session = create_init_session(&mut odoo, config);
+    let path = diagnostics_path("panic_super_arg_none.py");
+    prepare_custom_entry_point(&mut session, &path);
+}
+
+// Alias = ClassMaybe, where ClassMaybe is only conditionally assigned (`if int(): ClassMaybe
+// = Base`, no else). Referencing "Alias" itself is unconditional so it evaluates to a single
+// Evaluation, but Alias's own evaluations are [WEAK(ClassMaybe), UNBOUND("ClassMaybe")], and
+// ClassMaybe needs one more hop through next_refs before it becomes terminal -- that hop
+// re-queues it behind the zero-hop UNBOUND entry, so follow_ref's first result used to be
+// UNBOUND, not the resolved class.
+#[test]
+fn test_super_first_arg_unbound_does_not_panic() {
+    let (mut odoo, config) = setup_server(false);
+    let mut session = create_init_session(&mut odoo, config);
+    let path = diagnostics_path("panic_super_arg_unbound.py");
+    prepare_custom_entry_point(&mut session, &path);
+}


### PR DESCRIPTION
If the first argument of `super` is `Any`, `None` or `Unbound` `upgrade_weak` can return None, which we were unwraping, causing a panic.

This PR, looks through all the refs hoping to find one valid symbol, it also moves the logic into helper functions to have slightly more readability.

Tests were added that would panic before the fix
Example crash report: 2291