### PR TITLE
[FIX] Handle deleted Addons

### DIFF
--- a/server/src/core/build_scheduler.rs
+++ b/server/src/core/build_scheduler.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, path::Path, rc::Rc, sync::atomic::Ordering};
 use lsp_types::MessageType;
 use tracing::{error, info, trace};
 
-use crate::{S, constants::{BuildStatus, BuildSteps, DEBUG_REBUILD_NOW, DEBUG_STEPS, DEBUG_THREADS, MAX_WATCHED_FILES_UPDATES_BEFORE_RESTART}, core::{csv_validation::CsvValidator, entry_point::EntryPoint, import_resolver::ImportCache, js_validator::JsValidator, odoo::InitState, python_arch_builder::PythonArchBuilder, python_arch_eval::PythonArchEval, python_validator::PythonValidator, symbols::{SymbolTable, symbol_keys::{BuildableSymbolKey, SymbolKey}, symbol_table_impl::CreateError}, xml_validation::XmlValidator}, fifo_ptr_weak_hash_set::FifoWeakHashSet, progress_reporter::ProgressReporterRemaining, threads::SessionInfo, tree::Tree, utils::HashSet};
+use crate::{S, constants::{BuildStatus, BuildSteps, DEBUG_REBUILD_NOW, DEBUG_STEPS, DEBUG_THREADS, MAX_WATCHED_FILES_UPDATES_BEFORE_RESTART}, core::{csv_validation::CsvValidator, entry_point::EntryPoint, import_resolver::ImportCache, js_validator::JsValidator, odoo::{InitState, OdooNotification}, python_arch_builder::PythonArchBuilder, python_arch_eval::PythonArchEval, python_validator::PythonValidator, symbols::{SymbolTable, symbol_keys::{BuildableSymbolKey, SymbolKey}, symbol_table_impl::CreateError}, xml_validation::XmlValidator}, fifo_ptr_weak_hash_set::FifoWeakHashSet, progress_reporter::ProgressReporterRemaining, threads::SessionInfo, tree::Tree, utils::HashSet};
 
 #[derive(Debug)]
 pub struct BuildScheduler {
@@ -262,7 +262,7 @@ impl BuildScheduler {
         if session.sync_odoo.need_rebuild {
             session.log_message(MessageType::INFO, S!("Rebuild required. Resetting database on breaktime..."));
             info!("Odoo version change detected. OdooLS is restarting");
-            session.send_notification("$Odoo/restartNeeded", ());
+            session.send_notification(OdooNotification::RestartNeeded, ());
         }
         session.sync_odoo.import_cache = None;
         session.sync_odoo.watched_file_updates = 0;

--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -73,7 +73,7 @@ impl EntryPointMgr {
     /**
      * Create each required directory symbols for a given path.
      * /!\ path must point to a directory on disk */
-    fn create_dir_symbols_for_new_entry(session: &mut SessionInfo, path: &str, entry: Rc<RefCell<EntryPoint>>) -> Option<SymbolKey> {
+    pub fn create_dir_symbols_for_new_entry(session: &mut SessionInfo, path: &str, entry: Rc<RefCell<EntryPoint>>) -> Option<SymbolKey> {
         let path = Path::new(path);
         let mut iter_path = PathBuf::new();
         let mut current_sym: FileSystemSymbolParent = entry.borrow().root.into();
@@ -81,8 +81,12 @@ impl EntryPointMgr {
         for component in path.components().take(component_count - 1) {
             iter_path.push(component);
             if let Some(name) = component.as_os_str().to_str() {
-                let disk_dir = session.st_mut().add_new_disk_dir(current_sym, name, iter_path.to_str().unwrap());
-                current_sym = disk_dir.expect("Starting from fresh root, no name collision expected").into();
+                current_sym = if let Some(existing_sym) = current_sym.get_child(session.st(), name) {
+                    existing_sym.try_into().expect("Expected existing_sym to be a DiskDirKey")
+                } else {
+                    session.st_mut().add_new_disk_dir(current_sym, name, iter_path.to_str().unwrap())
+                        .expect("Starting from fresh root, no name collision expected").into()
+                };
             } else {
                 error!("Unable to convert path component to string");
                 return None;
@@ -181,6 +185,36 @@ impl EntryPointMgr {
             shared_root
         );
         session.sync_odoo.entry_point_mgr.borrow_mut().addons_entry_points.push(entry.clone());
+    }
+
+    /* Re-add a configured addons path that was dropped by clean_entries after its
+     * directory got deleted. Rebuilds the "odoo.addons" namespace if needed.
+     */
+    pub fn restore_addon_entry(session: &mut SessionInfo, path: &str) -> Option<Rc<RefCell<EntryPoint>>> {
+        let main_entry = session.sync_odoo.entry_point_mgr.borrow().main_entry_point.as_ref()?.clone();
+        let main_sym = main_entry.borrow().get_symbol(session.st())?;
+        match session.st().get_symbol(main_sym, (&["odoo", "addons"], &[]), u32::MAX).first() {
+            Some(&SymbolKey::Namespace(k)) => {
+                if !session.st()[k].paths().iter().any(|p| p == path) {
+                    session.st_mut()[k].add_path(path.to_string());
+                }
+            }
+            None => {
+                let odoo_pkg = session
+                    .st()
+                    .get_symbol(main_sym, (&["odoo"], &[]), u32::MAX)
+                    .first()
+                    .and_then(|&sym| sym.try_into().ok())?;
+                session.st_mut().add_new_namespace(odoo_pkg, "addons", path).ok()?;
+            }
+            Some(other) => {
+                warn!("odoo.addons resolved to unexpected symbol {other:?} while restoring addon entry {path}");
+                return None;
+            }
+        }
+        info!("Restoring addon entry point: {}", path);
+        EntryPointMgr::add_entry_to_addons(session, path.to_string(), main_entry, vec![OYarn::from("odoo"), OYarn::from("addons")]);
+        session.sync_odoo.entry_point_mgr.borrow().addons_entry_points.last().cloned()
     }
 
     /* Create a new entry to public.
@@ -337,6 +371,15 @@ impl EntryPointMgr {
                 // addons entries share the same root as the main entry
                 self.addons_entry_points.clear();
             }
+        // addons entries share the main entry's root, so drop them without drop_entry/drop_root
+        self.addons_entry_points.retain(|entry| {
+            if entry.borrow().to_delete {
+                info!("Dropping addon entry point {}", entry.borrow().path);
+                false
+            } else {
+                true
+            }
+        });
         let mut drop_if_flagged = |label: &str, entries: &mut Vec<Rc<RefCell<EntryPoint>>>| {
             entries.retain(|entry| {
                 if entry.borrow().to_delete {

--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -819,7 +819,7 @@ impl FileInfo {
                 }
                 all_diagnostics.push(updated);
             }
-            session.send_notification::<PublishDiagnosticsParams>(PublishDiagnostics::METHOD, PublishDiagnosticsParams{
+            session.send_notification(PublishDiagnostics::METHOD, PublishDiagnosticsParams{
                 uri: FileMgr::pathname2uri(&self.uri),
                 diagnostics: all_diagnostics,
                 version: self.version,

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -115,6 +115,45 @@ impl TypeshedWeakReferences {
     }
 }
 
+/// Method names for the server's custom "$Odoo/..." LSP notifications, kept in one place so
+/// call sites can't typo a raw string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OdooNotification {
+    JsLsStatus,
+    InvalidPythonPath,
+    DiagnosticConfig,
+    RestartNeeded,
+    LoadingStatusUpdate,
+    SetConfiguration,
+    SetPid,
+}
+
+impl OdooNotification {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::JsLsStatus => "$Odoo/jsLsStatus",
+            Self::InvalidPythonPath => "$Odoo/invalid_python_path",
+            Self::DiagnosticConfig => "$Odoo/diagnostic_config",
+            Self::RestartNeeded => "$Odoo/restartNeeded",
+            Self::LoadingStatusUpdate => "$Odoo/loadingStatusUpdate",
+            Self::SetConfiguration => "$Odoo/setConfiguration",
+            Self::SetPid => "$Odoo/setPid",
+        }
+    }
+}
+
+impl From<OdooNotification> for &'static str {
+    fn from(notification: OdooNotification) -> Self {
+        notification.as_str()
+    }
+}
+
+impl std::fmt::Display for OdooNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug)]
 pub struct SyncOdoo {
     pub version: OdooVersion,
@@ -293,7 +332,7 @@ impl SyncOdoo {
         info!("Full Config: {:?}", config);
         let start_time = Instant::now();
         session.sync_odoo.state_init = InitState::NOT_READY;
-        session.send_notification("$Odoo/loadingStatusUpdate", "start");
+        session.send_notification(OdooNotification::LoadingStatusUpdate, "start");
         session.sync_odoo.config = config;
         if session.sync_odoo.config.no_typeshed_stubs() {
             session.sync_odoo.stubs_dirs.clear();
@@ -321,7 +360,7 @@ impl SyncOdoo {
             match Command::new(session.sync_odoo.config.python_path().clone()).args(["-c", "import sys; import json; print(json.dumps(sys.path))"]).output() {
                 Err(err) => {
                     warn!("Wrong python command: {}, error: {}", session.sync_odoo.config.python_path().clone(), err);
-                    session.send_notification("$Odoo/invalid_python_path", ());
+                    session.send_notification(OdooNotification::InvalidPythonPath, ());
                     break 'python_check;
                 },
                 Ok(output) => {
@@ -347,7 +386,7 @@ impl SyncOdoo {
             match Command::new(session.sync_odoo.config.python_path().clone()).args(["-c", "import sys, importlib.machinery, json; print(json.dumps({'version_info': list(sys.version_info)[:3], 'ext_suffixes': list(importlib.machinery.EXTENSION_SUFFIXES)}))"]).output() {
                 Err(err) => {
                     warn!("Wrong python command: {}, error: {}", session.sync_odoo.config.python_path().clone(), err);
-                    session.send_notification("$Odoo/invalid_python_path", ());
+                    session.send_notification(OdooNotification::InvalidPythonPath, ());
                 },
                 Ok(output) => {
                     session.sync_odoo.has_valid_python = true;
@@ -375,7 +414,7 @@ impl SyncOdoo {
             }
         }
         let tsserver_handle = if session.sync_odoo.config.is_javascript_disabled() {
-            session.send_notification("$Odoo/jsLsStatus", false);
+            session.send_notification(OdooNotification::JsLsStatus, false);
             None
         } else {
             let client_sender = session.clone_sender();
@@ -386,7 +425,7 @@ impl SyncOdoo {
                 let ts_check = session.sync_odoo.config.ts_check();
                 std::thread::spawn(move || {
                     let bridge = SyncOdoo::setup_and_start_tsserver(tsserver_cmd, sender, odoo_path, addons_paths, ts_check);
-                    let _ = send_notification_via(&client_sender, "$Odoo/jsLsStatus", bridge.is_some());
+                    let _ = send_notification_via(&client_sender, OdooNotification::JsLsStatus.into(), bridge.is_some());
                     bridge
                 })
             })
@@ -428,7 +467,7 @@ impl SyncOdoo {
                 ]);},
             }
         }
-        session.send_notification("$Odoo/loadingStatusUpdate", "stop");
+        session.send_notification(OdooNotification::LoadingStatusUpdate, "stop");
         session.log_message(MessageType::INFO, format!("End of initialization. Time taken: {} ms", start_time.elapsed().as_millis()));
     }
 
@@ -1368,7 +1407,7 @@ impl Odoo {
                 "diagnostics": config_file.diagnostic_messages(),
             });
             session.send_notification(
-                "$Odoo/setConfiguration",
+                OdooNotification::SetConfiguration,
                 payload
             );
         }
@@ -2062,10 +2101,21 @@ impl Odoo {
             }
         }
         // test if the new path is a new module under odoo/addons namespace.
-        let Some(addons) = session.sync_odoo.addons_namespace() else {
+        let Some(parent_path) = path_for_tree.parent().map(|parent| parent.sanitize_cow().into_owned()) else {
             return;
         };
-        let Some(parent_path) = path_for_tree.parent().map(|parent| parent.sanitize_cow()) else {
+        // path may have been deleted and recreated since; restore it if still configured
+        let already_registered = ep_mgr.borrow().addons_entry_points.iter()
+            .any(|entry| entry.borrow().path == parent_path);
+        if !already_registered && session.sync_odoo.config.addons_paths().contains(&parent_path) {
+            let restored = EntryPointMgr::restore_addon_entry(session, &parent_path);
+            if restored.is_some() {
+                // Request restart to get a clean reload, but not early return -
+                // also queue it in the build scheduler later, in case the client does not support `RestartNeeded`
+                session.send_notification(OdooNotification::RestartNeeded, ());
+            }
+        }
+        let Some(addons) = session.sync_odoo.addons_namespace() else {
             return;
         };
         if !session.st()[addons].directories().iter().any(|d| d.path == parent_path) {
@@ -2362,7 +2412,7 @@ impl Odoo {
     pub fn handle_config_update(session: &mut SessionInfo, new_config: ConfigEntry, cfg_file: ConfigView) {
         if config::needs_restart(&session.sync_odoo.config, &new_config) {
             // Changes require a restart, ask the client to restart the server
-            session.send_notification("$Odoo/restartNeeded", ());
+            session.send_notification(OdooNotification::RestartNeeded, ());
             return;
         }
         // Changes can be applied without restart

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use nix;
 use tracing::{error, info, warn};
 
-use crate::{S, constants::{DEBUG_THREADS, EXTENSION_VERSION}, core::odoo::SyncOdoo, crash_buffer, threads::{DelayedProcessingMessage, ThreadMessage, delayed_changes_process_thread, message_processor_thread_main}};
+use crate::{S, constants::{DEBUG_THREADS, EXTENSION_VERSION}, core::odoo::{OdooNotification, SyncOdoo}, crash_buffer, threads::{DelayedProcessingMessage, ThreadMessage, delayed_changes_process_thread, message_processor_thread_main}};
 
 
 /**
@@ -270,7 +270,7 @@ impl Server {
 
         self.connection.as_ref().unwrap().initialize_finish(id, serde_json::to_value(initialize_data).unwrap())?;
         let _ = self.connection.as_ref().unwrap().sender.send(Message::Notification(lsp_server::Notification {
-            method: "$Odoo/setPid".to_string(),
+            method: OdooNotification::SetPid.as_str().to_string(),
             params: json!({
                 "server_pid": std::process::id(),
             })

--- a/server/src/threads.rs
+++ b/server/src/threads.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use tracing::{error, info, warn};
 use crate::{constants::{DiagnosticSource, MAX_WATCHED_FILES_UPDATES_BEFORE_RESTART}, core::{build_scheduler::BuildScheduler, symbols::storage::SymbolTable}, create_session, lsp_types_custom::{ConfigDiagnosticAction, ConfigDiagnosticMessage}};
 
-use crate::{core::{file_mgr::NoqaInfo, odoo::{Odoo, SyncOdoo}}, server::ServerError, utils::PathSanitizer, S};
+use crate::{core::{file_mgr::NoqaInfo, odoo::{Odoo, OdooNotification, SyncOdoo}}, server::ServerError, utils::PathSanitizer, S};
 
 
 pub struct SessionInfo<'a> {
@@ -55,9 +55,17 @@ impl <'a> SessionInfo<'a> {
         self.sender.clone()
     }
 
+    /// Test-only: counts restart notifications and drains out the rest
+    pub fn test_drain_restart_notifications(&self) -> usize {
+        self.receiver.try_iter()
+            .filter(|msg| matches!(msg, Message::Notification(n) if n.method == OdooNotification::RestartNeeded.as_str()))
+            .count()
+    }
+
     /// Send a notification to the client using the given method and parameters via the session sender.
     /// Panics if the send fails and the server is not shutting down.
-    pub fn send_notification<T: Serialize>(&self, method: &str, params: T) {
+    pub fn send_notification<M: Into<&'static str>, T: Serialize>(&self, method: M, params: T) {
+        let method = method.into();
         if let Err(e) = send_notification_via(&self.sender, method, params)
             && !self.sync_odoo.terminate_rebuild.load(std::sync::atomic::Ordering::SeqCst)
         {
@@ -117,7 +125,7 @@ impl <'a> SessionInfo<'a> {
     }
 
     pub fn send_config_diagnostic(&self, action: ConfigDiagnosticAction, messages: &[ConfigDiagnosticMessage]) {
-        self.send_notification("$Odoo/diagnostic_config", serde_json::json!({
+        self.send_notification(OdooNotification::DiagnosticConfig, serde_json::json!({
             "action": action.as_str(),
             "messages": messages
         }));
@@ -281,7 +289,7 @@ fn restart_server(sync_odoo: &Arc<Mutex<SyncOdoo>>, sender_session: &Sender<Mess
             noqas_stack: vec![],
             current_noqa: NoqaInfo::None,
         };
-        session.send_notification("$Odoo/restartNeeded", ());
+        session.send_notification(OdooNotification::RestartNeeded, ());
     }
 }
 
@@ -297,7 +305,7 @@ fn notify_git_lock(sync_odoo: &Arc<Mutex<SyncOdoo>>, sender_session: &Sender<Mes
             current_noqa: NoqaInfo::None,
         };
         error!("Git index lock detected, notifying client: {}", status);
-        session.send_notification("$Odoo/loadingStatusUpdate", status);
+        session.send_notification(OdooNotification::LoadingStatusUpdate, status);
     }
 }
 

--- a/server/tests/test_addon_entry_lost_symbol.rs
+++ b/server/tests/test_addon_entry_lost_symbol.rs
@@ -1,0 +1,113 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+use lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+use odoo_ls_server::constants::OYarn;
+use odoo_ls_server::core::entry_point::EntryPointMgr;
+use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::{Odoo, SyncOdoo};
+use odoo_ls_server::core::symbols::symbol_keys::SymbolKey;
+use odoo_ls_server::utils::PathSanitizer;
+use odoo_ls_server::Sy;
+
+mod setup;
+
+// Regression test for the panic at odoo.rs:2414 (`Option::unwrap()` on `None`) in
+// `search_symbols_to_rebuild`'s `addons_entry_points` loop: deleting an addon's
+// directory unloads its symbol, but `clean_entries` never dropped the now-stale
+// entry, so the next create/change event under it hit an empty `get_symbol()`.
+// Fixed by making `clean_entries` actually drop it, and by re-registering the entry
+// (`restore_addon_entry`) if its path is created again.
+#[test]
+fn test_addon_entry_losing_its_symbol_does_not_panic() {
+    let (mut odoo, config) = setup::setup::setup_server(false);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+    let _ = session.test_drain_restart_notifications(); // discard whatever init itself sent
+
+    let fixture_root = env::current_dir().unwrap().join("tests/data/addon_entry_lost_symbol").sanitize();
+    let addons_dir = Path::new(&fixture_root).join("odoo").join("addons").sanitize();
+
+    // this test deletes and recreates the fixture, so build it fresh each run
+    let _ = fs::remove_dir_all(&fixture_root);
+    fs::create_dir_all(&addons_dir).unwrap();
+
+    // stand-in for the real "odoo" main entry point
+    let main_sym = EntryPointMgr::set_main_entry(&mut session, fixture_root.clone()).unwrap();
+    session.st_mut().set_is_external(main_sym, false);
+    let main_entry = session.sync_odoo.entry_point_mgr.borrow().main_entry_point.as_ref().unwrap().clone();
+    session.sync_odoo.main_entry_tree = main_entry.borrow().tree.clone();
+
+    // stand-in for the real "odoo.addons" namespace
+    EntryPointMgr::create_dir_symbols_for_new_entry(&mut session, &addons_dir, main_entry.clone());
+    EntryPointMgr::add_entry_to_addons(&mut session, addons_dir.clone(), main_entry.clone(), vec![Sy!("odoo"), Sy!("addons")]);
+
+    session.sync_odoo.config.set_string_list(odoo_ls_server::core::config::ConfigKey::AddonsPaths, vec![addons_dir.clone()]);
+
+    let entry = session.sync_odoo.entry_point_mgr.borrow().addons_entry_points.last().unwrap().clone();
+    assert!(
+        matches!(entry.borrow().get_symbol(session.st()), Some(SymbolKey::Namespace(_))),
+        "sanity check: the addon entry should resolve to a Namespace symbol right after creation"
+    );
+
+    // delete the whole addons directory and notify the server, like a file watcher would
+    fs::remove_dir_all(&addons_dir).unwrap();
+    Odoo::handle_did_change_watched_files(&mut session, DidChangeWatchedFilesParams {
+        changes: vec![FileEvent { uri: FileMgr::pathname2uri(&addons_dir), typ: FileChangeType::DELETED }],
+    });
+
+    assert!(
+        session.sync_odoo.entry_point_mgr.borrow().addons_entry_points.is_empty(),
+        "the now-symbol-less entry should have been cleaned up instead of left dangling"
+    );
+    assert_eq!(
+        session.test_drain_restart_notifications(), 0,
+        "merely dropping the stale addon entry point should not ask the client to restart"
+    );
+
+    // recreate a module under the same (now stale) addons path
+    let new_module_dir = Path::new(&addons_dir).join("new_module").sanitize();
+    fs::create_dir_all(&new_module_dir).unwrap();
+    let manifest_path = Path::new(&new_module_dir).join("__manifest__.py").sanitize();
+    let init_path = Path::new(&new_module_dir).join("__init__.py").sanitize();
+    fs::write(&manifest_path, "{'name': 'New Module'}\n").unwrap();
+    fs::write(&init_path, "class Thing:\n    def method(self):\n        return 1\n").unwrap();
+
+    Odoo::handle_did_change_watched_files(&mut session, DidChangeWatchedFilesParams {
+        changes: vec![
+            FileEvent { uri: FileMgr::pathname2uri(&new_module_dir), typ: FileChangeType::CREATED },
+            FileEvent { uri: FileMgr::pathname2uri(&manifest_path), typ: FileChangeType::CREATED },
+            FileEvent { uri: FileMgr::pathname2uri(&init_path), typ: FileChangeType::CREATED },
+        ],
+    });
+
+    assert_eq!(
+        session.test_drain_restart_notifications(), 1,
+        "restoring the addon entry point should ask the client to restart exactly once"
+    );
+    assert_eq!(
+        session.sync_odoo.entry_point_mgr.borrow().addons_entry_points.len(), 1,
+        "the addons path should have been re-registered as a real addon entry"
+    );
+    assert!(
+        session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.is_empty(),
+        "the recreated module should not have fallen back to a disconnected custom entry"
+    );
+    let module = session.sync_odoo.get_symbol(&fixture_root, (&["odoo", "addons", "new_module"], &[]), u32::MAX);
+    assert!(
+        !module.is_empty(),
+        "new_module should resolve as a real odoo.addons module again"
+    );
+
+    // and the rebuilt namespace should support full symbol resolution, not just a
+    // module shell: a method inside it should resolve and evaluate normally
+    let method = session.sync_odoo
+        .get_symbol(&fixture_root, (&["odoo", "addons", "new_module"], &["Thing", "method"]), u32::MAX)
+        .first()
+        .expect("new_module.Thing.method should resolve after the namespace is rebuilt")
+        .unwrap_function_key();
+    SyncOdoo::ensure_func_evaluations(&mut session, method);
+    assert!(!session.st()[method].evaluations.is_empty(), "method should have been built successfully");
+
+    let _ = fs::remove_dir_all(&fixture_root);
+}


### PR DESCRIPTION
When a directory that is an addon entry is deleted, the symbol gets dropped, but the entrypoint stays. In that case `search_symbols_to_rebuild` calls get_symbol on the entrpoint, then unwraps the result, which then panics.

This PR, adds the mechanism to drop, and then also recover addon entries upon deletion and creation.

See crash report 2271