### PR TITLE
Fix add new module in search symbols to rebuild

### DIFF
--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -10,7 +10,7 @@ use crate::core::pre_parser::{PreParseCache, PreParser};
 use crate::core::symbols::ModuleSymbol;
 use crate::core::symbols::storage::{FileSystemSymbolParent, JsFileParent, SymbolTable};
 use crate::core::symbols::storage::metrics::{log_slotmap_capacities, log_symbol_counts, log_memory_usage};
-use crate::core::symbols::symbol_keys::{BuildableSymbolKey, FunctionKey, ModuleKey, SourceFileKey, SymbolKey, Wk, XmlId, XmlTemplateKey};
+use crate::core::symbols::symbol_keys::{BuildableSymbolKey, FileSystemSymbolKey, FunctionKey, ModuleKey, SourceFileKey, SymbolKey, Wk, XmlId, XmlTemplateKey};
 use crate::core::symbols::symbol_table_impl::CreateError;
 use crate::core::tsserver_bridge::{TsServerBridge};
 use crate::features::tsserver_completion::TsCompletionResolveData;
@@ -852,7 +852,7 @@ impl SyncOdoo {
             if let Some(sym) = sym_in_data {
                 if let Some(sym) = sym.upgrade(session.st())
                     && should_unload(session.st(), sym.into()) {
-                        SymbolTable::unload(session, sym);
+                        SymbolTable::unload(session, sym.into());
                         unloaded_any = true;
                     }
                 continue;
@@ -872,11 +872,11 @@ impl SyncOdoo {
                 let Some(&path_symbol) = path_symbols.first() else {
                     continue;
                 };
-                let Some(source_file) = path_symbol.as_source_file_key() else {
+                let Ok(file_or_dir) = FileSystemSymbolKey::try_from(path_symbol) else {
                     continue;
                 };
                 if should_unload(session.st(), path_symbol) {
-                    SymbolTable::unload(session, source_file);
+                    SymbolTable::unload(session, file_or_dir);
                     unloaded_any = true;
                 }
             }

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -10,7 +10,7 @@ use crate::core::pre_parser::{PreParseCache, PreParser};
 use crate::core::symbols::ModuleSymbol;
 use crate::core::symbols::storage::{FileSystemSymbolParent, JsFileParent, SymbolTable};
 use crate::core::symbols::storage::metrics::{log_slotmap_capacities, log_symbol_counts, log_memory_usage};
-use crate::core::symbols::symbol_keys::{BuildableSymbolKey, FileSystemSymbolKey, FunctionKey, ModuleKey, SourceFileKey, SymbolKey, Wk, XmlId, XmlTemplateKey};
+use crate::core::symbols::symbol_keys::{BuildableSymbolKey, FileSystemSymbolKey, FunctionKey, ModuleKey, NamespaceKey, SourceFileKey, SymbolKey, Wk, XmlId, XmlTemplateKey};
 use crate::core::symbols::symbol_table_impl::CreateError;
 use crate::core::tsserver_bridge::{TsServerBridge};
 use crate::features::tsserver_completion::TsCompletionResolveData;
@@ -671,9 +671,7 @@ impl SyncOdoo {
     }
 
     fn build_modules(session: &mut SessionInfo) {
-        let Some(&SymbolKey::Namespace(addons_symbol)) = session.sync_odoo.get_symbol(
-            session.sync_odoo.config.odoo_path().as_ref().unwrap(), (&["odoo", "addons"], &[]), u32::MAX
-        ).first() else {
+        let Some(addons_symbol) = session.sync_odoo.addons_namespace() else {
             let message = S!("OdooLS: Unable to find 'odoo/addons'. Check the addons_paths in your config or your file structure. Skipping addons loading...");
             warn!("{}", message);
             session.show_message(MessageType::WARNING, message);
@@ -811,6 +809,16 @@ impl SyncOdoo {
 
     pub fn get_main_entry(&self) -> Rc<RefCell<EntryPoint>> {
         return self.entry_point_mgr.borrow().main_entry_point.as_ref().expect("Unable to find main entry point").clone()
+    }
+
+    /// The `odoo/addons` namespace, or None if odoo is not loaded (yet).
+    pub fn addons_namespace(&self) -> Option<NamespaceKey> {
+        let ep_mgr = self.entry_point_mgr.borrow();
+        let main_symbol = ep_mgr.main_entry_point.as_ref()?.borrow().get_symbol(&self.symbol_table)?;
+        match self.symbol_table.get_symbol(main_symbol, (&["odoo", "addons"], &[]), u32::MAX).first() {
+            Some(&SymbolKey::Namespace(addons)) => Some(addons),
+            _ => None,
+        }
     }
 
     /// Ensure that a function symbol's evaluations are as fully populated
@@ -2053,47 +2061,24 @@ impl Odoo {
                 entry.borrow_mut().search_symbols_to_rebuild(session, path, tree);
             }
         }
-        //test if the new path is a new module
-        if let Some(parent_path) = path_for_tree.parent() {
-            let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
-            for entry in ep_mgr.borrow().addons_entry_points.iter() {
-                if entry.borrow().path == parent_path.sanitize_cow() {
-                    if let SymbolKey::Namespace(addons) = entry.borrow().get_symbol(session.st()).unwrap() {
-                        match SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
-                            Ok(module_symbol) => {
-                                BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
-                            },
-                            Err(CreateError::NothingOnDisk) => {}, // not a module dir
-                            Err(CreateError::Existing(_symbol)) =>  {
-                                warn!("cannot create module at {}: name already taken", path_for_tree.sanitize_cow());
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-            if parent_path.sanitize() == session.sync_odoo.config.odoo_path().as_deref().unwrap_or_default().to_string() + "/odoo/addons" {
-                let addons_symbol = session.sync_odoo.get_main_entry().borrow().get_symbol(session.st()).map(|ep_sym_key|
-                    session.st().get_symbol(ep_sym_key, (&["odoo", "addons"], &[]), u32::MAX)
-                );
-                match addons_symbol {
-                    Some(addons_symbol) if !addons_symbol.is_empty() => {
-                        if let SymbolKey::Namespace(addons) = addons_symbol[0] {
-                            match SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
-                                Ok(module_symbol) => {
-                                    BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
-                                },
-                                Err(CreateError::NothingOnDisk) => {},
-                                Err(CreateError::Existing(_symbol)) => {
-                                    warn!("cannot create module at {}: name already taken", path_for_tree.sanitize_cow());
-                                },
-                            }
-                        }
-                    }
-                    _ => {
-                        error!("Unable to find addons symbol to create new module");
-                    }
-                }
+        // test if the new path is a new module under odoo/addons namespace.
+        let Some(addons) = session.sync_odoo.addons_namespace() else {
+            return;
+        };
+        let Some(parent_path) = path_for_tree.parent().map(|parent| parent.sanitize_cow()) else {
+            return;
+        };
+        if !session.st()[addons].directories().iter().any(|d| d.path == parent_path) {
+            return;
+        }
+        match SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
+            Ok(module_symbol) => {
+                BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
+            },
+            Err(CreateError::NothingOnDisk) => {}, // not a module dir
+            Err(CreateError::Existing(_symbol)) => {
+                // @todo: unload the existing symbol, then add the module symbol
+                warn!("cannot create module at {}: name already taken", path_for_tree.sanitize_cow());
             }
         }
     }

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -2071,14 +2071,34 @@ impl Odoo {
         if !session.st()[addons].directories().iter().any(|d| d.path == parent_path) {
             return;
         }
-        match SymbolTable::create_module_from_path(session, &path_for_tree, addons) {
-            Ok(module_symbol) => {
-                BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
-            },
-            Err(CreateError::NothingOnDisk) => {}, // not a module dir
-            Err(CreateError::Existing(_symbol)) => {
-                // @todo: unload the existing symbol, then add the module symbol
-                warn!("cannot create module at {}: name already taken", path_for_tree.sanitize_cow());
+        if let Some(module_symbol) = Self::create_or_replace_module(session, &path_for_tree, addons) {
+            BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
+        }
+    }
+
+    /// Create the module at `path` under `addons`, or replace non-module symbol that already holds
+    /// the name - e.g. namespace or a package before `__manifest__.py` existed.
+    fn create_or_replace_module(session: &mut SessionInfo, path: &Path, addons: NamespaceKey) -> Option<ModuleKey> {
+        let existing = match SymbolTable::create_module_from_path(session, path, addons) {
+            Ok(module) => return Some(module),
+            Err(CreateError::NothingOnDisk) => return None, // not a module dir
+            Err(CreateError::Existing(existing)) => existing,
+        };
+        if matches!(existing, SymbolKey::Module(_)) {
+            // Two addons paths declare the same module name: keep first one
+            warn!("module {} is already loaded, ignoring {}", session.st().name(existing), path.sanitize_cow());
+            return None;
+        }
+        let existing_fs_key = FileSystemSymbolKey::try_from(existing).ok()?;
+        SymbolTable::unload(session, existing_fs_key);
+        match SymbolTable::create_module_from_path(session, path, addons) {
+            Ok(module) => Some(module),
+            Err(CreateError::Existing(_)) => unreachable!("name freed by the unload just above"),
+            Err(CreateError::NothingOnDisk) => {
+                // only possible in a race condition: dir and/or __manifest__.py got removed
+                // between the two calls to `create_module_from_path`
+                error!("{} stopped being a module while replacing the previous symbol", path.sanitize_cow());
+                None
             }
         }
     }

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -10,24 +10,33 @@
 //! checks, unlike keys stored elsewhere (as Weak).
 
 use crate::{
-    constants::{OYarn, PackageType, SymType}, core::{
+    constants::{OYarn, PackageType, SymType},
+    core::{
         entry_point::{EntryPoint, EntryPointCleanupToken},
         odoo::SyncOdoo,
         symbols::{
-            ClassSymbol, CompiledSymbol, CsvFileSymbol, Dependencies, DiskDirSymbol, FileSymbol, FunctionSymbol, JsFileSymbol, ModuleSymbol, NamespaceSymbol, PythonPackageSymbol, RootSymbol, SymbolTable, VariableSymbol, XmlFileSymbol, storage::{
-                FileContentParent, FileSystemSymbolParent, JsFileParent, XmlDataParent, XmlFieldParent, xml::{
+            storage::{
+                xml::{
                     xml_asset_symbol::XmlAssetSymbol, xml_delete_symbol::XmlDeleteSymbol,
                     xml_field_symbol::XmlFieldSymbol, xml_menuitem_symbol::XmlMenuItemSymbol,
                     xml_record_symbol::XmlRecordSymbol, xml_template_symbol::XmlTemplateSymbol,
-                }
-            }, symbol_keys::{
-                ClassKey, CompiledKey, CsvFileKey, DiskDirKey, FileKey, FunctionKey, JsFileKey,
-                ModuleKey, NamespaceKey, PythonPackageKey, RootKey, SourceFileKey, SymbolKey,
-                VariableKey, XmlAssetKey, XmlDeleteKey, XmlFieldKey, XmlFileKey,
-                XmlMenuItemKey, XmlRecordKey, XmlTemplateKey,
-            }
+                },
+                FileContentParent, FileSystemSymbolParent, JsFileParent, XmlDataParent,
+                XmlFieldParent,
+            },
+            symbol_keys::{
+                ClassKey, CompiledKey, CsvFileKey, DiskDirKey, FileKey, FileSystemSymbolKey,
+                FunctionKey, JsFileKey, ModuleKey, NamespaceKey, PythonPackageKey, RootKey,
+                SourceFileKey, SymbolKey, VariableKey, XmlAssetKey, XmlDeleteKey, XmlFieldKey,
+                XmlFileKey, XmlMenuItemKey, XmlRecordKey, XmlTemplateKey,
+            },
+            ClassSymbol, CompiledSymbol, CsvFileSymbol, Dependencies, DiskDirSymbol, FileSymbol,
+            FunctionSymbol, JsFileSymbol, ModuleSymbol, NamespaceSymbol, PythonPackageSymbol,
+            RootSymbol, SymbolTable, VariableSymbol, XmlFileSymbol,
         },
-    }, oyarn, threads::SessionInfo
+    },
+    oyarn,
+    threads::SessionInfo,
 };
 use ruff_text_size::{TextRange, TextSize};
 use std::{cell::RefCell, ops::Range, path::Path, rc::Rc};
@@ -321,7 +330,7 @@ impl SymbolTable {
 
     /// Remove `symbol` and its descendants, and clean up.
     /// WARNING: After this call, `symbol` and its descendants are no longer valid keys.
-    pub fn unload(session: &mut SessionInfo, symbol: SourceFileKey) {
+    pub fn unload(session: &mut SessionInfo, symbol: FileSystemSymbolKey) {
         fn unload_recursively(session: &mut SessionInfo, symbol: SymbolKey) {
             for child in session.st().children(symbol) {
                 unload_recursively(session, child);
@@ -397,44 +406,63 @@ impl SymbolTable {
         result
     }
 
-    fn unlink_from_parent(&mut self, child: SourceFileKey) {
+    fn unlink_from_parent(&mut self, child: FileSystemSymbolKey) {
         match child {
-            SourceFileKey::File(f) => {
+            FileSystemSymbolKey::File(f) => {
                 let file_symbol = &self[f];
                 let name = file_symbol.name.to_string();
                 let parent = file_symbol.parent();
                 self.remove_from_parent_fs_symbols(parent, &name);
             },
-            SourceFileKey::Module(m) => {
+            FileSystemSymbolKey::Module(m) => {
                 let module_symbol = &self[m];
                 let name = module_symbol.name.to_string();
                 let parent = module_symbol.parent();
                 self.remove_from_parent_fs_symbols(parent.into(), &name);
             },
-            SourceFileKey::PythonPackage(p) => {
+            FileSystemSymbolKey::PythonPackage(p) => {
                 let package_symbol = &self[p];
                 let name = package_symbol.name.to_string();
                 let parent = package_symbol.parent();
                 self.remove_from_parent_fs_symbols(parent, &name);
             },
-            SourceFileKey::XmlFile(x) => {
+            FileSystemSymbolKey::Namespace(n) => {
+                let namespace_symbol = &self[n];
+                let name = namespace_symbol.name.clone();
+                let parent = namespace_symbol.parent();
+                self.remove_from_parent_fs_symbols(parent, &name);
+            },
+            FileSystemSymbolKey::DiskDir(d) => {
+                let disk_dir_symbol = &self[d];
+                let name = disk_dir_symbol.name.clone();
+                let parent = disk_dir_symbol.parent();
+                self.remove_from_parent_fs_symbols(parent, &name);
+            },
+            FileSystemSymbolKey::Compiled(c) => {
+                let compiled_symbol = &self[c];
+                let name = compiled_symbol.name.clone();
+                let parent = compiled_symbol.parent();
+                self.remove_from_parent_fs_symbols(parent, &name);
+            },
+            FileSystemSymbolKey::XmlFile(x) => {
                 let xml_symbol = &self[x];
                 let parent = xml_symbol.parent();
                 let path = xml_symbol.path.clone();
                 self.remove_from_module_data_symbols(parent, &path);
             },
-            SourceFileKey::CsvFile(c) => {
+            FileSystemSymbolKey::CsvFile(c) => {
                 let csv_symbol = &self[c];
                 let parent = csv_symbol.parent();
                 let path = csv_symbol.path.clone();
                 self.remove_from_module_data_symbols(parent, &path);
             },
-            SourceFileKey::JsFile(j) => {
+            FileSystemSymbolKey::JsFile(j) => {
                 let js_symbol = &self[j];
                 let parent = js_symbol.parent();
                 let path = js_symbol.path.clone();
                 self.remove_from_parent_js_symbols(parent, &path);
             },
+            
         }
     }
 }
@@ -516,7 +544,7 @@ mod tests {
             assert!(f.holds(parent, child), "{child:?} is not a child of {parent:?}");
             assert_eq!(f.st.parent(child), Some(parent), "{child:?} does not point back at {parent:?}");
 
-            f.st.unlink_from_parent(child);
+            f.st.unlink_from_parent(child.into());
             assert!(!f.holds(parent, child), "{child:?} is still a child of {parent:?} after unlink");
         }
 

--- a/server/src/core/symbols/symbol_keys.rs
+++ b/server/src/core/symbols/symbol_keys.rs
@@ -309,7 +309,7 @@ impl SymbolKey {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, SymbolKeySubset, IntoKey)]
-#[into_key(BuildableSymbolKey)]
+#[into_key(BuildableSymbolKey, FileSystemSymbolKey)]
 pub enum SourceFileKey {
     File(FileKey),
     PythonPackage(PythonPackageKey),
@@ -477,4 +477,18 @@ impl SymbolKey {
             _ => None,
         }
     }
+}
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SymbolKeySubset)]
+pub enum FileSystemSymbolKey {
+    DiskDir(DiskDirKey),
+    Namespace(NamespaceKey),
+    PythonPackage(PythonPackageKey),
+    Module(ModuleKey),
+    Compiled(CompiledKey),
+    File(FileKey),
+    XmlFile(XmlFileKey),
+    CsvFile(CsvFileKey),
+    JsFile(JsFileKey),
 }

--- a/server/tests/test_module_lifecycle.rs
+++ b/server/tests/test_module_lifecycle.rs
@@ -1,0 +1,60 @@
+//! Lifecycle of a module directory under `odoo/addons`.
+
+use assert_fs::TempDir;
+use assert_fs::prelude::*;
+use lsp_types::{CreateFilesParams, FileCreate};
+use odoo_ls_server::core::config::ConfigKey;
+use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::Odoo;
+use odoo_ls_server::core::symbols::symbol_keys::{KeyValidator, SymbolKey};
+use odoo_ls_server::utils::PathSanitizer;
+use std::fs;
+use std::path::Path;
+
+mod setup;
+
+/// A directory already indexed as a namespace must become a module when its `__manifest__.py`
+/// appears, and the namespace it replaces must be unloaded rather than left in the arena.
+#[test]
+fn test_namespace_becomes_module_when_manifest_is_created() {
+    let temp = TempDir::new().unwrap();
+    // `foo` is a bare directory: with no `__init__.py` and no `__manifest__.py`, the import
+    // resolver can only index it as a namespace.
+    temp.child("foo").create_dir_all().unwrap();
+    // A module importing it, so that `odoo.addons.foo` is indexed the way production does it:
+    // through the import resolver, during the ARCH of `importer`.
+    temp.child("importer").create_dir_all().unwrap();
+    temp.child("importer").child("__manifest__.py").write_str("{'name': 'importer'}\n").unwrap();
+    temp.child("importer").child("__init__.py").write_str("from odoo.addons import foo\n").unwrap();
+
+    // `canonicalize` so that the addons path we register and the paths we build from it are the
+    // same string (on macOS the temp dir is behind a symlink).
+    let addons_path = fs::canonicalize(temp.path()).unwrap();
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("data").join("addons");
+    let (mut odoo, mut config) = setup::setup::setup_server(true);
+    config.set_string_list(ConfigKey::AddonsPaths, [fixtures.sanitize(), addons_path.sanitize()]);
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    let addons = session.sync_odoo.addons_namespace().expect("odoo/addons namespace should exist");
+    let child = session.st()[addons].get_child("foo");
+    let Some(SymbolKey::Namespace(namespace)) = child else {
+        panic!("`foo` should have been indexed as a namespace, got {child:?}");
+    };
+
+    // The manifest appears: `foo` is a module from now on.
+    let manifest = addons_path.join("foo").join("__manifest__.py");
+    fs::write(&manifest, "{'name': 'foo'}\n").unwrap();
+    Odoo::handle_did_create(&mut session, CreateFilesParams {
+        files: vec![FileCreate { uri: FileMgr::pathname2uri(&manifest.sanitize()).to_string() }],
+    });
+
+    let child = session.st()[addons].get_child("foo");
+    assert!(
+        matches!(child, Some(SymbolKey::Module(_))),
+        "`foo` should have been replaced by a module, got {child:?}"
+    );
+    assert!(
+        !session.st().is_key_valid(namespace),
+        "the replaced namespace should have been unloaded, not left in the arena"
+    );
+}


### PR DESCRIPTION
[185411](https://github.com/odoo/odoo-ls/commit/185411baf4b48a5e00cb5fc79fb4e9bf9127577c) changed the behavior of adding a new Module symbol where there was already one.
This breaks the flow in which a namespace of package should be replaced by a Module when a `__manifest__.py` is created.
This PR fixes it.