### PR TITLE
[FIX] add model dependency from inherited model to the base one

### DIFF
--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -729,6 +729,8 @@ impl PythonValidator {
         let model = session.sync_odoo.models.get(model_name);
         if model.map(|m| m.borrow_mut().has_symbols(session.st())).unwrap_or(false) {
             let model = model.unwrap().clone();
+            let file = session.st().get_file(class_key.into()).unwrap();
+            session.st_mut().add_model_dependencies(file, &model);
             let borrowed_model = model.borrow();
             let mut main_modules = vec![];
             let mut found_one = false;


### PR DESCRIPTION
Actually if a model B inherit from A, no model dependency was set, so reference feature was not able to go up in the dependency tree