### PR TITLE
prevent key replacement on symbol insertion

### DIFF
--- a/server/src/core/build_scheduler.rs
+++ b/server/src/core/build_scheduler.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, path::Path, rc::Rc, sync::atomic::Ordering};
 use lsp_types::MessageType;
 use tracing::{error, info, trace};
 
-use crate::{S, constants::{BuildStatus, BuildSteps, DEBUG_REBUILD_NOW, DEBUG_STEPS, DEBUG_THREADS, MAX_WATCHED_FILES_UPDATES_BEFORE_RESTART}, core::{csv_validation::CsvValidator, entry_point::EntryPoint, import_resolver::ImportCache, js_validator::JsValidator, odoo::InitState, python_arch_builder::PythonArchBuilder, python_arch_eval::PythonArchEval, python_validator::PythonValidator, symbols::{SymbolTable, symbol_keys::{BuildableSymbolKey, SymbolKey}}, xml_validation::XmlValidator}, fifo_ptr_weak_hash_set::FifoWeakHashSet, progress_reporter::ProgressReporterRemaining, threads::SessionInfo, tree::Tree, utils::HashSet};
+use crate::{S, constants::{BuildStatus, BuildSteps, DEBUG_REBUILD_NOW, DEBUG_STEPS, DEBUG_THREADS, MAX_WATCHED_FILES_UPDATES_BEFORE_RESTART}, core::{csv_validation::CsvValidator, entry_point::EntryPoint, import_resolver::ImportCache, js_validator::JsValidator, odoo::InitState, python_arch_builder::PythonArchBuilder, python_arch_eval::PythonArchEval, python_validator::PythonValidator, symbols::{SymbolTable, symbol_keys::{BuildableSymbolKey, SymbolKey}, symbol_table_impl::CreateError}, xml_validation::XmlValidator}, fifo_ptr_weak_hash_set::FifoWeakHashSet, progress_reporter::ProgressReporterRemaining, threads::SessionInfo, tree::Tree, utils::HashSet};
 
 #[derive(Debug)]
 pub struct BuildScheduler {
@@ -141,9 +141,12 @@ impl BuildScheduler {
                 continue;
             };
             let in_addons = session.sync_odoo.get_main_entry_tree(parent) == (&["odoo", "addons"], &[]);
-            let new_symbol = SymbolTable::create_from_path(session, Path::new(path), parent, in_addons);
-            let Some(new_symbol) = new_symbol else {
-                continue;
+            let new_symbol = match SymbolTable::create_from_path(session, Path::new(&path), parent, in_addons) {
+                Ok(symbol) => symbol,
+                Err(CreateError::NothingOnDisk) => continue,
+                Err(CreateError::Existing(existing)) => panic!(
+                   "reload path {path} still occupied by {existing:?}: unload failed to unlink it" 
+                ),
             };
             session.sync_odoo.must_reload_paths.retain(|(_, p)| p != path);
             session.st_mut().set_is_external(new_symbol, false);

--- a/server/src/core/build_scheduler.rs
+++ b/server/src/core/build_scheduler.rs
@@ -136,7 +136,7 @@ impl BuildScheduler {
     }
 
     fn add_from_self_reload(session: &mut SessionInfo) {
-        for (weak_sym, path) in session.sync_odoo.must_reload_paths.clone().iter() {
+        for (weak_sym, path) in std::mem::take(&mut session.sync_odoo.must_reload_paths) {
             let Some(parent) = weak_sym.upgrade(session.st()) else {
                 continue;
             };
@@ -148,7 +148,6 @@ impl BuildScheduler {
                    "reload path {path} still occupied by {existing:?}: unload failed to unlink it" 
                 ),
             };
-            session.sync_odoo.must_reload_paths.retain(|(_, p)| p != path);
             session.st_mut().set_is_external(new_symbol, false);
             match new_symbol {
                 SymbolKey::PythonPackage(p) => {
@@ -172,7 +171,6 @@ impl BuildScheduler {
             }
             BuildScheduler::queue(session, new_symbol.unwrap_buildable_key());
         }
-        session.sync_odoo.must_reload_paths.retain(|x| x.0.upgrade(&session.sync_odoo.symbol_table).is_some());
     }
 
     pub fn process_rebuilds(session: &mut SessionInfo, no_validation: bool) -> bool {

--- a/server/src/core/csv_arch_builder.rs
+++ b/server/src/core/csv_arch_builder.rs
@@ -3,7 +3,7 @@ use crate::{
         build_scheduler::BuildScheduler, data_hooks, diagnostics::{DiagnosticCode, create_diagnostic}, symbols::{
             Buildable, ModuleSymbol, symbol_keys::{CsvFileKey, XmlId, XmlRecordKey}
         },
-    }, features::csv_ast_utils::{CsvFieldIter, CsvRecordIter}, oyarn, threads::SessionInfo
+    }, features::csv_ast_utils::{CsvFieldIter, CsvRecordIter}, oyarn, threads::SessionInfo, utils::HashSet
 };
 use csv::StringRecord;
 use lsp_types::{Diagnostic, Position, Range};
@@ -42,15 +42,27 @@ impl CsvArchBuilder {
         if DEBUG_STEPS {
             info!("ARCH       - CSV: {}", session.st()[csv_symbol].path);
         }
-        let csv = &mut session.st_mut()[csv_symbol];
         let mut rdr = csv::ReaderBuilder::new().from_reader(content.as_bytes());
         if rdr.has_headers()
             && let Ok(header) = rdr.headers() {
+                let csv = &mut session.st_mut()[csv_symbol];
                 for h in header.iter() {
                     csv.headers.push(oyarn!("{}", h));
                 }
+                // Look for duplicate column (field) names. Odoo keeps the last one, so we issue a warning for the one getting overridden.
+                let columns: Vec<_> = CsvFieldIter::new(header, content).into_iter().flatten().collect();
+                let mut seen = HashSet::default();
+                for (start, end, name) in columns.into_iter().rev() {
+                    if !seen.insert(name)
+                        && let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05076, &[name]) {
+                            diagnostics.push(Diagnostic {
+                                range: Range { start: Position::new(start as u32, 0), end: Position::new(end as u32, 0) },
+                                ..diagnostic
+                            });
+                        }
+                }
             }
-        if csv.headers.contains(&Sy!("id")) {
+        if session.st()[csv_symbol].headers.contains(&Sy!("id")) {
             for (start, end, result) in CsvRecordIter::new(&mut rdr, content) {
                 match result {
                     Ok(result) => {
@@ -137,7 +149,8 @@ impl CsvArchBuilder {
                     }
                 },
                 Err(_) => {
-                    //TODO: add diagnostic for duplicate fields?
+                    // field already stored, this one gets overriden.
+                    // Diagnostic issued on the header in `load_csv`.
                 }
             };
         }

--- a/server/src/core/csv_arch_builder.rs
+++ b/server/src/core/csv_arch_builder.rs
@@ -108,8 +108,8 @@ impl CsvArchBuilder {
     }
 
     fn extract_record(&self, session: &mut SessionInfo, file_symbol: CsvFileKey, model_name: OYarn, record: &StringRecord, content: &str) -> Option<XmlRecordKey> {
-        let field_iter = CsvFieldIter::new(record, content)?;
-        let mut last_end = 0;
+        let fields: Vec<_> = CsvFieldIter::new(record, content)?.collect();
+        let last_end = fields.last().map_or(0, |(_, end, _)| *end);
         let mut xml_id = None;
         let record_key = session.st_mut().add_new_xml_record(
             file_symbol.into(),
@@ -121,18 +121,25 @@ impl CsvArchBuilder {
             TextRange::new(TextSize::new(0), TextSize::new(0_u32)) //dummy
         );
         let headers = &session.st()[file_symbol].headers.clone();
-        for (idx, (start, end, field)) in field_iter.enumerate() {
-            let field_name = headers.get(idx).unwrap().clone();
-            if field_name == "id" {
-                xml_id = Some(oyarn!("{}", field));
-            }
-            session.st_mut().add_new_xml_field(record_key.into(),
+        // Iterate in reverse order so that the last occurrence of a field is the one that is stored
+        for (idx, (start, end, field)) in fields.into_iter().enumerate().rev() {
+            let field_name = headers.get(idx).unwrap();
+            match session.st_mut().add_new_xml_field(record_key.into(),
                 field_name,
                 TextRange::new(TextSize::new(start as u32), TextSize::new(end as u32)),
                 Some(field.to_string()),
                 Some(TextRange::new(TextSize::new(start as u32), TextSize::new(end as u32))),
-                None);
-            last_end = end;
+                None
+            ) {
+                Ok(_) => {
+                    if field_name == "id" {
+                        xml_id = Some(oyarn!("{}", field));
+                    }
+                },
+                Err(_) => {
+                    //TODO: add diagnostic for duplicate fields?
+                }
+            };
         }
         let rec = &mut session.st_mut()[record_key];
         rec.xml_id = xml_id;

--- a/server/src/core/diagnostic_codes_list.rs
+++ b/server/src/core/diagnostic_codes_list.rs
@@ -586,6 +586,11 @@ OLS05074, DiagnosticSetting::Error, "Template '{0}' is not declared in any depen
 */
 OLS05075, DiagnosticSetting::Warning, "It is discouraged to declare a template at the root of the file. Consider adding an 'odoo' or 'template' node as root of the file",
 /**
+* The same field is declared twice in a record or an asset node, or twice in a CSV header row.
+* Odoo keeps the last declaration, so the earlier ones have no effect.
+*/
+OLS05076, DiagnosticSetting::Warning, "Duplicate declaration of field '{0}'. Only the last one is used",
+/**
 * Template not found
 */
 OLS06000, DiagnosticSetting::Error, "Template not found",

--- a/server/src/core/entry_point.rs
+++ b/server/src/core/entry_point.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, cmp, path::PathBuf, rc::Rc};
 use crate::constants::MissingDataSource;
 use crate::core::build_scheduler::BuildScheduler;
 use crate::core::symbols::storage::FileSystemSymbolParent;
+use crate::core::symbols::symbol_table_impl::CreateError;
 use crate::utils::HashMap;
 
 use slotmap::Key;
@@ -66,32 +67,33 @@ impl EntryPointMgr {
         let path_stem = Path::new(&path).with_extension("");
         let name = path_stem.components().next_back().unwrap().as_os_str().to_str().unwrap();
 
-        session.st_mut().add_new_file(entry.borrow().root.into(), name, &path)
+        session.st_mut().add_new_file(entry.borrow().root.into(), name, &path).expect("fresh root has no children")
     }
 
     /**
      * Create each required directory symbols for a given path.
      * /!\ path must point to a directory on disk */
-    pub fn create_dir_symbols_from_path_to_entry(session: &mut SessionInfo, path: &Path, entry: Rc<RefCell<EntryPoint>>) -> Option<SymbolKey> {
+    fn create_dir_symbols_for_new_entry(session: &mut SessionInfo, path: &str, entry: Rc<RefCell<EntryPoint>>) -> Option<SymbolKey> {
+        let path = Path::new(path);
         let mut iter_path = PathBuf::new();
         let mut current_sym: FileSystemSymbolParent = entry.borrow().root.into();
         let component_count = path.components().count();
         for component in path.components().take(component_count - 1) {
             iter_path.push(component);
             if let Some(name) = component.as_os_str().to_str() {
-                let sym = current_sym.get_child(session.st(), name);
-                if let Some(existing_sym) = sym {
-                    current_sym = existing_sym.try_into().expect("Expected existing_sym to be a DiskDirKey");
-                } else {
-                    let disk_dir = session.st_mut().add_new_disk_dir(current_sym, name, iter_path.to_str().unwrap());
-                    current_sym = disk_dir.into();
-                }
+                let disk_dir = session.st_mut().add_new_disk_dir(current_sym, name, iter_path.to_str().unwrap());
+                current_sym = disk_dir.expect("Starting from fresh root, no name collision expected").into();
             } else {
                 error!("Unable to convert path component to string");
                 return None;
             }
         }
-        SymbolTable::create_from_path(session, path, current_sym, false)
+        match SymbolTable::create_from_path(session, path, current_sym, false) {
+            Ok(sym) => Some(sym),
+            Err(CreateError::NothingOnDisk) => None,
+            Err(CreateError::Existing(key)) =>
+                unreachable!("callers pass a freshly created EntryPoint, so the chain should be empty; found {key:?}"),
+        }
     }
 
     /* Create a new main entry_point.
@@ -109,7 +111,7 @@ impl EntryPointMgr {
             None);
         session.sync_odoo.entry_point_mgr.borrow_mut().main_entry_point = Some(entry.clone());
 
-        EntryPointMgr::_create_dir_symbols_for_new_entry(session, &path, entry)
+        EntryPointMgr::create_dir_symbols_for_new_entry(session, &path, entry)
     }
 
     /* Create a new entry to builtins.
@@ -127,7 +129,7 @@ impl EntryPointMgr {
             None);
         session.sync_odoo.entry_point_mgr.borrow_mut().builtins_entry_points.push(entry.clone());
 
-        EntryPointMgr::_create_dir_symbols_for_new_entry(session, &path, entry)
+        EntryPointMgr::create_dir_symbols_for_new_entry(session, &path, entry)
     }
 
     /* Create a new entry to public.
@@ -158,7 +160,7 @@ impl EntryPointMgr {
             None);
         session.sync_odoo.entry_point_mgr.borrow_mut().public_entry_points.push(entry.clone());
 
-        EntryPointMgr::_create_dir_symbols_for_new_entry(session, &path, entry)
+        EntryPointMgr::create_dir_symbols_for_new_entry(session, &path, entry)
     }
 
     /* Create a new entry to addons.
@@ -195,11 +197,7 @@ impl EntryPointMgr {
             None,
             None);
         session.sync_odoo.entry_point_mgr.borrow_mut().custom_entry_points.push(entry.clone());
-        EntryPointMgr::_create_dir_symbols_for_new_entry(session, path, entry)
-    }
-
-    fn _create_dir_symbols_for_new_entry(session: &mut SessionInfo, path: &str, entry: Rc<RefCell<EntryPoint>>) -> Option<SymbolKey> {
-        EntryPointMgr::create_dir_symbols_from_path_to_entry(session, Path::new(path), entry)
+        EntryPointMgr::create_dir_symbols_for_new_entry(session, path, entry)
     }
 
     /// Create a new custom entry point for a given tree path and file path.

--- a/server/src/core/import_resolver.rs
+++ b/server/src/core/import_resolver.rs
@@ -2,6 +2,7 @@ use lsp_types::{Diagnostic, DiagnosticTag, Position, Range};
 use ruff_python_ast::name::Name;
 use tracing::error;
 use crate::core::build_scheduler::BuildScheduler;
+use crate::core::symbols::symbol_table_impl::CreateError;
 use crate::utils::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -98,7 +99,6 @@ pub fn resolve_from_stmt(
         source_path.as_str(),
         start_symbol,
         &file_tree,
-        None,
         level);
     let fallback_sym = Some(fallback_sym.unwrap_or(vec![source_root]));
     (from_symbol, fallback_sym, file_tree)
@@ -155,8 +155,8 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
             source_path.as_str(),
             from_symbols.clone(),
             &name_first_part,
-            None,
-        0);
+            0
+        );
         if next_symbol.is_none()
             && name_split.len() == 1
             && let Some(from_symbols) = from_symbols.as_ref() {
@@ -184,8 +184,8 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
                 "",
                 Some(next_symbol.as_ref().unwrap().clone()),
                 &name_middle_part,
-                None,
-            0);
+                0
+            );
         }
         if next_symbol.is_none() {
             if alias.asname.is_some() {
@@ -201,8 +201,8 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
                 "",
                 Some(next_symbol.as_ref().unwrap().clone()),
                 &name_last_name,
-                None,
-            0);
+                0
+            );
             if last_symbol.is_none() { //If not a file/package, try to look up in symbols in current file (second parameter of get_symbol)
                 //TODO what if multiple values?
                 let name_symbol_vec = next_symbol.as_ref().unwrap().iter().flat_map(|&s| session.st().get_symbol(s, (&[], &name_last_name), u32::MAX)).collect::<Vec<_>>();
@@ -232,19 +232,22 @@ pub fn resolve_import_stmt(session: &mut SessionInfo, source_file_symbol: Symbol
     result
 }
 
-pub fn create_module_from_name(session: &mut SessionInfo, odoo_addons: NamespaceKey, name: &str) -> Option<ModuleKey> {
+pub fn create_module_from_name(session: &mut SessionInfo, odoo_addons: NamespaceKey, name: &str) -> Result<ModuleKey, CreateError> {
     for path in session.st()[odoo_addons].paths() {
         let full_path = Path::new(&path).join(name);
         if !session.sync_odoo.is_dir_cs(&full_path.sanitize_cow()) {
             continue;
         }
-        let Some(module) = SymbolTable::create_module_from_path(session, &full_path, odoo_addons) else {
-            continue;
-        };
-        BuildScheduler::build_now(session, module, BuildSteps::ARCH);
-        return Some(module);
+        match SymbolTable::create_module_from_path(session, &full_path, odoo_addons) {
+            Err(CreateError::NothingOnDisk) => continue,
+            Err(e @ CreateError::Existing(_)) => return Err(e),
+            Ok(module) => {
+                BuildScheduler::build_now(session, module, BuildSteps::ARCH);
+                return Ok(module);
+            },
+        }
     }
-    None
+    Err(CreateError::NothingOnDisk)
 }
 
 fn resolve_packages(symbol_table: &SymbolTable, from_file: SymbolKey, level: u32, from_stmt: Option<&Identifier>) -> Option<Vec<OYarn>> {
@@ -280,7 +283,7 @@ fn resolve_packages(symbol_table: &SymbolTable, from_file: SymbolKey, level: u32
 }
 
 fn get_or_create_symbol(
-    session: &mut SessionInfo, for_entry: &Rc<RefCell<EntryPoint>>, from_path: &str, symbol: Option<Vec<SymbolKey>>, names: &[OYarn], asname: Option<&str>, level: u32
+    session: &mut SessionInfo, for_entry: &Rc<RefCell<EntryPoint>>, from_path: &str, symbol: Option<Vec<SymbolKey>>, names: &[OYarn], level: u32
 ) -> (Option<Vec<SymbolKey>>, Option<Vec<SymbolKey>>) {
     let mut syms = symbol.clone();
     let mut last_symbols = symbol;
@@ -298,7 +301,7 @@ fn get_or_create_symbol(
                     if let Ok(parent) = FileSystemSymbolParent::try_from(s) {
                         let current_batch_symbol = parent
                             .get_child(session.st(), branch)
-                            .or_else(|| resolve_new_symbol(session, parent, branch, asname).ok());
+                            .or_else(|| resolve_new_symbol(session, parent, branch).ok());
                         next_symbol.extend(current_batch_symbol);
                     }
                 }
@@ -345,7 +348,7 @@ fn get_or_create_symbol(
                             };
                             let next_symbol = parent
                                 .get_child(session.st(), branch)
-                                .or_else(|| resolve_new_symbol(session, parent, branch, asname).ok());
+                                .or_else(|| resolve_new_symbol(session, parent, branch).ok());
                             let Some(next_symbol) = next_symbol else {
                                 continue;
                             };
@@ -385,24 +388,25 @@ fn get_or_create_symbol(
     (syms, last_symbols)
 }
 
+/// Helper for get_or_create_symbol: symbol for `sym_name` has been checked as non-existant.
 /// Resolve a new symbol from disk, creating it if found, or just creating a COMPILED symbol if a parent is COMPILED
 /// parent : parent symbol where to search, either ROOT, NAMESPACE, PACKAGE, COMPILED or DISK_DIR
-fn resolve_new_symbol(session: &mut SessionInfo, parent: FileSystemSymbolParent, imported_name: &OYarn, asname: Option<&str>) -> Result<SymbolKey, &'static str> {
-    if imported_name.is_empty() {
+fn resolve_new_symbol(session: &mut SessionInfo, parent: FileSystemSymbolParent, name: &str) -> Result<SymbolKey, &'static str> {
+    if name.is_empty() {
         return Err("Empty name");
     }
-    let sym_name = asname.unwrap_or(imported_name.as_str());
     // COMPILED: we can only create a COMPILED symbol
     if matches!(parent, FileSystemSymbolParent::Compiled(_)) {
-        return Ok(session.st_mut().add_new_compiled(parent, sym_name, "").into());
+        let compiled = session.st_mut().add_new_compiled(parent, name, "").expect("sym_name should not collide");
+        return Ok(compiled.into());
     }
     // ROOT, NAMESPACE, PACKAGE or DISK_DIR: we can search on disk
     'paths: for path in session.st().paths(parent.into()) {
         let is_stub = session.sync_odoo.stubs_dirs.contains(&path);
         let mut full_path = PathBuf::from(path);
-        full_path.push(imported_name.as_str());
+        full_path.push(name);
         if is_stub {
-            full_path.push(imported_name.as_str());
+            full_path.push(name);
         }
         let full_path_str = full_path.sanitize_cow();
         let is_dir = session.sync_odoo.is_dir_cs(&full_path_str);
@@ -411,7 +415,7 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: FileSystemSymbolParent,
             session.sync_odoo.is_file_cs(&full_path.join("__init__.py").sanitize_cow())
             || session.sync_odoo.is_file_cs(&full_path.join("__init__.pyi").sanitize_cow())
         ) {
-            if let Some(symbol) = SymbolTable::create_from_path(session, &full_path, parent, false) {
+            if let Some(symbol) = create_new_from_path(session, &full_path, parent) {
                 if let Some(buildable) = symbol.as_buildable_symbol_key() {
                     BuildScheduler::build_now(session, buildable, BuildSteps::ARCH);
                 }
@@ -423,7 +427,7 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: FileSystemSymbolParent,
         for extension in ["py", "pyi"] {
             let path = full_path.with_extension(extension);
             if session.sync_odoo.is_file_cs(&path.sanitize_cow()) {
-                if let Some(symbol) = SymbolTable::create_from_path(session, &path, parent, false) {
+                if let Some(symbol) = create_new_from_path(session, &path, parent) {
                     if let Some(buildable) = symbol.as_buildable_symbol_key() {
                         BuildScheduler::build_now(session, buildable, BuildSteps::ARCH);
                     }
@@ -434,7 +438,7 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: FileSystemSymbolParent,
         }
         // Try as directory (namespace)
         if is_dir {
-            if let Some(symbol) = SymbolTable::create_from_path(session, &full_path, parent, false) {
+            if let Some(symbol) = create_new_from_path(session, &full_path, parent) {
                 if let Some(buildable) = symbol.as_buildable_symbol_key() {
                     BuildScheduler::build_now(session, buildable, BuildSteps::ARCH);
                 }
@@ -452,12 +456,24 @@ fn resolve_new_symbol(session: &mut SessionInfo, parent: FileSystemSymbolParent,
                 .collect::<Vec<_>>();
             for candidate in candidates {
                 if session.sync_odoo.is_file_cs(&candidate) {
-                    return Ok(session.st_mut().add_new_compiled(parent, sym_name, &candidate).into());
+                    return Ok(
+                        session.st_mut().add_new_compiled(parent, name, &candidate)
+                            .expect("sym name should not collide, as checked by the caller").into()
+                    );
                 }
             }
         }
     }
     Err("Symbol not found")
+}
+
+/// `create_from_path` for a name already checked as free: `Existing` is a bug, `None` = nothing on disk.
+fn create_new_from_path(session: &mut SessionInfo, path: &Path, parent: FileSystemSymbolParent) -> Option<SymbolKey> {
+    match SymbolTable::create_from_path(session, path, parent, false) {
+        Ok(symbol) => Some(symbol),
+        Err(CreateError::NothingOnDisk) => None,
+        Err(CreateError::Existing(_)) => panic!("child expected to be non-existant"),
+    }
 }
 
 /*
@@ -525,7 +541,6 @@ pub fn get_all_valid_names(session: &mut SessionInfo, source_file_symbol: Source
             &source_path,
             from_symbol.clone(),
             &import_parts[0..import_parts.len()-1].iter().map(|s| oyarn!("{}", *s)).collect::<Vec<_>>(),
-            None,
             level,
         );
         if next_symbol.is_none() {

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -11,6 +11,7 @@ use crate::core::symbols::ModuleSymbol;
 use crate::core::symbols::storage::{FileSystemSymbolParent, JsFileParent, SymbolTable};
 use crate::core::symbols::storage::metrics::{log_slotmap_capacities, log_symbol_counts, log_memory_usage};
 use crate::core::symbols::symbol_keys::{BuildableSymbolKey, FunctionKey, ModuleKey, SourceFileKey, SymbolKey, Wk, XmlId, XmlTemplateKey};
+use crate::core::symbols::symbol_table_impl::CreateError;
 use crate::core::tsserver_bridge::{TsServerBridge};
 use crate::features::tsserver_completion::TsCompletionResolveData;
 use crate::features::owl_virtual;
@@ -600,7 +601,7 @@ impl SyncOdoo {
         session.st_mut().set_is_external(odoo_sym, false);
         let odoo_sym: FileSystemSymbolParent = odoo_sym.try_into().expect("odoo root symbol to be a DiskDir");
         let odoo_odoo = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo"), odoo_sym, false);
-        let Some(odoo_odoo) = odoo_odoo else {
+        let Ok(odoo_odoo) = odoo_odoo else {
             panic!("Not able to find odoo with given path. Aborting...");
         };
         match odoo_odoo {
@@ -611,7 +612,7 @@ impl SyncOdoo {
             SymbolKey::Namespace(ns) => {
                 //starting from > 18.0, odoo is now a namespace. Start import project from odoo/__main__.py
                 let main_file = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo").join("__main__.py"),  ns.into(), false);
-                let Some(main_file) = main_file else {
+                let Ok(main_file) = main_file else {
                     panic!("Not able to find odoo/__main__.py. Aborting...");
                 };
                 let f = main_file.unwrap_file_key();
@@ -638,7 +639,7 @@ impl SyncOdoo {
             //if we are > 18.1, odoo.addons is not imported automatically anymore. Let's try to import it manually
             let parent = odoo_odoo.try_into().expect("Expected odoo to be a package or namespace");
             let addons_folder = SymbolTable::create_from_path(session, &config_odoo_path.join("odoo").join("addons"), parent, false);
-            if let Some(SymbolKey::Namespace(addons_ns)) = addons_folder {
+            if let Ok(SymbolKey::Namespace(addons_ns)) = addons_folder {
                 addons_ns
             } else {
                 session.log_message(MessageType::WARNING, "Not able to find odoo/addons. Please check your configuration. Switching to non-odoo mode...".to_string());
@@ -687,7 +688,7 @@ impl SyncOdoo {
                 for item in Path::new(addon_path).read_dir().expect("Unable to browse and odoo addon directory") {
                     if let Ok(item) = item
                         && item.file_type().unwrap().is_dir() && !session.sync_odoo.modules.contains_key(item.file_name().to_str().unwrap())
-                            && let Some(module_symbol) = SymbolTable::create_module_from_path(session, &item.path(), addons_symbol) {
+                            && let Ok(module_symbol) = SymbolTable::create_module_from_path(session, &item.path(), addons_symbol) {
                                 modules.push(module_symbol);
                             }
                 }
@@ -2057,9 +2058,16 @@ impl Odoo {
             let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
             for entry in ep_mgr.borrow().addons_entry_points.iter() {
                 if entry.borrow().path == parent_path.sanitize_cow() {
-                    if let SymbolKey::Namespace(addons) = entry.borrow().get_symbol(session.st()).unwrap()
-                    && let Some(module_symbol) = SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
-                        BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
+                    if let SymbolKey::Namespace(addons) = entry.borrow().get_symbol(session.st()).unwrap() {
+                        match SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
+                            Ok(module_symbol) => {
+                                BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
+                            },
+                            Err(CreateError::NothingOnDisk) => {}, // not a module dir
+                            Err(CreateError::Existing(_symbol)) =>  {
+                                warn!("cannot create module at {}: name already taken", path_for_tree.sanitize_cow());
+                            }
+                        }
                     }
                     break;
                 }
@@ -2070,9 +2078,16 @@ impl Odoo {
                 );
                 match addons_symbol {
                     Some(addons_symbol) if !addons_symbol.is_empty() => {
-                        if let SymbolKey::Namespace(addons) = addons_symbol[0]
-                        && let Some(module_symbol) = SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
-                        BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
+                        if let SymbolKey::Namespace(addons) = addons_symbol[0] {
+                            match SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
+                                Ok(module_symbol) => {
+                                    BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
+                                },
+                                Err(CreateError::NothingOnDisk) => {},
+                                Err(CreateError::Existing(_symbol)) => {
+                                    warn!("cannot create module at {}: name already taken", path_for_tree.sanitize_cow());
+                                },
+                            }
                         }
                     }
                     _ => {

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -199,7 +199,8 @@ impl ModuleSymbol {
                 continue;
             }
             let file_name = file_path.file_name().unwrap().to_str().unwrap().to_string();
-            let js_key = session.st_mut().add_new_js_file(module.into(), &file_name, file_path_str.as_ref());
+            let js_key = session.st_mut().add_new_js_file(module.into(), &file_name, file_path_str.as_ref())
+                .expect("path should not already exist, as checked above");
             session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, file_path_str.as_ref(), None, None, false); //create ast if not in cache
             // as the update_file_info built the arch, let's add the file to the validation queue.
             BuildScheduler::queue(session, js_key);

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -51,12 +51,14 @@ impl ModuleSymbol {
             let (_, file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, &path_string, None, None, false); //create ast if not in cache
             let mut file_info = file_info.borrow_mut();
             if file_name.ends_with(".xml") {
-                let xml_sym = session.st_mut().add_new_xml_file(symbol_key, &file_name, &path_string);
+                let xml_sym = session.st_mut().add_new_xml_file(symbol_key, &file_name, &path_string)
+                    .expect("path should not already exist, as checked above");
                 Self::on_data_file_load(session.st(), xml_sym.into());
                 session.st_mut().add_dependency(symbol_key.into(), xml_sym.into(), BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
                 ModuleSymbol::load_xml_arch(session, xml_sym, &mut file_info, false);
             } else if file_name.ends_with(".csv") {
-                let csv_sym = session.st_mut().add_new_csv_file(symbol_key, &file_name, &path_string);
+                let csv_sym = session.st_mut().add_new_csv_file(symbol_key, &file_name, &path_string)
+                    .expect("path should not already exist, as checked above");
                 Self::on_data_file_load(session.st(), csv_sym.into());
                 session.st_mut().add_dependency(symbol_key.into(), csv_sym.into(), BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
                 let Some(data) = file_info.file_info_ast.borrow().text_document.as_ref().map(|td| td.contents().to_string()) else {
@@ -156,7 +158,8 @@ impl ModuleSymbol {
             if session.st()[module].data_file_symbols().contains_key(file_path_str.as_ref()) { //already imported. can happen if the file is in multiple bundle or caught by multiple regex
                 continue;
             }
-            let xml_sym = session.st_mut().add_new_xml_file(module, &file_name, file_path_str.as_ref());
+            let xml_sym = session.st_mut().add_new_xml_file(module, &file_name, file_path_str.as_ref())
+                .expect("path should not already exist, as checked above");
             Self::on_data_file_load(session.st(), xml_sym.into());
             session.st_mut().add_dependency(module.into(), xml_sym.into(), BuildSteps::ARCH_EVAL, BuildSteps::ARCH);
             let (_, file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, file_path_str.as_ref(), None, None, false); //create ast if not in cache

--- a/server/src/core/symbols/module_utils.rs
+++ b/server/src/core/symbols/module_utils.rs
@@ -1,8 +1,11 @@
 use std::path::Path;
 
 use lsp_types::Diagnostic;
+use ruff_text_size::TextRange;
+use tracing::warn;
 
 use crate::{Sy, constants::{BuildSteps, DiagnosticSource, OYarn}, core::{build_scheduler::BuildScheduler, diagnostics::{DiagnosticCode, create_diagnostic}, file_mgr::FileMgr, import_resolver::create_module_from_name, symbols::{ModuleSymbol, SymbolTable, symbol_keys::{ModuleKey, NamespaceKey, SymbolKey}}}, threads::SessionInfo, utils::PathSanitizer};
+use crate::core::symbols::symbol_table_impl::CreateError;
 
 
 
@@ -33,37 +36,52 @@ impl ModuleSymbol {
         let mut diagnostics: Vec<Diagnostic> = vec![];
         let mut loaded: Vec<OYarn> = vec![];
         let dependencies = module.depends.clone();
-        for (depend, range) in dependencies.iter() {
-            if let Some(dependency) = session.sync_odoo.modules.get(depend).and_then(|m| m.upgrade(session.st())) {
-                // Dependency already in modules
-                BuildScheduler::build_now(session, dependency, BuildSteps::ARCH);
-                if session.st()[dependency].all_depends.contains(&name)
-                    && let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS04012, &[depend]) {
-                        diagnostics.push(Diagnostic {
-                            range: FileMgr::textRange_to_temporary_Range(range),
-                            ..diagnostic_base.clone()
-                        });
+        for (depend, range) in dependencies {
+            match session.st()[odoo_addons].get_child(&depend) {
+                Some(SymbolKey::Module(dependency)) => {
+                    // Dependency already in modules
+                    BuildScheduler::build_now(session, dependency, BuildSteps::ARCH);
+                    if session.st()[dependency].all_depends.contains(&name)
+                        && let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS04012, &[&depend]) {
+                            diagnostics.push(Diagnostic {
+                                range: FileMgr::textRange_to_temporary_Range(&range),
+                                ..diagnostic_base.clone()
+                            });
+                        }
+                    ModuleSymbol::extend_dependencies(session.st_mut(), symbol_key, dependency);
+                },
+                Some(other) => {
+                    // odoo addons has a child symbol with the same name but not a module
+                    warn!("dependency '{depend}' of '{name}' is {:?} at {:?}", other.typ(), session.st().paths(other));
+                    Self::report_missing_dependency(session, &mut diagnostics, symbol_key, &name, &depend, &range);
+                },
+                None => match create_module_from_name(session, odoo_addons, &depend) {
+                    Ok(dependency) => {
+                        // Dependency just added to modules
+                        loaded.push(depend);
+                        ModuleSymbol::extend_dependencies(session.st_mut(), symbol_key, dependency);
+                    },
+                    Err(CreateError::Existing(_)) => unreachable!("name checked vacant on odoo_addons above"),
+                    Err(CreateError::NothingOnDisk) => {
+                        // Dependency not found nor created
+                        Self::report_missing_dependency(session, &mut diagnostics, symbol_key, &name, &depend, &range);
                     }
-                ModuleSymbol::extend_dependencies(session.st_mut(), symbol_key, dependency);
-            } else if let Some(dependency) = create_module_from_name(session, odoo_addons, depend) {
-                // Dependency just added to modules
-                loaded.push(depend.clone());
-                ModuleSymbol::extend_dependencies(session.st_mut(), symbol_key, dependency);
-            } else {
-                // Dependency not found nor created
-                let entry = session.st().get_entry(symbol_key);
-                entry.borrow_mut().not_found_symbols.insert(symbol_key.into());
-                session.st_mut()[symbol_key].not_found_paths.push((BuildSteps::ARCH, vec![Sy!("odoo"), Sy!("addons"), depend.clone()]));
-                if let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS04010, &[&name, depend]) {
-                    diagnostics.push(Diagnostic {
-                        range: FileMgr::textRange_to_temporary_Range(range),
-                        ..diagnostic_base.clone()
-                    });
                 }
             }
-
         }
         (diagnostics, loaded)
+    }
+
+    fn report_missing_dependency(session: &mut SessionInfo, diagnostics: &mut Vec<Diagnostic>, module: ModuleKey, name: &OYarn, depend: &OYarn, range: &TextRange) {
+        let entry = session.st().get_entry(module);
+        entry.borrow_mut().not_found_symbols.insert(module.into());
+        session.st_mut()[module].not_found_paths.push((BuildSteps::ARCH, vec![Sy!("odoo"), Sy!("addons"), depend.clone()]));
+        if let Some(diagnostic_base) = create_diagnostic(session, DiagnosticCode::OLS04010, &[name, depend]) {
+            diagnostics.push(Diagnostic {
+                range: FileMgr::textRange_to_temporary_Range(range),
+                ..diagnostic_base
+            });
+        }
     }
 
     fn extend_dependencies(symbol_table: &mut SymbolTable, symbol_key: ModuleKey, dependency: ModuleKey) {
@@ -81,7 +99,7 @@ impl ModuleSymbol {
         let tests_path = Path::new(&root_path).join("tests");
         if tests_path.exists() && !session.st()[module_key].module_symbols().contains_key("tests") {
             let symbol = SymbolTable::create_from_path(session, &tests_path, module_key.into(), false);
-            if let Some(sym) = symbol && !matches!(sym, SymbolKey::Namespace(_)) {
+            if let Ok(sym) = symbol && !matches!(sym, SymbolKey::Namespace(_)) {
                 BuildScheduler::queue(session, sym.unwrap_buildable_key());
             }
         }

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -32,6 +32,9 @@ use crate::{
 use ruff_text_size::{TextRange, TextSize};
 use std::{cell::RefCell, ops::Range, path::Path, rc::Rc};
 
+#[derive(Debug)]
+pub struct NameTakenError(pub SymbolKey);
+
 impl SymbolTable {
 
     // ===== Symbol creation methods ======
@@ -41,55 +44,61 @@ impl SymbolTable {
         self.roots.insert(root_symbol)
     }
     // Create a sub-symbol that is representing a file
-    pub fn add_new_file(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> FileKey {
+    pub fn add_new_file(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> Result<FileKey, NameTakenError> {
+        self.check_fs_symbol_name_vacant(parent, name)?;
         let is_external = self.is_external(parent.into());
         let file_symbol = FileSymbol::new(name, path, parent, is_external);
         let file_key = self.files.insert(file_symbol);
-        self.add_to_parent_module_symbols(parent, file_key.into(), name, path);
-        file_key
+        self.add_to_parent_fs_symbols(parent, file_key.into(), name, path);
+        Ok(file_key)
     }
 
     //Create a sub-symbol that is representing a package
-    pub fn add_new_python_package(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str, i_ext: &'static str) -> PythonPackageKey {
+    pub fn add_new_python_package(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str, i_ext: &'static str) -> Result<PythonPackageKey, NameTakenError> {
+        self.check_fs_symbol_name_vacant(parent, name)?;
         let is_external = self.is_external(parent.into());
         let package_symbol = PythonPackageSymbol::new(name, path, parent, is_external, i_ext);
         let package_key = self.python_packages.insert(package_symbol);
-        self.add_to_parent_module_symbols(parent, package_key.into(), name, path);
-        package_key
+        self.add_to_parent_fs_symbols(parent, package_key.into(), name, path);
+        Ok(package_key)
     }
 
-    pub fn add_new_namespace(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> NamespaceKey {
+    pub fn add_new_namespace(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> Result<NamespaceKey, NameTakenError> {
+        self.check_fs_symbol_name_vacant(parent, name)?;
         let is_external = self.is_external(parent.into());
         let namespace_symbol = NamespaceSymbol::new(name, vec![path.to_string()], parent, is_external);
         let namespace_key = self.namespaces.insert(namespace_symbol);
-        self.add_to_parent_module_symbols(parent, namespace_key.into(), name, path);
-        namespace_key
+        self.add_to_parent_fs_symbols(parent, namespace_key.into(), name, path);
+        Ok(namespace_key)
     }
 
-    pub fn add_new_disk_dir(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> DiskDirKey {
+    pub fn add_new_disk_dir(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> Result<DiskDirKey, NameTakenError> {
+        self.check_fs_symbol_name_vacant(parent, name)?;
         let is_external = self.is_external(parent.into());
         let disk_dir_symbol = DiskDirSymbol::new(name, path, parent, is_external);
         let disk_dir_key = self.disk_dirs.insert(disk_dir_symbol);
-        self.add_to_parent_module_symbols(parent, disk_dir_key.into(), name, path);
-        disk_dir_key
+        self.add_to_parent_fs_symbols(parent, disk_dir_key.into(), name, path);
+        Ok(disk_dir_key)
     }
 
-    pub fn add_new_compiled(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> CompiledKey {
+    pub fn add_new_compiled(&mut self, parent: FileSystemSymbolParent, name: &str, path: &str) -> Result<CompiledKey, NameTakenError> {
+        self.check_fs_symbol_name_vacant(parent, name)?;
         let is_external = self.is_external(parent.into());
         let compiled_symbol = CompiledSymbol::new(name, path, parent, is_external);
         let compiled_key = self.compiled.insert(compiled_symbol);
-        self.add_to_parent_module_symbols(parent, compiled_key.into(), name, path);
-        compiled_key
+        self.add_to_parent_fs_symbols(parent, compiled_key.into(), name, path);
+        Ok(compiled_key)
     }
 
-    pub fn add_new_module_package(session: &mut SessionInfo, parent: NamespaceKey, name: &str, path: &Path) -> ModuleKey {
+    pub fn add_new_module_package(session: &mut SessionInfo, parent: NamespaceKey, name: &str, path: &Path) -> Result<ModuleKey, NameTakenError> {
+        session.st().check_fs_symbol_name_vacant(parent.into(), name)?;
         let is_external = session.sync_odoo.symbol_table.is_external(parent.into());
         let module = ModuleSymbol::new(name, path, parent, is_external);
         let path_str = module.path.clone();
         let module_key = session.st_mut().modules.insert(module);
+        session.st_mut().add_to_parent_fs_symbols(parent.into(), module_key.into(), name, &path_str);
         ModuleSymbol::load_manifest_content(session, module_key);
-        session.st_mut().add_to_parent_module_symbols(parent.into(), module_key.into(), name, &path_str);
-        module_key
+        Ok(module_key)
     }
 
     pub fn add_new_variable(&mut self, parent: impl Into<SymbolKey>, name: &str, range: TextRange) -> VariableKey {
@@ -237,17 +246,28 @@ impl SymbolTable {
             self.remove(replaced.into());
         }
     }
-    
-    fn add_to_parent_module_symbols(&mut self, parent: FileSystemSymbolParent, child: SymbolKey, name: &str, path: &str) {
+
+    fn panic_on_replaced_key(replaced: Option<impl Into<SymbolKey>>) {
+        if replaced.is_some() { panic!("replaced key on insertion") }
+    }
+
+    fn check_fs_symbol_name_vacant(&self, parent: FileSystemSymbolParent, name: &str) -> Result<(), NameTakenError> {
+        match parent.get_child(self, name) {
+            Some(existing) => Err(NameTakenError(existing)),
+            None => Ok(())
+        }
+    }
+
+    fn add_to_parent_fs_symbols(&mut self, parent: FileSystemSymbolParent, child: SymbolKey, name: &str, path: &str) {
         // A compiled can only be a parent to another compiled
         if let FileSystemSymbolParent::Compiled(_) = parent && !matches!(child, SymbolKey::Compiled(_)) {
             panic!("Impossible to add a {} to a CompiledSymbol parent", child.typ());
         }
         let replaced_key = parent.add_fs_symbol(self, name, child, path);
-        self.remove_replaced(replaced_key);
+        Self::panic_on_replaced_key(replaced_key);
     }
 
-    fn remove_from_parent_module_symbols(&mut self, parent: FileSystemSymbolParent, name: &str) {
+    fn remove_from_parent_fs_symbols(&mut self, parent: FileSystemSymbolParent, name: &str) {
         parent.remove_fs_symbol(self, name);
     }
 
@@ -359,19 +379,19 @@ impl SymbolTable {
                 let file_symbol = &self[f];
                 let name = file_symbol.name.to_string();
                 let parent = file_symbol.parent();
-                self.remove_from_parent_module_symbols(parent, &name);
+                self.remove_from_parent_fs_symbols(parent, &name);
             },
             SourceFileKey::Module(m) => {
                 let module_symbol = &self[m];
                 let name = module_symbol.name.to_string();
                 let parent = module_symbol.parent();
-                self.remove_from_parent_module_symbols(parent.into(), &name);
+                self.remove_from_parent_fs_symbols(parent.into(), &name);
             },
             SourceFileKey::PythonPackage(p) => {
                 let package_symbol = &self[p];
                 let name = package_symbol.name.to_string();
                 let parent = package_symbol.parent();
-                self.remove_from_parent_module_symbols(parent, &name);
+                self.remove_from_parent_fs_symbols(parent, &name);
             },
             SourceFileKey::XmlFile(x) => {
                 let xml_symbol = &self[x];
@@ -412,7 +432,7 @@ mod tests {
         let is_external = st.is_external(parent.into());
         let module = ModuleSymbol::new(name, Path::new(path), parent, is_external);
         let module_key = st.modules.insert(module);
-        st.add_to_parent_module_symbols(parent.into(), module_key.into(), name, path);
+        st.add_to_parent_fs_symbols(parent.into(), module_key.into(), name, path);
         module_key
     }
 
@@ -431,8 +451,8 @@ mod tests {
             let mut st = SymbolTable::new();
             let entry = EntryPoint::new(&mut st, "/root".to_string(), vec![], EntryPointType::MAIN, None, None);
             let root = entry.borrow().root;
-            let namespace = st.add_new_namespace(root.into(), "ns", "/root/ns");
-            let disk_dir = st.add_new_disk_dir(root.into(), "dd", "/root/dd");
+            let namespace = st.add_new_namespace(root.into(), "ns", "/root/ns").unwrap();
+            let disk_dir = st.add_new_disk_dir(root.into(), "dd", "/root/dd").unwrap();
             let module = add_module(&mut st, namespace, "mod", "/root/ns/mod");
             Self { st, root, namespace, disk_dir, module }
         }
@@ -443,19 +463,19 @@ mod tests {
     }
 
     #[test]
-    fn source_files_round_trip_through_their_parent() {
+    fn source_files_round_trip_through_their_parent() -> Result<(), NameTakenError> {
         let mut f = Fixture::new();
         // One child per `SourceFileKey` variant. `File` and `JsFile` appear twice, to cover both
         // of their parent kinds; the namespace is the only hand-written `FileSystemItemHolder`.
-        let in_root = f.st.add_new_file(f.root.into(), "in_root", "/root/in_root.py");
-        let in_namespace = f.st.add_new_file(f.namespace.into(), "in_namespace", "/root/ns/in_namespace.py");
-        let package = f.st.add_new_python_package(f.root.into(), "a_package", "/root/a_package", "");
+        let in_root = f.st.add_new_file(f.root.into(), "in_root", "/root/in_root.py")?;
+        let in_namespace = f.st.add_new_file(f.namespace.into(), "in_namespace", "/root/ns/in_namespace.py")?;
+        let package = f.st.add_new_python_package(f.root.into(), "a_package", "/root/a_package", "")?;
         let module = add_module(&mut f.st, f.namespace, "another_module", "/root/ns/another_module");
         let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
         let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
         let js_in_module = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
         let js_in_disk_dir = f.st.add_new_js_file(JsFileParent::DiskDir(f.disk_dir), "lib.js", "/root/dd/lib.js");
-        let sibling = f.st.add_new_file(f.module.into(), "sibling", "/root/ns/mod/sibling.py");
+        let sibling = f.st.add_new_file(f.module.into(), "sibling", "/root/ns/mod/sibling.py")?;
 
         let cases: Vec<(SymbolKey, SourceFileKey)> = vec![
             (f.root.into(), in_root.into()),
@@ -477,12 +497,13 @@ mod tests {
         }
 
         assert!(f.holds(f.module.into(), sibling), "an unlink evicted an unrelated sibling");
+        Ok(())
     }
 
     #[test]
     fn file_content_round_trips_and_dies_with_its_file() {
         let mut f = Fixture::new();
-        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py");
+        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py").unwrap();
         let class = f.st.add_new_class(file.into(), "AClass", range_at(0), TextSize::new(0));
         let method = f.st.add_new_function(class.into(), "method", range_at(10), TextSize::new(10));
         let local = f.st.add_new_variable(method, "local", range_at(20));
@@ -536,9 +557,9 @@ mod tests {
     /// child-like relation `children()` does not cover. Removing the module has to leave
     /// nothing behind.
     #[test]
-    fn unloading_a_module_leaves_no_orphan() {
+    fn unloading_a_module_leaves_no_orphan() -> Result<(), NameTakenError> {
         let mut f = Fixture::new();
-        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py");
+        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py")?;
         let class = f.st.add_new_class(file.into(), "AClass", range_at(0), TextSize::new(0));
         let method = f.st.add_new_function(class.into(), "method", range_at(10), TextSize::new(10));
         f.st.add_new_variable(method, "local", range_at(20));
@@ -553,7 +574,7 @@ mod tests {
 
         // injected into a file outside the module, but owned by one of its files: it dies with
         // the owner, through `ext_symbols` rather than through any holder.
-        let host = f.st.add_new_file(f.root.into(), "host", "/root/host.py");
+        let host = f.st.add_new_file(f.root.into(), "host", "/root/host.py")?;
         let injected = f.st.add_new_ext_symbol(host.into(), "injected", range_at(30), file.into());
 
         f.st.assert_no_orphans();
@@ -565,6 +586,7 @@ mod tests {
         assert!(!f.st.is_key_valid(injected), "the ext symbol outlived its owner");
         assert!(f.st.is_key_valid(host), "removing the module took the injection target down");
         f.st.assert_no_orphans();
+        Ok(())
     }
 
     /// `ModuleSymbol` implements four holder traits, which is why `children` is a sequence of
@@ -572,7 +594,7 @@ mod tests {
     #[test]
     fn module_children_join_every_family_it_holds() {
         let mut f = Fixture::new();
-        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py");
+        let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py").unwrap();
         let constant = f.st.add_new_variable(f.module, "MODULE_CONSTANT", range_at(0));
         let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
         let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -175,12 +175,21 @@ impl SymbolTable {
         xml_delete_key
     }
 
-    pub fn add_new_xml_field(&mut self, parent: XmlFieldParent, field_name: OYarn, range: TextRange, text: Option<String>, text_range: Option<TextRange>, ref_key: Option<(String, TextRange)>) -> XmlFieldKey {
+    pub fn add_new_xml_field(
+        &mut self,
+        parent: XmlFieldParent,
+        field_name: &str,
+        range: TextRange,
+        text: Option<String>,
+        text_range: Option<TextRange>,
+        ref_key: Option<(String, TextRange)>,
+    ) -> Result<XmlFieldKey, NameTakenError> {
+        self.check_xml_field_name_vacant(parent, field_name)?;
         let is_external = self.is_external(parent.into());
-        let xml_field_sym = XmlFieldSymbol::new(field_name.clone(), range, text, text_range, ref_key, parent, is_external);
+        let xml_field_sym = XmlFieldSymbol::new(field_name, range, text, text_range, ref_key, parent, is_external);
         let xml_field_key = self.xml_fields.insert(xml_field_sym);
-        self.add_field_to_xml_record(parent, xml_field_key, field_name.as_str());
-        xml_field_key
+        self.add_field_to_xml_record(parent, xml_field_key, field_name);
+        Ok(xml_field_key)
     }
 
     pub fn add_new_xml_template(&mut self, parent: XmlFileKey, name: Option<OYarn>, t_name: Option<OYarn>, range: TextRange, is_web: bool) -> XmlTemplateKey {
@@ -241,15 +250,6 @@ impl SymbolTable {
     }
 
     // ====== Helpers for symbol creation ======
-    /// Evict a child displaced by a map insert with a colliding name/path. This
-    /// prevents a leak, but `unload` side effects are NOT run. Callers should
-    /// properly unload the symbol first.
-    fn remove_replaced(&mut self, replaced: Option<impl Into<SymbolKey>>) {
-        if let Some(replaced) = replaced {
-            self.remove(replaced.into());
-        }
-    }
-
     fn panic_on_replaced_key(replaced: Option<impl Into<SymbolKey>>) {
         if replaced.is_some() { panic!("replaced key on insertion") }
     }
@@ -275,6 +275,13 @@ impl SymbolTable {
         }
     }
 
+    fn check_xml_field_name_vacant(&self, parent: XmlFieldParent, name: &str) -> Result<(), NameTakenError> {
+        match parent.fields(self).get(name).copied() {
+            Some(existing) => Err(NameTakenError(existing.into())),
+            None => Ok(())
+        }
+    }
+
     fn add_to_parent_fs_symbols(&mut self, parent: FileSystemSymbolParent, child: SymbolKey, name: &str, path: &str) {
         // A compiled can only be a parent to another compiled
         if let FileSystemSymbolParent::Compiled(_) = parent && !matches!(child, SymbolKey::Compiled(_)) {
@@ -290,7 +297,7 @@ impl SymbolTable {
 
     fn add_field_to_xml_record(&mut self, parent: XmlFieldParent, field: XmlFieldKey, name: &str) {
         let replaced_key = parent.fields_mut(self).insert(oyarn!("{}", name), field);
-        self.remove_replaced(replaced_key);
+        Self::panic_on_replaced_key(replaced_key);
     }
 
     fn add_to_module_data_symbols(&mut self, parent: ModuleKey, path: &str, data_file: SourceFileKey) {
@@ -550,7 +557,7 @@ mod tests {
 
         let record = f.st.add_new_xml_record(XmlDataParent::XmlFile(xml_file), (oyarn!("res.partner"), 0..1), Some(oyarn!("a_partner")), range_at(0));
         let menuitem = f.st.add_new_xml_menuitem(xml_file, Some(oyarn!("a_menu")), range_at(10));
-        let field = f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), oyarn!("name"), range_at(1), None, None, None);
+        let field = f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), "name", range_at(1), None, None, None).unwrap();
         let csv_record = f.st.add_new_xml_record(XmlDataParent::CsvFile(csv_file), (oyarn!("res.partner"), 0..1), Some(oyarn!("a_csv_partner")), range_at(0));
 
         assert!(f.holds(xml_file.into(), record));
@@ -584,7 +591,7 @@ mod tests {
 
         let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml")?;
         let record = f.st.add_new_xml_record(XmlDataParent::XmlFile(xml_file), (oyarn!("res.partner"), 0..1), None, range_at(0));
-        f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), oyarn!("name"), range_at(1), None, None, None);
+        _ = f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), "name", range_at(1), None, None, None);
         let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv")?;
         f.st.add_new_xml_record(XmlDataParent::CsvFile(csv_file), (oyarn!("res.partner"), 0..1), None, range_at(0));
         _ = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -201,13 +201,14 @@ impl SymbolTable {
         Ok(csv_file_key)
     }
 
-    pub fn add_new_js_file(&mut self, parent: JsFileParent, name: &str, path: &str) -> JsFileKey {
+    pub fn add_new_js_file(&mut self, parent: JsFileParent, name: &str, path: &str) -> Result<JsFileKey, NameTakenError> {
+        self.check_js_symbol_path_vacant(parent, name)?;
         let mut js_file_symbol = JsFileSymbol::new(name, path, parent, self.is_external(parent.into()));
         js_file_symbol.set_in_workspace(self.in_workspace(parent.into()));
         let js_file_key = self.js_files.insert(js_file_symbol);
         self.add_to_parent_js_symbols(parent, path, js_file_key);
         ModuleSymbol::on_js_file_load(self, js_file_key);
-        js_file_key
+        Ok(js_file_key)
     }
 
     pub fn add_new_ext_symbol(
@@ -266,6 +267,13 @@ impl SymbolTable {
             None => Ok(())
         }
     }
+ 
+    fn check_js_symbol_path_vacant(&self, parent: JsFileParent, name: &str) -> Result<(), NameTakenError> {
+        match parent.js_symbols(self).get(name).copied() {
+            Some(existing) => Err(NameTakenError(existing.into())),
+            None => Ok(())
+        }
+    }
 
     fn add_to_parent_fs_symbols(&mut self, parent: FileSystemSymbolParent, child: SymbolKey, name: &str, path: &str) {
         // A compiled can only be a parent to another compiled
@@ -296,7 +304,7 @@ impl SymbolTable {
 
     fn add_to_parent_js_symbols(&mut self, parent: JsFileParent, path: &str, js_key: JsFileKey) {
         let replaced_key = parent.js_symbols_mut(self).insert(path.to_string(), js_key);
-        self.remove_replaced(replaced_key);
+        Self::panic_on_replaced_key(replaced_key);
     }
 
     fn remove_from_parent_js_symbols(&mut self, parent: JsFileParent, path: &str) {
@@ -482,8 +490,8 @@ mod tests {
         let module = add_module(&mut f.st, f.namespace, "another_module", "/root/ns/another_module");
         let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml")?;
         let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv")?;
-        let js_in_module = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
-        let js_in_disk_dir = f.st.add_new_js_file(JsFileParent::DiskDir(f.disk_dir), "lib.js", "/root/dd/lib.js");
+        let js_in_module = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js")?;
+        let js_in_disk_dir = f.st.add_new_js_file(JsFileParent::DiskDir(f.disk_dir), "lib.js", "/root/dd/lib.js")?;
         let sibling = f.st.add_new_file(f.module.into(), "sibling", "/root/ns/mod/sibling.py")?;
 
         let cases: Vec<(SymbolKey, SourceFileKey)> = vec![
@@ -579,7 +587,7 @@ mod tests {
         f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), oyarn!("name"), range_at(1), None, None, None);
         let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv")?;
         f.st.add_new_xml_record(XmlDataParent::CsvFile(csv_file), (oyarn!("res.partner"), 0..1), None, range_at(0));
-        f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
+        _ = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
 
         // injected into a file outside the module, but owned by one of its files: it dies with
         // the owner, through `ext_symbols` rather than through any holder.
@@ -607,7 +615,7 @@ mod tests {
         let constant = f.st.add_new_variable(f.module, "MODULE_CONSTANT", range_at(0));
         let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml").unwrap();
         let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv").unwrap();
-        let js_file = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
+        let js_file = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js").unwrap();
 
         let children = f.st.children(f.module.into());
         for expected in [SymbolKey::from(file), constant.into(), xml_file.into(), csv_file.into(), js_file.into()] {

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -128,13 +128,14 @@ impl SymbolTable {
         class_key
     }
 
-    pub fn add_new_xml_file(&mut self, parent: ModuleKey, name: &str, path: &str) -> XmlFileKey {
+    pub fn add_new_xml_file(&mut self, parent: ModuleKey, name: &str, path: &str) -> Result<XmlFileKey, NameTakenError> {
+        self.check_data_symbol_path_vacant(parent, path)?;
         let parent_symbol = &self.modules[parent];
         let mut xml_file_symbol = XmlFileSymbol::new(name, path, parent, parent_symbol.is_external);
         xml_file_symbol.set_in_workspace(parent_symbol.in_workspace);
         let xml_file_key = self.xml_files.insert(xml_file_symbol);
         self.add_to_module_data_symbols(parent, path, xml_file_key.into());
-        xml_file_key
+        Ok(xml_file_key)
     }
 
     pub fn add_new_xml_record(&mut self, parent: XmlDataParent, model: (OYarn, Range<usize>) , xml_id: Option<OYarn>, range: TextRange) -> XmlRecordKey {
@@ -190,13 +191,14 @@ impl SymbolTable {
         xml_template_key
     }
 
-    pub fn add_new_csv_file(&mut self, parent: ModuleKey, name: &str, path: &str) -> CsvFileKey {
+    pub fn add_new_csv_file(&mut self, parent: ModuleKey, name: &str, path: &str) -> Result<CsvFileKey, NameTakenError> {
+        self.check_data_symbol_path_vacant(parent, path)?;
         let parent_symbol = &self.modules[parent];
         let mut csv_file_symbol = CsvFileSymbol::new(name, path, parent, parent_symbol.is_external);
         csv_file_symbol.set_in_workspace(parent_symbol.in_workspace);
         let csv_file_key = self.csv_files.insert(csv_file_symbol);
         self.add_to_module_data_symbols(parent, path, csv_file_key.into());
-        csv_file_key
+        Ok(csv_file_key)
     }
 
     pub fn add_new_js_file(&mut self, parent: JsFileParent, name: &str, path: &str) -> JsFileKey {
@@ -258,6 +260,13 @@ impl SymbolTable {
         }
     }
 
+    fn check_data_symbol_path_vacant(&self, parent: ModuleKey, path: &str) -> Result<(), NameTakenError> {
+        match self[parent].data_file_symbols.get(path).copied() {
+            Some(existing) => Err(NameTakenError(existing.into())),
+            None => Ok(())
+        }
+    }
+
     fn add_to_parent_fs_symbols(&mut self, parent: FileSystemSymbolParent, child: SymbolKey, name: &str, path: &str) {
         // A compiled can only be a parent to another compiled
         if let FileSystemSymbolParent::Compiled(_) = parent && !matches!(child, SymbolKey::Compiled(_)) {
@@ -278,7 +287,7 @@ impl SymbolTable {
 
     fn add_to_module_data_symbols(&mut self, parent: ModuleKey, path: &str, data_file: SourceFileKey) {
         let replaced_key = self.modules[parent].data_file_symbols.insert(path.to_string(), data_file);
-        self.remove_replaced(replaced_key);
+        Self::panic_on_replaced_key(replaced_key);
     }
     
     fn remove_from_module_data_symbols(&mut self, parent: ModuleKey, path: &str) {
@@ -471,8 +480,8 @@ mod tests {
         let in_namespace = f.st.add_new_file(f.namespace.into(), "in_namespace", "/root/ns/in_namespace.py")?;
         let package = f.st.add_new_python_package(f.root.into(), "a_package", "/root/a_package", "")?;
         let module = add_module(&mut f.st, f.namespace, "another_module", "/root/ns/another_module");
-        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
-        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml")?;
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv")?;
         let js_in_module = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
         let js_in_disk_dir = f.st.add_new_js_file(JsFileParent::DiskDir(f.disk_dir), "lib.js", "/root/dd/lib.js");
         let sibling = f.st.add_new_file(f.module.into(), "sibling", "/root/ns/mod/sibling.py")?;
@@ -528,8 +537,8 @@ mod tests {
     #[test]
     fn xml_data_round_trips_and_dies_with_its_file() {
         let mut f = Fixture::new();
-        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
-        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml").unwrap();
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv").unwrap();
 
         let record = f.st.add_new_xml_record(XmlDataParent::XmlFile(xml_file), (oyarn!("res.partner"), 0..1), Some(oyarn!("a_partner")), range_at(0));
         let menuitem = f.st.add_new_xml_menuitem(xml_file, Some(oyarn!("a_menu")), range_at(10));
@@ -565,10 +574,10 @@ mod tests {
         f.st.add_new_variable(method, "local", range_at(20));
         f.st.add_new_variable(f.module, "MODULE_CONSTANT", range_at(0));
 
-        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml")?;
         let record = f.st.add_new_xml_record(XmlDataParent::XmlFile(xml_file), (oyarn!("res.partner"), 0..1), None, range_at(0));
         f.st.add_new_xml_field(XmlFieldParent::XmlRecord(record), oyarn!("name"), range_at(1), None, None, None);
-        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv")?;
         f.st.add_new_xml_record(XmlDataParent::CsvFile(csv_file), (oyarn!("res.partner"), 0..1), None, range_at(0));
         f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
 
@@ -596,8 +605,8 @@ mod tests {
         let mut f = Fixture::new();
         let file = f.st.add_new_file(f.module.into(), "models", "/root/ns/mod/models.py").unwrap();
         let constant = f.st.add_new_variable(f.module, "MODULE_CONSTANT", range_at(0));
-        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml");
-        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv");
+        let xml_file = f.st.add_new_xml_file(f.module, "data.xml", "/root/ns/mod/data.xml").unwrap();
+        let csv_file = f.st.add_new_csv_file(f.module, "res.partner.csv", "/root/ns/mod/res.partner.csv").unwrap();
         let js_file = f.st.add_new_js_file(JsFileParent::Module(f.module), "widget.js", "/root/ns/mod/static/src/widget.js");
 
         let children = f.st.children(f.module.into());

--- a/server/src/core/symbols/storage/xml/xml_field_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_field_symbol.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::TextRange;
 
-use crate::{constants::OYarn, core::symbols::storage::XmlFieldParent};
+use crate::{constants::OYarn, core::symbols::storage::XmlFieldParent, oyarn};
 use std::fmt::Display;
 
 
@@ -18,7 +18,7 @@ pub struct XmlFieldSymbol {
 
 impl XmlFieldSymbol {
     pub fn new(
-        field_name: OYarn,
+        field_name: &str,
         range: TextRange,
         text: Option<String>,
         text_range: Option<TextRange>,
@@ -27,7 +27,7 @@ impl XmlFieldSymbol {
         is_external: bool,
     ) -> Self {
         Self {
-            field_name,
+            field_name: oyarn!("{}", field_name),
             range,
             text,
             text_range,

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -6,17 +6,49 @@ use lsp_types::{Diagnostic, DiagnosticTag, Range, SymbolKind};
 use ruff_text_size::TextRange;
 
 use crate::{
-    Sy, constants::{BuildStatus, BuildSteps, MissingDataSource, OYarn, PackageType, SymType}, core::{
-        build_scheduler::BuildScheduler, diagnostics::{DiagnosticCode, create_diagnostic}, entry_point::EntryPoint, evaluation::{Evaluation, EvaluationSymbolPtr}, evaluation_context::{Context, ContextKey, ContextValue}, file_mgr::{FileInfo, FileMgr, NoqaInfo}, model::Model, odoo::SyncOdoo, python_arch_eval_hooks::get_base_model_symbol, symbols::{
-            Buildable, Dependencies, ModuleSymbol, storage::{
-                FileContentParent, FileSystemSymbolParent, SymbolTable, buildable::ResettableBuildable as _, dependency_mgr::{DependenciesTable, DependentsTable}, xml::xml_field_symbol::XmlFieldName,
-            }, symbol_keys::{
+    constants::{BuildStatus, BuildSteps, MissingDataSource, OYarn, PackageType, SymType},
+    core::{
+        build_scheduler::BuildScheduler,
+        diagnostics::{create_diagnostic, DiagnosticCode},
+        entry_point::EntryPoint,
+        evaluation::{Evaluation, EvaluationSymbolPtr},
+        evaluation_context::{Context, ContextKey, ContextValue},
+        file_mgr::{FileInfo, FileMgr, NoqaInfo},
+        model::Model,
+        odoo::SyncOdoo,
+        python_arch_eval_hooks::get_base_model_symbol,
+        symbols::{
+            storage::{
+                buildable::ResettableBuildable as _,
+                dependency_mgr::{DependenciesTable, DependentsTable},
+                lifecycle::NameTakenError,
+                xml::xml_field_symbol::XmlFieldName,
+                FileContentParent, FileSystemSymbolParent, SymbolTable,
+            },
+            symbol_keys::{
                 BuildableSymbolKey, ClassKey, FunctionKey, KeyValidator, ModuleKey, NamespaceKey,
                 RootKey, SourceFileKey, SymbolKey, VariableKey, XmlDataKey, XmlRecordKey,
-            }, symbol_mgr::{ContentSymbols, SectionIndex, SectionRange, SymbolMgr, iter_symbol_keys},
+            },
+            symbol_mgr::{iter_symbol_keys, ContentSymbols, SectionIndex, SectionRange, SymbolMgr},
+            Buildable, Dependencies, ModuleSymbol,
         },
-    }, oyarn, threads::SessionInfo, tree::{OYarnExt, Tree}, utils::{HashMap, HashSet, PathSanitizer}, weak_collections::WeakSet,
+    },
+    oyarn,
+    threads::SessionInfo,
+    tree::{OYarnExt, Tree},
+    utils::{HashMap, HashSet, PathSanitizer},
+    weak_collections::WeakSet,
+    Sy,
 };
+#[derive(Debug)]
+pub enum CreateError {
+    NothingOnDisk,
+    Existing(SymbolKey)
+}
+
+impl From<NameTakenError> for CreateError {
+    fn from(e: NameTakenError) -> Self { Self::Existing(e.0) }
+}
 
 impl SymbolTable {
 
@@ -668,10 +700,10 @@ impl SymbolTable {
     }
 
     ///Given a path, create the appropriated symbol and attach it to the given parent
-    pub fn create_from_path(session: &mut SessionInfo, path: &Path, parent: FileSystemSymbolParent, require_module: bool) -> Option<SymbolKey> {
+    pub fn create_from_path(session: &mut SessionInfo, path: &Path, parent: FileSystemSymbolParent, require_module: bool) -> Result<SymbolKey, CreateError> {
         if require_module {
             let FileSystemSymbolParent::Namespace(addons) = parent else {
-                return None;
+                return Err(CreateError::NothingOnDisk);
             };
             return Self::create_module_from_path(session, path, addons).map(SymbolKey::from)
         }
@@ -682,29 +714,29 @@ impl SymbolTable {
         };
         let path_str = path.sanitize_cow();
         if path_str.ends_with(".py") || path_str.ends_with(".pyi") || FileMgr::is_untitled(&path_str) {
-            return Some(session.st_mut().add_new_file(parent, &name, &path_str).into());
+            return Ok(session.st_mut().add_new_file(parent, &name, &path_str)?.into());
         }
         if path_str.ends_with(".js") && !session.sync_odoo.config.is_javascript_disabled()
             && let FileSystemSymbolParent::DiskDir(d) = parent
         {
             //js file created here is because of js in a custom entrypoint, and that should be created under a diskdir.
             //JS files under a Module should be created by the module loading, through load_assets
-            return Some(session.st_mut().add_new_js_file(d.into(), &name, &path_str).into());
+            return Ok(session.st_mut().add_new_js_file(d.into(), &name, &path_str).into());
         }
         let main_entry_tree = session.sync_odoo.get_main_entry_tree(parent);
         if main_entry_tree == (&["odoo", "addons"], &[]) && path.join("__manifest__.py").exists() {
             if let FileSystemSymbolParent::Namespace(addons) = parent {
-                let module = Self::add_new_module_package(session, addons, &name, path);
+                let module = Self::add_new_module_package(session, addons, &name, path)?;
                 let dir_name = session.st()[module].dir_name.clone();
                 session.sync_odoo.modules.insert(dir_name, module.into());
-                return Some(module.into());
+                return Ok(module.into());
             } else {
                 if path.join("__init__.py").exists() || path.join("__init__.pyi").exists() {
                     let i_ext = if path.join("__init__.py").exists() { "" } else { "i" };
-                    let package_key = session.st_mut().add_new_python_package(parent, &name, &path_str, i_ext);
-                    return Some(package_key.into());
+                    let package_key = session.st_mut().add_new_python_package(parent, &name, &path_str, i_ext)?;
+                    return Ok(package_key.into());
                 } else {
-                    return None;
+                    return Err(CreateError::NothingOnDisk);
                 }
             }
         } else {
@@ -712,35 +744,31 @@ impl SymbolTable {
             if path.join("__init__.py").exists() || path.join("__init__.pyi").exists() {
                 if main_entry_tree == (&["odoo"], &[]) && path_str.ends_with("addons") {
                     //Force namespace for odoo/addons
-                    let namespace_key = symbol_table.add_new_namespace(parent, &name, &path_str);
-                    return Some(namespace_key.into());
+                    let namespace_key = symbol_table.add_new_namespace(parent, &name, &path_str)?;
+                    return Ok(namespace_key.into());
                 } else {
                     let i_ext = if path.join("__init__.py").exists() { "" } else { "i" };
-                    let package_key = symbol_table.add_new_python_package(parent, &name, &path_str, i_ext);
-                    return Some(package_key.into());
+                    let package_key = symbol_table.add_new_python_package(parent, &name, &path_str, i_ext)?;
+                    return Ok(package_key.into());
                 }
             } else if path.is_dir() {
-                let namespace_key = symbol_table.add_new_namespace(parent, &name, &path_str);
-                return Some(namespace_key.into());
+                let namespace_key = symbol_table.add_new_namespace(parent, &name, &path_str)?;
+                return Ok(namespace_key.into());
             }
         }
-        None
+        Err(CreateError::NothingOnDisk)
     }
 
-    pub fn create_module_from_path(session: &mut SessionInfo, path: &Path, addons: NamespaceKey) -> Option<ModuleKey> {
+    pub fn create_module_from_path(session: &mut SessionInfo, path: &Path, addons: NamespaceKey) -> Result<ModuleKey, CreateError> {
         let main_entry_tree = session.sync_odoo.get_main_entry_tree(addons);
         if !(main_entry_tree == (&["odoo", "addons"], &[]) && path.join("__manifest__.py").exists()) {
-            return None;
+            return Err(CreateError::NothingOnDisk);
         }
         let name = path.components().next_back().unwrap().as_os_str().to_str().unwrap();
-        if FileSystemSymbolParent::from(addons).get_child(session.st(), name).is_some() {
-            // Module already exists, do not create a new one
-            return None;
-        }
-        let module = Self::add_new_module_package(session, addons, name, path);
+        let module = Self::add_new_module_package(session, addons, name, path)?;
         let dir_name = session.sync_odoo.symbol_table[module].dir_name.clone();
         session.sync_odoo.modules.insert(dir_name, module.into());
-        Some(module)
+        Ok(module)
     }
 
     fn get_tree_helper(&self, symbol_key: SymbolKey) -> (Tree, RootKey) {
@@ -2471,7 +2499,7 @@ mod get_symbol_tests {
     #[test]
     fn file_only() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
 
         let files: &[&str] = &["my_file"];
         let content: &[&str] = &[];
@@ -2484,7 +2512,7 @@ mod get_symbol_tests {
     #[test]
     fn file_plus_one_content() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         let class = st.add_new_class(file.into(), "MyClass", range_at(0), TextSize::new(0));
 
         let files: &[&str] = &["my_file"];
@@ -2498,7 +2526,7 @@ mod get_symbol_tests {
     #[test]
     fn file_plus_nested_content() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         let class = st.add_new_class(file.into(), "MyClass", range_at(0), TextSize::new(0));
         let method = st.add_new_function(class.into(), "method", range_at(1), TextSize::new(1));
 
@@ -2514,7 +2542,7 @@ mod get_symbol_tests {
     fn deeply_nested_content() {
         // Content path longer than 2: file -> Outer -> Inner -> v
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         let outer = st.add_new_class(file.into(), "Outer", range_at(0), TextSize::new(0));
         let inner = st.add_new_class(outer.into(), "Inner", range_at(1), TextSize::new(1));
         let var = st.add_new_variable(SymbolKey::Class(inner), "v", range_at(2));
@@ -2531,8 +2559,8 @@ mod get_symbol_tests {
     fn nested_file_paths() {
         // File tree with several levels: package -> file -> class
         let (mut st, root) = empty_table_with_root();
-        let package = st.add_new_python_package(root.into(), "pkg", "/test/pkg", "");
-        let file = st.add_new_file(package.into(), "mod", "/test/pkg/mod.py");
+        let package = st.add_new_python_package(root.into(), "pkg", "/test/pkg", "").unwrap();
+        let file = st.add_new_file(package.into(), "mod", "/test/pkg/mod.py").unwrap();
         let class = st.add_new_class(file.into(), "Cls", range_at(0), TextSize::new(0));
 
         let files: &[&str] = &["pkg", "mod"];
@@ -2546,7 +2574,7 @@ mod get_symbol_tests {
     #[test]
     fn missing_file_returns_empty() {
         let (mut st, root) = empty_table_with_root();
-        st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        _ = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
 
         let files: &[&str] = &["does_not_exist"];
         let content: &[&str] = &[];
@@ -2556,7 +2584,7 @@ mod get_symbol_tests {
     #[test]
     fn missing_content_returns_empty() {
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         st.add_new_class(file.into(), "MyClass", range_at(0), TextSize::new(0));
 
         let files: &[&str] = &["my_file"];
@@ -2569,7 +2597,7 @@ mod get_symbol_tests {
         // Two variables with the same name in the same section: only the last
         // declaration visible before the position is returned.
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         let _first = st.add_new_variable(SymbolKey::File(file), "x", range_at(5));
         let second = st.add_new_variable(SymbolKey::File(file), "x", range_at(15));
 
@@ -2585,7 +2613,7 @@ mod get_symbol_tests {
     fn same_name_respects_position() {
         // Querying before the second declaration returns the first one.
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         let first = st.add_new_variable(SymbolKey::File(file), "x", range_at(5));
         let _second = st.add_new_variable(SymbolKey::File(file), "x", range_at(15));
 
@@ -2603,7 +2631,7 @@ mod get_symbol_tests {
         // A name defined in two mutually-exclusive branches (if / else) must
         // resolve to both symbols once the branches merge.
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         let file_key = SymbolKey::File(file);
 
         // sections: 0 base | 1 if-test | 2 if-body | 3 else-body | 4 merge(OR[2,3])
@@ -2636,7 +2664,7 @@ mod get_symbol_tests {
         // The same name resolving to multiple symbols must keep walking every
         // branch for the remaining content path (tests the flat_map behaviour).
         let (mut st, root) = empty_table_with_root();
-        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py");
+        let file = st.add_new_file(root.into(), "my_file", "/test/my_file.py").unwrap();
         let file_key = SymbolKey::File(file);
 
         {
@@ -2668,8 +2696,8 @@ mod get_symbol_tests {
     #[test]
     fn compiled_child_is_found_by_name() {
         let (mut st, root) = empty_table_with_root();
-        let parent = st.add_new_compiled(root.into(), "cmod", "/test/cmod.so");
-        let child = st.add_new_compiled(parent.into(), "sub", "/test/cmod/sub");
+        let parent = st.add_new_compiled(root.into(), "cmod", "/test/cmod.so").unwrap();
+        let child = st.add_new_compiled(parent.into(), "sub", "/test/cmod/sub").unwrap();
     
         assert_eq!(st.get_module_symbol(parent.into(), "sub"), Some(child.into()));
     }
@@ -2677,12 +2705,12 @@ mod get_symbol_tests {
     #[test]
     fn resolving_a_compiled_child_twice_keeps_one_key() {
         let (mut st, root) = empty_table_with_root();
-        let parent: SymbolKey = st.add_new_compiled(root.into(), "cmod", "/test/cmod.so").into();
+        let parent: SymbolKey = st.add_new_compiled(root.into(), "cmod", "/test/cmod.so").unwrap().into();
     
         fn resolve(st: &mut SymbolTable, parent: SymbolKey) -> SymbolKey {
             match st.get_module_symbol(parent, "sub") {
                 Some(found) => found,
-                None => st.add_new_compiled(parent.try_into().unwrap(), "sub", "/test/cmod/sub").into(),
+                None => st.add_new_compiled(parent.try_into().unwrap(), "sub", "/test/cmod/sub").unwrap().into(),
             }
         }
     

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -721,7 +721,8 @@ impl SymbolTable {
         {
             //js file created here is because of js in a custom entrypoint, and that should be created under a diskdir.
             //JS files under a Module should be created by the module loading, through load_assets
-            return Ok(session.st_mut().add_new_js_file(d.into(), &name, &path_str).into());
+            let js_file = session.st_mut().add_new_js_file(d.into(), &name, &path_str)?;
+            return Ok(js_file.into());
         }
         let main_entry_tree = session.sync_odoo.get_main_entry_tree(parent);
         if main_entry_tree == (&["odoo", "addons"], &[]) && path.join("__manifest__.py").exists() {

--- a/server/src/core/xml_arch_builder_rng_validation.rs
+++ b/server/src/core/xml_arch_builder_rng_validation.rs
@@ -237,16 +237,9 @@ impl XmlArchBuilder {
             found_id.clone().map(|id| oyarn!("{}", id)),
             TextRange::new(TextSize::new(node.range().start as u32), TextSize::new(node.range().end as u32))
         );
-        for child in node.children().filter(|n| n.is_element()) {
-            if self.load_field(session, &child, record.into(), diagnostics).is_none() && child.tag_name().name() != "field" {
-                // Diagnostic only for non-field tags, not for invalid ones
-                if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05015, &[child.tag_name().name()]) {
-                    diagnostics.push(Diagnostic {
-                        range: Range { start: Position::new(child.range().start as u32, 0), end: Position::new(child.range().end as u32, 0) },
-                        ..diagnostic.clone()
-                    });
-                }
-            }
+        // load fields in reverse order to have last field declaration overwrite previous ones, as Odoo does
+        for child in node.children().filter(|n| n.is_element()).rev() {
+            self.load_field(session, &child, record.into(), diagnostics);
         }
         self.register_ir_model_record(session, record);
         self.register_ir_model_fields_record(session, record);
@@ -256,7 +249,15 @@ impl XmlArchBuilder {
 
     // load a field and add it to the parent symbol. Parent could be either XmlRecordKey or XmlAssetKey
     fn load_field(&mut self, session: &mut SessionInfo, node: &Node, parent: XmlFieldParent, diagnostics: &mut Vec<Diagnostic>) -> Option<XmlFieldKey> {
-        if node.tag_name().name() != "field" { return None; }
+        if node.tag_name().name() != "field" {
+            if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05015, &[node.tag_name().name()]) {
+                diagnostics.push(Diagnostic {
+                    range: Range { start: Position::new(node.range().start as u32, 0), end: Position::new(node.range().end as u32, 0) },
+                    ..diagnostic
+                });
+            }
+            return None;
+        }
         let Some(node_name_node) = node.attribute_node("name") else {
             if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05016, &[]) {
                 diagnostics.push(Diagnostic {
@@ -390,14 +391,15 @@ impl XmlArchBuilder {
                 text_range = Some(child.range());
             }
         }
-        let field = session.st_mut().add_new_xml_field(
+        // TODO: add diagnostic for duplicate fields?
+        session.st_mut().add_new_xml_field(
             parent,
-            oyarn!("{}", node_name_node.value()),
+            node_name_node.value(),
             TextRange::new(TextSize::new(node_name_node.range().start as u32), TextSize::new(node_name_node.range().end as u32)),
             text,
             text_range.map(|r| TextRange::new(TextSize::new(r.start as u32), TextSize::new(r.end as u32))),
-            ref_key);
-        Some(field)
+            ref_key
+        ).ok()
     }
 
     fn load_value(&mut self, session: &mut SessionInfo, node: &Node, diagnostics: &mut Vec<Diagnostic>) -> bool {
@@ -687,7 +689,8 @@ impl XmlArchBuilder {
             TextRange::new(TextSize::new(node.range().start as u32), TextSize::new(node.range().end as u32)));
         // Validate children: must be bundle, path, or field
         let (mut has_bundle, mut has_path) = (false, false);
-        for child in node.children().filter(|n| n.is_element()) {
+        // iterate in reverse order so that last field declaration overwrite previous ones, as Odoo does
+        for child in node.children().filter(|n| n.is_element()).rev() {
             match child.tag_name().name() {
                 "bundle" => {
                     has_bundle = true;

--- a/server/src/core/xml_arch_builder_rng_validation.rs
+++ b/server/src/core/xml_arch_builder_rng_validation.rs
@@ -391,15 +391,25 @@ impl XmlArchBuilder {
                 text_range = Some(child.range());
             }
         }
-        // TODO: add diagnostic for duplicate fields?
-        session.st_mut().add_new_xml_field(
+        match session.st_mut().add_new_xml_field(
             parent,
             node_name_node.value(),
             TextRange::new(TextSize::new(node_name_node.range().start as u32), TextSize::new(node_name_node.range().end as u32)),
             text,
             text_range.map(|r| TextRange::new(TextSize::new(r.start as u32), TextSize::new(r.end as u32))),
             ref_key
-        ).ok()
+        ) {
+            Ok(field) => Some(field),
+            Err(_) => {
+                if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05076, &[node_name_node.value()]) {
+                    diagnostics.push(Diagnostic {
+                        range: Range { start: Position::new(node_name_node.range().start as u32, 0), end: Position::new(node_name_node.range().end as u32, 0) },
+                        ..diagnostic
+                    });
+                }
+                None
+            },
+        }
     }
 
     fn load_value(&mut self, session: &mut SessionInfo, node: &Node, diagnostics: &mut Vec<Diagnostic>) -> bool {

--- a/server/tests/data/addons/module_csv/__manifest__.py
+++ b/server/tests/data/addons/module_csv/__manifest__.py
@@ -20,6 +20,7 @@ This is the description of the module CSV
         'data/country_unquoted_lf/res.country.state.csv',
         'data/csv_field_mismatch/res.country.state.csv',
         'data/csv_invalid_xml_id/res.country.state.csv',
+        'data/csv_duplicate_column/res.country.state.csv',
     ],
     'installable': True,
     'application': True,

--- a/server/tests/data/addons/module_csv/data/csv_duplicate_column/res.country.state.csv
+++ b/server/tests/data/addons/module_csv/data/csv_duplicate_column/res.country.state.csv
@@ -1,0 +1,3 @@
+id,country_id:id,name,code,name
+state_dup_1,base.au,Overwritten,TS1,Odoo keeps this one
+state_dup_2,base.au,Overwritten too,TS2,Odoo keeps this one too

--- a/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
+++ b/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
@@ -50,28 +50,28 @@
     </menuitem>
     <record model="bikes.bike" wrong_attr="bof"/> <!-- OLS05013 -->
     <record id="bikes.bike"/> <!-- OLS05014 -->
-    <record model="bikes.bike"> <!-- OLS05014 -->
-        <not_field name="name">Nope</not_field>  <!-- OLS05015 -->
-        <field nam="watchouttypo!">Nope</field>  <!-- OLS05016 -->
-        <field name="name" ref="ref" eval="andeval?">Nope</field>  <!-- OLS05017 -->
-        <field name="name" type="int">3.14</field>  <!-- OLS05018 -->
-        <field name="name" type="float">am_i_a_float?</field>  <!-- OLS05019 -->
-        <field name="name" type="list"><not_value/></field>  <!-- OLS05020 -->
-        <field name="name" type="base64" file="path/to/file">f</field>  <!-- OLS05021 -->
-        <field name="name" ref="bike_4">f</field>  <!-- OLS05022 -->
-        <field name="name" model="bike_4"/>  <!-- OLS05023 -->
-        <field name="name" use="use"/>  <!-- OLS05024 -->
-        <field name="name" invalid_attr="invalid_attr"/>  <!-- OLS05025 -->
-        <field name="name"><not_field/></field>  <!-- OLS05026 -->
-        <field name="name" type="list"><value type="type" search="s">text</value></field>  <!-- OLS05027 -->
-        <field name="name" type="list"><value type="type" eval="s">text</value></field>  <!-- OLS05028 -->
-        <field name="name" type="list"><value eval="eval" type="s"/></field>  <!-- OLS05029 -->
-        <field name="name" type="list"><value file="s">text</value></field>  <!-- OLS05030 -->
-        <field name="name" type="list"><value eval="eval" file="s"/></field>  <!-- OLS05031 -->
-        <field name="name" type="list"><value bla="bla">text</value></field>  <!-- OLS05032 -->
-        <field name="name" type="list"><value type="type"/></field>  <!-- OLS05058 -->
-        <field name="name" type="list"><value/></field>  <!-- OLS05059 -->
-    </record>
+    <!-- Field diagnostics: one record per line -->
+    <record model="bikes.bike"><not_field name="name">Nope</not_field></record>  <!-- OLS05015 -->
+    <record model="bikes.bike"><field nam="watchouttypo!">Nope</field></record>  <!-- OLS05016 -->
+    <record model="bikes.bike"><field name="name" ref="ref" eval="andeval?">Nope</field></record>  <!-- OLS05017 -->
+    <record model="bikes.bike"><field name="name" type="int">3.14</field></record>  <!-- OLS05018 -->
+    <record model="bikes.bike"><field name="name" type="float">am_i_a_float?</field></record>  <!-- OLS05019 -->
+    <record model="bikes.bike"><field name="name" type="list"><not_value/></field></record>  <!-- OLS05020 -->
+    <record model="bikes.bike"><field name="name" type="base64" file="path/to/file">f</field></record>  <!-- OLS05021 -->
+    <record model="bikes.bike"><field name="name" ref="bike_3">f</field></record>  <!-- OLS05022 -->
+    <record model="bikes.bike"><field name="name" model="bike_4"/></record>  <!-- OLS05023 -->
+    <record model="bikes.bike"><field name="name" use="use"/></record>  <!-- OLS05024 -->
+    <record model="bikes.bike"><field name="name" invalid_attr="invalid_attr"/></record>  <!-- OLS05025 -->
+    <record model="bikes.bike"><field name="name"><not_field/></field></record>  <!-- OLS05026 -->
+    <record model="bikes.bike"><field name="name" type="list"><value type="type" search="s">text</value></field></record>  <!-- OLS05027 -->
+    <record model="bikes.bike"><field name="name" type="list"><value type="type" eval="s">text</value></field></record>  <!-- OLS05028 -->
+    <record model="bikes.bike"><field name="name" type="list"><value eval="eval" type="s"/></field></record>  <!-- OLS05029 -->
+    <record model="bikes.bike"><field name="name" type="list"><value file="s">text</value></field></record>  <!-- OLS05030 -->
+    <record model="bikes.bike"><field name="name" type="list"><value eval="eval" file="s"/></field></record>  <!-- OLS05031 -->
+    <record model="bikes.bike"><field name="name" type="list"><value bla="bla">text</value></field></record>  <!-- OLS05032 -->
+    <record model="bikes.bike"><field name="name" type="list"><value type="type"/></field></record>  <!-- OLS05036 -->
+    <record model="bikes.bike"><field name="name" type="list"><value/></field></record>  <!-- OLS05037 -->
+
     <delete id="id" /> <!-- OLS05033 -->
     <delete model="bikes.bike" id="id" search="search"/> <!-- OLS05034 -->
     <delete model="bikes.bike"/> <!-- OLS05035 -->

--- a/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
+++ b/server/tests/data/addons/module_for_diagnostics/data/bikes.xml
@@ -120,4 +120,8 @@
         <path></path> <!-- OLS05067 -->
     </asset>
     <record id="bike_translation_1" model="bikes.bike"><field name="name@nl_WV">Da's gin geldige taal, jonge.</field></record> <!-- West Flemish is not a valid language, unfortunately (OLS05068: unknown language code) -->
+    <record id="bike_duplicate_field" model="bikes.bike">
+        <field name="name">Overwritten by the declaration below</field> <!-- OLS05076 -->
+        <field name="name">Odoo keeps this one</field>
+    </record>
 </odoo>

--- a/server/tests/diagnostics/ols05000s.rs
+++ b/server/tests/diagnostics/ols05000s.rs
@@ -109,6 +109,7 @@ fn test_ols05000s_xml_file() {
     check_xml_diag("OLS05066", 118);
     check_xml_diag("OLS05067", 119);
     check_xml_warning("OLS05068", 121);
+    check_xml_warning("OLS05076", 123);
 }
 
 #[test]

--- a/server/tests/setup/setup.rs
+++ b/server/tests/setup/setup.rs
@@ -108,7 +108,8 @@ pub fn get_diagnostics_for_paths(session: &mut SessionInfo, paths: &[String]) ->
                 let params: PublishDiagnosticsParams = serde_json::from_value(n.params).expect("Unable to parse PublishDiagnosticsParams");
                 let params_path = FileMgr::uri2pathname(params.uri.as_str());
                 if paths.contains(&params_path) {
-                    res.entry(params_path).or_insert_with(Vec::new).extend(params.diagnostics);
+                    // publishDiagnostics carries the whole file each time, so the last one wins
+                    res.insert(params_path, params.diagnostics);
                 }
             }
     }

--- a/server/tests/test_csv_diagnostics.rs
+++ b/server/tests/test_csv_diagnostics.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 mod setup;
 mod test_utils;
 
-fn csv_test_paths() -> (String, String, String) {
+fn csv_test_paths() -> (String, String, String, String) {
     let test_addons_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("data")
@@ -22,15 +22,18 @@ fn csv_test_paths() -> (String, String, String) {
     let invalid_xml_id = test_addons_path
         .join("module_csv").join("data").join("csv_invalid_xml_id").join("res.country.state.csv")
         .sanitize();
+    let duplicate_column = test_addons_path
+        .join("module_csv").join("data").join("csv_duplicate_column").join("res.country.state.csv")
+        .sanitize();
     let valid_csv = test_addons_path
         .join("module_for_diagnostics").join("data").join("bike_parts.wheel.csv")
         .sanitize();
 
-    for path in [&field_mismatch, &invalid_xml_id, &valid_csv] {
+    for path in [&field_mismatch, &invalid_xml_id, &duplicate_column, &valid_csv] {
         assert!(Path::new(path).exists(), "Test file does not exist: {}", path);
     }
 
-    (field_mismatch, invalid_xml_id, valid_csv)
+    (field_mismatch, invalid_xml_id, duplicate_column, valid_csv)
 }
 
 fn collect_all_csv_diagnostics(session: &mut SessionInfo, paths: &[&str]) -> HashMap<String, Vec<Diagnostic>> {
@@ -54,16 +57,17 @@ fn test_csv_diagnostics() {
     let (mut odoo, config) = setup::setup::setup_server(true);
     let mut session = setup::setup::create_init_session(&mut odoo, config);
 
-    let (field_mismatch, invalid_xml_id, valid_csv) = csv_test_paths();
+    let (field_mismatch, invalid_xml_id, duplicate_column, valid_csv) = csv_test_paths();
 
     // Collect all diagnostics in one pass (consuming the message queue once)
     let all_diags = collect_all_csv_diagnostics(
         &mut session,
-        &[&field_mismatch, &invalid_xml_id, &valid_csv],
+        &[&field_mismatch, &invalid_xml_id, &duplicate_column, &valid_csv],
     );
 
     test_field_count_mismatch(get_diags_for(&all_diags, &field_mismatch));
     test_xml_id_format(get_diags_for(&all_diags, &invalid_xml_id));
+    test_duplicate_column(get_diags_for(&all_diags, &duplicate_column));
     test_valid_file_no_errors(get_diags_for(&all_diags, &valid_csv));
 }
 
@@ -135,6 +139,38 @@ fn test_xml_id_format(diagnostics: &[Diagnostic]) {
             diag.range.start.line
         );
     }
+}
+
+/// OLS05076: "name" is declared by two columns, Odoo only uses the last one.
+/// Reported once on the header row.
+/// File: csv_duplicate_column/res.country.state.csv
+///   Line 0: id,country_id:id,name,code,name
+///   Line 1: state_dup_1,base.au,Overwritten,TS1,Odoo keeps this one
+///   Line 2: state_dup_2,base.au,Overwritten too,TS2,Odoo keeps this one too
+fn test_duplicate_column(diagnostics: &[Diagnostic]) {
+    let dup_diags: Vec<_> = diagnostics.iter().filter(|d| has_code(d, "OLS05076")).collect();
+    // Two data rows, so a per-record diagnostic would show up here as two
+    assert_eq!(
+        dup_diags.len(),
+        1,
+        "Expected a single OLS05076 on the header row, got: {:?}",
+        diagnostics
+    );
+
+    let diag = dup_diags[0];
+    assert_eq!(
+        diag.severity,
+        Some(lsp_types::DiagnosticSeverity::WARNING),
+        "OLS05076 should be a warning"
+    );
+    assert!(
+        diag.message.contains("name"),
+        "OLS05076 message should name the duplicated column, got: {}",
+        diag.message
+    );
+    // The overwritten column is the first "name", at characters 17..21 of the header
+    assert_eq!(diag.range.start, lsp_types::Position::new(0, 17));
+    assert_eq!(diag.range.end, lsp_types::Position::new(0, 21));
 }
 
 /// Well-formed CSV: no error-level diagnostics expected


### PR DESCRIPTION
The goal: a symbol key can only be removed via `unload`.

Before: inserting into a parent's hashmap with an existing key (name or path) replaces the old value (a symbol key), which effectively allowed for a second mechanism of symbol key removal

After: inserting to a parent's hashmap with an existing key (name or path) fails, and callers must handle the Error. 