### PR TITLE
[FIX] handle files being deleted by FS while opened

### DIFF
--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -1072,6 +1072,11 @@ impl FileMgr {
 
     /// Helper for delete_path and delete_file_path
     fn delete_entry(session: &mut SessionInfo, key: &str, uri: &str) {
+        // Do not delete an opened file's cache; handle_did_close decides whether to clear it on close.
+        if let Some(file_info) = session.sync_odoo.get_file_mgr().borrow().get_file_info(key)
+            && file_info.borrow().opened {
+                return;
+            }
         let to_del = session.sync_odoo.get_file_mgr().borrow_mut().files.remove(key);
         if let Some(to_del) = to_del
             && SyncOdoo::is_in_workspace_or_entry(session, uri) {

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -838,21 +838,31 @@ impl SyncOdoo {
     }
 
     pub fn unload_path(session: &mut SessionInfo, path: &Path) {
+        Self::unload_path_if(session, path, |_, _| true);
+    }
+
+    /// Like `unload_path`, but only unloads a symbol when `should_unload` returns true. Returns whether anything was unloaded.
+    pub fn unload_path_if(session: &mut SessionInfo, path: &Path, should_unload: impl Fn(&SymbolTable, SymbolKey) -> bool) -> bool {
+        let mut unloaded_any = false;
         let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
         for entry in ep_mgr.borrow().iter_all() {
             let path_str = path.sanitize_cow();
             let sym_in_data = entry.borrow().data_file_symbols.get(path_str.as_ref()).copied();
             if let Some(sym) = sym_in_data {
-                if let Some(sym) = sym.upgrade(session.st()) {
-                    SymbolTable::unload(session, sym);
-                }
+                if let Some(sym) = sym.upgrade(session.st())
+                    && should_unload(session.st(), sym.into()) {
+                        SymbolTable::unload(session, sym);
+                        unloaded_any = true;
+                    }
                 continue;
             }
             let sym_in_js = entry.borrow().js_symbols.get(path_str.as_ref()).cloned();
             if let Some(sym) = sym_in_js {
-                if let Some(sym) = sym.upgrade(session.st()) {
-                    SymbolTable::unload(session, sym.into());
-                }
+                if let Some(sym) = sym.upgrade(session.st())
+                    && should_unload(session.st(), sym.into()) {
+                        SymbolTable::unload(session, sym.into());
+                        unloaded_any = true;
+                    }
                 continue;
             }
             if entry.borrow().is_valid_for(path) {
@@ -864,9 +874,13 @@ impl SyncOdoo {
                 let Some(source_file) = path_symbol.as_source_file_key() else {
                     continue;
                 };
-                SymbolTable::unload(session, source_file);
+                if should_unload(session.st(), path_symbol) {
+                    SymbolTable::unload(session, source_file);
+                    unloaded_any = true;
+                }
             }
         }
+        unloaded_any
     }
 
     /// Side effects of unloading a symbol
@@ -2004,12 +2018,23 @@ impl Odoo {
             && let Some(bridge) = session.sync_odoo.tsserver_bridge.as_mut() {
                 bridge.close_file(&path);
             }
-        let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path);
-        if let Some(file_info) = file_info {
-            file_info.borrow_mut().opened = false;
-            file_info.borrow_mut().version = None;
+        if let Some(file_info) = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path) {
+            let mut file_info = file_info.borrow_mut();
+            file_info.opened = false;
+            file_info.version = None;
         }
         session.sync_odoo.entry_point_mgr.borrow_mut().remove_entries_with_path(&mut session.sync_odoo.symbol_table, &Path::new(&path).to_tree_path().sanitize_cow());
+        // Clear it now if deleted from disk or external
+        let path_exists = !FileMgr::is_untitled(&path) && Path::new(&path).exists();
+        let cleared = if !path_exists {
+            SyncOdoo::unload_path(session, Path::new(&path));
+            true
+        } else {
+            SyncOdoo::unload_path_if(session, Path::new(&path), |st, sym| st.is_external(sym))
+        };
+        if cleared {
+            FileMgr::delete_file_path(session, &path);
+        }
     }
 
     pub fn search_symbols_to_rebuild(session: &mut SessionInfo, path: &str) {
@@ -2101,10 +2126,12 @@ impl Odoo {
         for f in params.files.iter() {
             let path = FileMgr::uri2pathname(&f.uri);
             session.log_message(MessageType::INFO, format!("Deleting {}", path));
-            //1 - delete old uri
-            SyncOdoo::unload_path(session, Path::new(&path));
-            FileMgr::delete_path(session, &path);
-            session.sync_odoo.entry_point_mgr.borrow_mut().remove_entries_with_path(&mut session.sync_odoo.symbol_table, &Path::new(&path).to_tree_path().sanitize_cow());
+            let is_open_file = session.sync_odoo.get_file_mgr().borrow().get_file_info(&path).is_some_and(|fi| fi.borrow().opened);
+            if !is_open_file {
+                SyncOdoo::unload_path(session, Path::new(&path));
+                FileMgr::delete_path(session, &path);
+                session.sync_odoo.entry_point_mgr.borrow_mut().remove_entries_with_path(&mut session.sync_odoo.symbol_table, &Path::new(&path).to_tree_path().sanitize_cow());
+            }
         }
         BuildScheduler::process_rebuilds(session, false);
     }

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -155,9 +155,12 @@ impl PythonValidator {
                 if !session.st().is_external(symbol) {
                     return;
                 }
-                let file = symbol.as_source_file_key().unwrap();
-                let file_path = session.sync_odoo.symbol_table.file_path(file).to_string();
-                FileMgr::delete_file_path(session, &file_path);
+                let file_info = self.file_info.as_ref().unwrap();
+                if !file_info.borrow().opened { // Never delete opened files
+                    let file = symbol.as_source_file_key().unwrap();
+                    let file_path = session.sync_odoo.symbol_table.file_path(file).to_string();
+                    FileMgr::delete_file_path(session, &file_path);
+                }
             } else {
                 self.file_info.as_ref().unwrap().borrow_mut().publish_diagnostics(session);
             }

--- a/server/tests/data/deleted_dir_race/point.py
+++ b/server/tests/data/deleted_dir_race/point.py
@@ -1,0 +1,3 @@
+class Thing:
+    def method(self):
+        return 1

--- a/server/tests/data/deleted_dir_race/point_close.py
+++ b/server/tests/data/deleted_dir_race/point_close.py
@@ -1,0 +1,3 @@
+class Thing:
+    def method(self):
+        return 1

--- a/server/tests/data/deleted_dir_race/point_phantom.py
+++ b/server/tests/data/deleted_dir_race/point_phantom.py
@@ -1,0 +1,3 @@
+class Thing:
+    def method(self):
+        return 1

--- a/server/tests/data/nested_dir_race/pkg/__init__.py
+++ b/server/tests/data/nested_dir_race/pkg/__init__.py
@@ -1,0 +1,1 @@
+from .models.point import Thing

--- a/server/tests/data/nested_dir_race/pkg/models/point.py
+++ b/server/tests/data/nested_dir_race/pkg/models/point.py
@@ -1,0 +1,3 @@
+class Thing:
+    def method(self):
+        return 1

--- a/server/tests/data/recreated_file_race/point.py
+++ b/server/tests/data/recreated_file_race/point.py
@@ -1,0 +1,3 @@
+class Thing:
+    def method(self):
+        return 1

--- a/server/tests/test_delete_dir_while_open.rs
+++ b/server/tests/test_delete_dir_while_open.rs
@@ -1,0 +1,290 @@
+use std::env;
+use std::path::Path;
+
+use lsp_types::{
+    CreateFilesParams, DeleteFilesParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, FileCreate, FileDelete, Position, Range, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, VersionedTextDocumentIdentifier,
+};
+use odoo_ls_server::core::build_scheduler::BuildScheduler;
+use odoo_ls_server::core::entry_point::EntryPointMgr;
+use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::{Odoo, SyncOdoo};
+use odoo_ls_server::utils::PathSanitizer;
+
+mod setup;
+
+// Restores a fixture file's original content on drop (even on panic), for
+// tests that actually delete/overwrite a tracked fixture on disk.
+struct RestoreFixture { path: String, original: String }
+impl Drop for RestoreFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::write(&self.path, &self.original);
+    }
+}
+
+// Regression tests for how a deleted-while-open file's symbol, entry, and
+// cache get cleared. The bug: `handle_did_delete` used to tear down the
+// symbol/entry immediately even for an open file, so
+// `get_symbol_of_opened_file` would find nothing and resurrect a phantom,
+// disk-unchecked entry via its "not found, create one" fallback. Fix: leave
+// an open file's symbol/entry/cache alone on delete; `handle_did_close`
+// clears them on close, based on disk existence / externality, not a
+// stored flag.
+#[test]
+fn test_delete_open_file_then_edit_it() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let dir = env::current_dir().unwrap().join("tests/data/deleted_dir_race").sanitize();
+    let point_path = Path::new(&dir).join("point.py").sanitize();
+    let point_content = std::fs::read_to_string(&point_path).unwrap();
+    let point_uri = FileMgr::pathname2uri(&point_path);
+
+    // 1. Open point.py directly.
+    Odoo::handle_did_open(&mut session, DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: point_uri.clone(),
+            language_id: "python".to_string(),
+            version: 1,
+            text: point_content,
+        },
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+    assert!(session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_some());
+    assert!(session.sync_odoo.opened_files.contains(&point_path));
+    let point_sym_before = session.sync_odoo.get_symbol(&point_path, (&[], &["Thing"]), u32::MAX);
+    assert!(!point_sym_before.is_empty(), "point.Thing should resolve before any delete");
+
+    // 2. point.py gets deleted while the tab stays open (no didClose).
+    Odoo::handle_did_delete(&mut session, DeleteFilesParams {
+        files: vec![FileDelete { uri: point_uri.to_string() }],
+    });
+
+    assert!(session.sync_odoo.opened_files.contains(&point_path), "delete must not implicitly close it");
+    assert!(session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_some(), "FileInfo must survive");
+    assert!(
+        !session.sync_odoo.get_symbol(&point_path, (&[], &["Thing"]), u32::MAX).is_empty(),
+        "symbol must survive the delete while open - the root-cause fix"
+    );
+
+    // 3. The user keeps typing; an ordinary didChange, never preceded by didClose.
+    Odoo::handle_did_change(&mut session, DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier { uri: point_uri, version: 2 },
+        content_changes: vec![TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(0, 0), Position::new(0, 0))),
+            range_length: None,
+            text: "x".to_string(),
+        }],
+    });
+
+    let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path)
+        .expect("FileInfo must still exist after the incremental edit");
+    let contents = file_info.borrow().file_info_ast.borrow().text_document.as_ref()
+        .expect("text_document must be populated after the incremental edit")
+        .contents().to_string();
+    assert!(contents.starts_with("xclass Thing"), "edit should have applied against the live symbol, got: {contents:?}");
+}
+
+#[test]
+fn test_delete_open_file_then_close_it_clears_everything() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let dir = env::current_dir().unwrap().join("tests/data/deleted_dir_race").sanitize();
+    let point_path = Path::new(&dir).join("point_close.py").sanitize();
+    let point_content = std::fs::read_to_string(&point_path).unwrap();
+    let point_uri = FileMgr::pathname2uri(&point_path);
+    let _restore_fixture = RestoreFixture { path: point_path.clone(), original: point_content.clone() };
+
+    // 1. Open point.py, then actually delete it on disk while it stays open.
+    Odoo::handle_did_open(&mut session, DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: point_uri.clone(),
+            language_id: "python".to_string(),
+            version: 1,
+            text: point_content,
+        },
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+    std::fs::remove_file(&point_path).unwrap();
+    Odoo::handle_did_delete(&mut session, DeleteFilesParams {
+        files: vec![FileDelete { uri: point_uri.to_string() }],
+    });
+    assert!(session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_some(), "must survive the delete while open");
+
+    // 2. The user eventually closes the tab without ever reopening it.
+    Odoo::handle_did_close(&mut session, DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: point_uri },
+    });
+
+    assert!(
+        session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_none(),
+        "FileInfo must finally be cleared once closed, not leak for the rest of the session"
+    );
+    assert!(
+        session.sync_odoo.get_symbol(&point_path, (&[], &["Thing"]), u32::MAX).is_empty(),
+        "symbol must also be cleared on close, not just its cache"
+    );
+    assert!(
+        !session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.iter().any(|ep| ep.borrow().path == point_path),
+        "entry point must be gone too, not left dangling"
+    );
+}
+
+// The key regression test: a feature request (hover/completion/etc., all
+// resolving via `get_symbol_of_opened_file`) runs on the deleted-but-still-open
+// buffer before it's ever saved back. Must resolve the real, live symbol -
+// not resurrect a phantom entry.
+#[test]
+fn test_feature_request_on_deleted_open_file_does_not_resurrect_a_phantom_entry() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let dir = env::current_dir().unwrap().join("tests/data/deleted_dir_race").sanitize();
+    let point_path = Path::new(&dir).join("point_phantom.py").sanitize();
+    let point_content = std::fs::read_to_string(&point_path).unwrap();
+    let point_uri = FileMgr::pathname2uri(&point_path);
+    let _restore_fixture = RestoreFixture { path: point_path.clone(), original: point_content.clone() };
+
+    Odoo::handle_did_open(&mut session, DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: point_uri.clone(),
+            language_id: "python".to_string(),
+            version: 1,
+            text: point_content,
+        },
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+    let entries_before = session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.len();
+
+    std::fs::remove_file(&point_path).unwrap();
+    Odoo::handle_did_delete(&mut session, DeleteFilesParams {
+        files: vec![FileDelete { uri: point_uri.to_string() }],
+    });
+
+    // Simulate hover/completion/goto-definition on the still-open buffer.
+    let resolved = SyncOdoo::get_symbol_of_opened_file(&mut session, Path::new(&point_path));
+    assert!(resolved.is_some(), "should resolve the real, still-live symbol");
+    assert_eq!(
+        session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.len(), entries_before,
+        "no phantom entry point should have been created"
+    );
+
+    // Closing now must still fully clear everything, exactly as if the
+    // feature request had never happened.
+    Odoo::handle_did_close(&mut session, DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: point_uri },
+    });
+    assert!(
+        session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_none(),
+        "a feature request must not be able to silently disable cleanup"
+    );
+}
+
+#[test]
+fn test_delete_open_file_then_recreate_it_keeps_it() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let dir = env::current_dir().unwrap().join("tests/data/recreated_file_race").sanitize();
+    let point_path = Path::new(&dir).join("point.py").sanitize();
+    let point_content = std::fs::read_to_string(&point_path).unwrap();
+    let point_uri = FileMgr::pathname2uri(&point_path);
+    let _restore_fixture = RestoreFixture { path: point_path.clone(), original: point_content.clone() };
+
+    // 1. Open point.py, then delete it on disk while it stays open.
+    Odoo::handle_did_open(&mut session, DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: point_uri.clone(),
+            language_id: "python".to_string(),
+            version: 1,
+            text: point_content.clone(),
+        },
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+    Odoo::handle_did_delete(&mut session, DeleteFilesParams {
+        files: vec![FileDelete { uri: point_uri.to_string() }],
+    });
+    assert!(session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_some(), "must survive the delete while open");
+
+    // 2. The user edits the still-open buffer (never saved yet).
+    Odoo::handle_did_change(&mut session, DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier { uri: point_uri.clone(), version: 2 },
+        content_changes: vec![TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(1, 8), Position::new(1, 14))),
+            range_length: None,
+            text: "renamed_method".to_string(),
+        }],
+    });
+    let edited_content = session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path)
+        .unwrap().borrow().file_info_ast.borrow().text_document.as_ref().unwrap().contents().to_string();
+
+    // 3. The user saves the buffer, recreating the file on disk.
+    std::fs::write(&point_path, &edited_content).unwrap();
+    Odoo::handle_did_create(&mut session, CreateFilesParams {
+        files: vec![FileCreate { uri: point_uri.to_string() }],
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+
+    assert!(
+        session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.iter().any(|ep| ep.borrow().path == point_path),
+        "entry point was never actually removed"
+    );
+    assert!(
+        !session.sync_odoo.get_symbol(&point_path, (&[], &["Thing", "renamed_method"]), u32::MAX).is_empty(),
+        "symbol must reflect the edited content, proving didChange kept it fresh throughout"
+    );
+    assert!(
+        session.sync_odoo.get_symbol(&point_path, (&[], &["Thing", "method"]), u32::MAX).is_empty(),
+        "the OLD pre-edit method name must be gone, not stale-cached"
+    );
+
+    // 4. Closing a legitimately-tracked-again file must keep its FileInfo.
+    Odoo::handle_did_close(&mut session, DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: point_uri },
+    });
+    assert!(session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_some());
+}
+
+// Scope boundary, documented rather than silently dropped: deleting a whole
+// directory containing an open file is not covered by the per-file rule above
+// (that would need the recursive symbol/entry teardown itself to be
+// open-aware). This asserts today's unchanged behavior: immediate teardown.
+#[test]
+fn test_directory_delete_with_nested_open_file_is_not_deferred() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let dir = env::current_dir().unwrap().join("tests/data/nested_dir_race/pkg").sanitize();
+    let point_path = Path::new(&dir).join("models").join("point.py").sanitize();
+    let point_content = std::fs::read_to_string(&point_path).unwrap();
+    let point_uri = FileMgr::pathname2uri(&point_path);
+    let pkg_init = Path::new(&dir).join("__init__.py").sanitize();
+
+    EntryPointMgr::create_new_custom_entry_for_path(&mut session, &dir, &pkg_init);
+    BuildScheduler::process_rebuilds(&mut session, false);
+    Odoo::handle_did_open(&mut session, DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: point_uri,
+            language_id: "python".to_string(),
+            version: 1,
+            text: point_content,
+        },
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+    assert!(session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).unwrap().borrow().opened);
+    assert!(!session.sync_odoo.get_symbol(&dir, (&["models", "point"], &["Thing"]), u32::MAX).is_empty());
+
+    // Delete the whole `pkg` dir (not point.py directly). `pkg` has an
+    // `__init__.py` (a `PythonPackage`, convertible to a `SourceFileKey`) -
+    // unlike the bare `models` subdir, which `unload_path` can't resolve at all.
+    Odoo::handle_did_delete(&mut session, DeleteFilesParams {
+        files: vec![FileDelete { uri: FileMgr::pathname2uri(&dir).to_string() }],
+    });
+
+    assert!(
+        session.sync_odoo.get_symbol(&dir, (&["models", "point"], &["Thing"]), u32::MAX).is_empty(),
+        "a directory delete tears down nested symbols immediately, even if one is open"
+    );
+}

--- a/server/tests/test_nested_file_pending_delete_gap.rs
+++ b/server/tests/test_nested_file_pending_delete_gap.rs
@@ -1,0 +1,58 @@
+use std::env;
+use std::path::Path;
+
+use lsp_types::{DidCloseTextDocumentParams, DidOpenTextDocumentParams, TextDocumentIdentifier, TextDocumentItem};
+use odoo_ls_server::core::build_scheduler::BuildScheduler;
+use odoo_ls_server::core::entry_point::EntryPointMgr;
+use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::Odoo;
+use odoo_ls_server::utils::PathSanitizer;
+
+mod setup;
+
+// `in_workspace` only checks a file's immediate parent, so a file under a
+// bare, `__init__.py`-less directory (e.g. `pkg/models/point.py`) ends up
+// `in_workspace = false` even though it's real and internal (not external
+// either). Since `handle_did_close` clears only on "gone from disk" or
+// "external", a file like this must just behave like any other ordinary
+// tracked file - kept on close.
+#[test]
+fn test_nested_bare_dir_file_is_kept_on_close_even_though_not_flagged_in_workspace() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let pkg_dir = env::current_dir().unwrap().join("tests/data/nested_dir_race/pkg").sanitize();
+    let pkg_init = Path::new(&pkg_dir).join("__init__.py").sanitize();
+    let point_path = Path::new(&pkg_dir).join("models").join("point.py").sanitize();
+    let point_content = std::fs::read_to_string(&point_path).unwrap();
+    let point_uri = FileMgr::pathname2uri(&point_path);
+
+    EntryPointMgr::create_new_custom_entry_for_path(&mut session, &pkg_dir, &pkg_init);
+    BuildScheduler::process_rebuilds(&mut session, false);
+
+    let point_syms = session.sync_odoo.get_symbol(&pkg_dir, (&["models", "point"], &[]), u32::MAX);
+    assert_eq!(point_syms.len(), 1, "expected exactly one symbol for pkg.models.point");
+    let point_sym = point_syms[0];
+    assert!(!session.st().is_external(point_sym));
+    assert!(!session.st().in_workspace(point_sym), "immediate parent is a bare dir, in_workspace is never computed for it");
+
+    Odoo::handle_did_open(&mut session, DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: point_uri.clone(),
+            language_id: "python".to_string(),
+            version: 1,
+            text: point_content,
+        },
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+
+    Odoo::handle_did_close(&mut session, DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: point_uri },
+    });
+
+    assert!(
+        session.sync_odoo.get_file_mgr().borrow().get_file_info(&point_path).is_some(),
+        "closing must not evict the FileInfo of a live, valid, internal, non-external file"
+    );
+    assert!(!session.sync_odoo.get_symbol(&pkg_dir, (&["models", "point"], &[]), u32::MAX).is_empty());
+}

--- a/server/tests/test_untitled_pending_delete_unaffected.rs
+++ b/server/tests/test_untitled_pending_delete_unaffected.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+
+use lsp_types::{DidCloseTextDocumentParams, DidOpenTextDocumentParams, TextDocumentIdentifier, TextDocumentItem};
+use odoo_ls_server::core::build_scheduler::BuildScheduler;
+use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::{Odoo, SyncOdoo};
+
+mod setup;
+
+// `handle_did_close` treats an untitled path as always "gone from disk"
+// (`FileMgr::is_untitled`), so closing one takes the unconditional-clear
+// path. Guards against a crash/regression there - the untitled `FileInfo`
+// itself leaking forever on close is a separate, pre-existing bug (nothing
+// ever removes from `untitled_files`), out of scope here.
+#[test]
+fn test_untitled_buffer_close_does_not_crash() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let untitled_uri_str = "untitled:Untitled-1".to_string();
+    let untitled_uri = FileMgr::pathname2uri(&untitled_uri_str);
+
+    Odoo::handle_did_open(&mut session, DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: untitled_uri.clone(),
+            language_id: "python".to_string(),
+            version: 1,
+            text: "def foo():\n    return 42\n".to_string(),
+        },
+    });
+    BuildScheduler::process_rebuilds(&mut session, false);
+
+    let file_info = session.sync_odoo.get_file_mgr().borrow().get_file_info(&untitled_uri_str)
+        .expect("FileInfo for the untitled buffer should exist once opened");
+    assert!(file_info.borrow().opened);
+    drop(file_info);
+    assert!(SyncOdoo::get_symbol_of_opened_file(&mut session, Path::new(&untitled_uri_str)).is_some());
+
+    Odoo::handle_did_close(&mut session, DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: untitled_uri },
+    });
+
+    assert!(
+        !session.sync_odoo.entry_point_mgr.borrow().untitled_entry_points.iter().any(|ep| ep.borrow().path == untitled_uri_str),
+        "the untitled entry point must still be removed on close"
+    );
+}


### PR DESCRIPTION
Before that could easily trigger a panic when doing a git operation for example. A deleted file will have its file info deleted, then upon doing any edit, it would panic.

This change prevents deletion if file is opened, but keeps track of that state, if the file gets closed, then the deletion happens at that point.