### PR TITLE
[IMP] goto feature now take the header range of functions and classes.

### DIFF
--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -27,7 +27,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use crate::S;
 use crate::constants::*;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 use percent_encoding::{AsciiSet, CONTROLS};
 
 use super::odoo::SyncOdoo;
@@ -874,6 +874,17 @@ impl FileInfo {
 
     pub fn position_to_offset(&self, line: u32, char: u32, encoding: PositionEncoding) -> usize {
         FileInfo::position_to_offset_with_text_document(self.file_info_ast.borrow().text_document.as_ref().expect("no text_document provided"), line, char, encoding)
+    }
+
+    /// Returns the offset of the end of the line preceding the line that `offset` is on
+    /// (excluding the newline character), using the document's `LineIndex`.
+    pub fn prev_line_end(&self, offset: TextSize) -> Option<TextSize> {
+        let ast_ref = self.file_info_ast.borrow();
+        let td = ast_ref.text_document.as_ref()?;
+        let index = td.index();
+        let line = index.line_index(offset);
+        let prev_line = line.checked_sub(OneIndexed::new(1).unwrap()).unwrap_or(line);
+        Some(index.line_end_exclusive(prev_line, td.contents()))
     }
 }
 

--- a/server/src/core/symbols/symbol_table_impl.rs
+++ b/server/src/core/symbols/symbol_table_impl.rs
@@ -7,7 +7,7 @@ use ruff_text_size::TextRange;
 
 use crate::{
     Sy, constants::{BuildStatus, BuildSteps, MissingDataSource, OYarn, PackageType, SymType}, core::{
-        build_scheduler::BuildScheduler, diagnostics::{DiagnosticCode, create_diagnostic}, entry_point::EntryPoint, evaluation::{Evaluation, EvaluationSymbolPtr}, evaluation_context::{Context, ContextKey, ContextValue}, file_mgr::{FileMgr, NoqaInfo}, model::Model, odoo::SyncOdoo, python_arch_eval_hooks::get_base_model_symbol, symbols::{
+        build_scheduler::BuildScheduler, diagnostics::{DiagnosticCode, create_diagnostic}, entry_point::EntryPoint, evaluation::{Evaluation, EvaluationSymbolPtr}, evaluation_context::{Context, ContextKey, ContextValue}, file_mgr::{FileInfo, FileMgr, NoqaInfo}, model::Model, odoo::SyncOdoo, python_arch_eval_hooks::get_base_model_symbol, symbols::{
             Buildable, Dependencies, ModuleSymbol, storage::{
                 FileContentParent, FileSystemSymbolParent, SymbolTable, buildable::ResettableBuildable as _, dependency_mgr::{DependenciesTable, DependentsTable}, xml::xml_field_symbol::XmlFieldName,
             }, symbol_keys::{
@@ -231,6 +231,51 @@ impl SymbolTable {
             SymbolKey::CsvFile(_) => panic!(),
             SymbolKey::JsFile(_) => panic!(),
         }
+    }
+
+    pub fn body_range(&self, target: SymbolKey) -> Option<TextRange> {
+        match target {
+            SymbolKey::Root(_) => None,
+            SymbolKey::DiskDir(_) => None,
+            SymbolKey::Namespace(_) => None,
+            SymbolKey::PythonPackage(_) => None,
+            SymbolKey::Module(_) => None,
+            SymbolKey::File(_) => None,
+            SymbolKey::Compiled(_) => None,
+            SymbolKey::Class(c) => Some(self[c].body_range),
+            SymbolKey::Function(f) => Some(self[f].body_range),
+            SymbolKey::Variable(_) => None,
+            SymbolKey::XmlFile(_) => None,
+            SymbolKey::XmlRecord(_) => None,
+            SymbolKey::XmlField(_) => None,
+            SymbolKey::XmlMenuItem(_) => None,
+            SymbolKey::XmlTemplate(_) => None,
+            SymbolKey::XmlAsset(_) => None,
+            SymbolKey::XmlDelete(_) => None,
+            SymbolKey::CsvFile(_) => None,
+            SymbolKey::JsFile(_) => None,
+        }
+    }
+
+    /* 
+    * Return the header range of a class or function, by substracting the body of the element from the full range.
+    * Require a fileInfo to use the lineIndex and get the line before the body, or a less precise end range will be returned
+    */
+    pub fn header_range(&self, target: SymbolKey, file_info: Option<Rc<RefCell<FileInfo>>>) -> Option<TextRange> {
+        let range = self.range(target);
+        if let Some(body_range) = self.body_range(target)
+        && body_range.start() > range.start() {
+            let end = match file_info {
+                Some(file_info)=> {
+                    file_info.borrow().prev_line_end(body_range.start())
+                        .filter(|&end| end > range.start())
+                        .unwrap_or(body_range.start())
+                },
+                None => body_range.start(),
+            };
+            return Some(TextRange::new(range.start(), end));
+        }
+        None
     }
 
     pub fn parent(&self, target: impl Into<SymbolKey>) -> Option<SymbolKey> {

--- a/server/src/features/goto_utils.rs
+++ b/server/src/features/goto_utils.rs
@@ -270,8 +270,12 @@ impl GotoUtils {
                         if let Some(file) = session.st().get_file(*symbol_key) {
                             let path = session.st().path(file).to_string();
                             let range = if session.st().has_range(*symbol_key) {
-                                let range = session.st().range(*symbol_key);
-                                session.sync_odoo.get_file_mgr().borrow().text_range_to_range(session, &path, range)
+                                let file_mgr = session.sync_odoo.get_file_mgr();
+                                let file_info = file_mgr.borrow().get_file_info(&path);
+                                let header_range = session.st().header_range(*symbol_key, file_info);
+                                session.sync_odoo.get_file_mgr().borrow().text_range_to_range(session, &path, header_range.unwrap_or(
+                                    session.st().range(*symbol_key)
+                                ))
                             } else {
                                 Range::default()
                             };

--- a/server/tests/test_get_symbol.rs
+++ b/server/tests/test_get_symbol.rs
@@ -298,15 +298,17 @@ fn test_definition() {
     assert_eq!(compute_arg_locs[0].target_uri.to_file_path().unwrap().sanitize(), module1_test_file, "Expected location to be in the same file");
     let sym_compute_something = session.st().get_symbol(m1_tf_file_symbol.into(), (&[], &["BaseTestModel", "_compute_something"]), u32::MAX);
     assert_eq!(sym_compute_something.len(), 1, "Expected 1 symbol for _compute_something");
-    let range = session.st().range(sym_compute_something[0]);
-    assert_eq!(file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, range), compute_arg_locs[0].target_range, "Expected _compute_something to be at the same location as the compute argument");
+    let range = session.st().header_range(sym_compute_something[0], Some(m1_tf_file_info.clone())).unwrap();
+    let range = file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, range);
+    assert_eq!(range, compute_arg_locs[0].target_range, "Expected _compute_something to be at the same location as the compute argument");
 
     // Test definition for model class BaseTestModel compute something in module_2, first on the super call
     let compute_arg_locs = test_utils::get_definition_locs(&mut session, m2_tf_file_symbol, &m2_tf_file_info, 10, 36);
     assert_eq!(compute_arg_locs.len(), 1, "Expected 1 location for compute method '_compute_something'");
     assert_eq!(compute_arg_locs[0].target_uri.to_file_path().unwrap().sanitize(), module1_test_file, "Expected location to be in module_1 file");
-    let range = session.st().range(sym_compute_something[0]);
-    assert_eq!(file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, range), compute_arg_locs[0].target_range, "Expected _compute_something to be at the same location as the compute argument");
+    let range = session.st().header_range(sym_compute_something[0], Some(m1_tf_file_info.clone())).unwrap();
+    let range = file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, range);
+    assert_eq!(range, compute_arg_locs[0].target_range, "Expected _compute_something to be at the same location as the compute argument");
 
     // Then on the compute keyword argument in module_2, it should point to both methods in module_1 and module_2
     let compute_kwarg_locs = test_utils::get_definition_locs(&mut session, m2_tf_file_symbol, &m2_tf_file_info, 6, 50);
@@ -317,10 +319,12 @@ fn test_definition() {
     assert_eq!(sym_compute_something_m2.len(), 1, "Expected 1 symbol for _compute_something in module_2");
 
     // Check that compute_kwarg_locs contains the range of the compute something syms from both files
-    let range = session.st().range(sym_compute_something[0]);
-    assert!(compute_kwarg_locs.iter().any(|loc| file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, range) == loc.target_range), "Expected _compute_something to be at the same location as the compute keyword argument in module_1");
-    let range_m2 = session.st().range(sym_compute_something_m2[0]);
-    assert!(compute_kwarg_locs.iter().any(|loc| file_mgr.borrow().text_range_to_range(&mut session, &module2_test_file, range_m2) == loc.target_range), "Expected _compute_something to be at the same location as the compute keyword argument in module_2");
+    let range = session.st().header_range(sym_compute_something[0], Some(m1_tf_file_info.clone())).unwrap();
+    let range = file_mgr.borrow().text_range_to_range(&mut session, &module1_test_file, range);
+    assert!(compute_kwarg_locs.iter().any(|loc| range == loc.target_range), "Expected _compute_something to be at the same location as the compute keyword argument in module_1");
+    let range_m2 = session.st().header_range(sym_compute_something_m2[0], Some(m2_tf_file_info.clone())).unwrap();
+    let range_m2 = file_mgr.borrow().text_range_to_range(&mut session, &module2_test_file, range_m2);
+    assert!(compute_kwarg_locs.iter().any(|loc| range_m2 == loc.target_range), "Expected _compute_something to be at the same location as the compute keyword argument in module_2");
 
     // Now test go to def of `partner_id.country_id.phone_code` on each field.
     let partner_id_locs = test_utils::get_definition_locs(&mut session, m1_tf_file_symbol, &m1_tf_file_info, 33, 25);

--- a/server/tests/test_untitled.rs
+++ b/server/tests/test_untitled.rs
@@ -98,5 +98,5 @@ fn test_untitled_file_lifecycle() {
     let def_loc = &def_locs[0];
     // Should point to line 0 (def foo)
     assert_eq!(def_loc.range.start.line, 0, "Definition should start at line 0 (function definition), got: {:?}", def_loc);
-    assert_eq!(def_loc.range.end.line, 1, "Definition should end at line 0 (function definition), got: {:?}", def_loc);
+    assert_eq!(def_loc.range.end.line, 0, "Definition should end at line 0 (function definition), got: {:?}", def_loc);
 }

--- a/server/tests/test_utils.rs
+++ b/server/tests/test_utils.rs
@@ -116,7 +116,6 @@ pub fn get_definition_locs(
         .collect::<Vec<_>>()
 }
 
-
 pub fn diag_on_line(diagnostics: &[lsp_types::Diagnostic], line: u32) -> Vec<&lsp_types::Diagnostic> {
     diagnostics.iter().filter(|d| d.range.start.line <= line && d.range.end.line >= line).collect()
 }


### PR DESCRIPTION
It allows us to fallback on gotoreference if the cursor is in the range of the element, but not the body.