### PR TITLE
[FIX] missing label details in completion items

### DIFF
--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1762,22 +1762,25 @@ impl Odoo {
                 if schema != "untitled" && !file_info.borrow().file_info_ast.borrow().ast.is_built() {
                     file_info.borrow_mut().prepare_ast(session);
                 }
+                let trigger_kind = params.context.as_ref()
+                    .map_or(CompletionTriggerKind::INVOKED, |context| context.trigger_kind);
                 let ast_kind = file_info.borrow().file_info_ast.borrow().ast.kind();
                 match ast_kind {
                     AstKind::JsAst => {
                         if let Some(bridge) = session.sync_odoo.tsserver_bridge.as_mut() {
-                            let items = bridge.completion_items_for_content(
+                            let list = bridge.completion_list_for_content(
                                 &path,
                                 params.text_document_position.position.line,
                                 params.text_document_position.position.character,
+                                trigger_kind,
                             );
-                            return Ok(Some(CompletionResponse::Array(items)));
+                            return Ok(Some(CompletionResponse::List(list)));
                         }
                         return Ok(None);
                     },
                     AstKind::XmlAst => {
-                        if let Some(items) = owl_virtual::completion_xml_owl(session, &file_info, params.text_document_position.position.line, params.text_document_position.position.character) {
-                            return Ok(Some(CompletionResponse::Array(items)));
+                        if let Some(list) = owl_virtual::completion_xml_owl(session, &file_info, params.text_document_position.position.line, params.text_document_position.position.character, trigger_kind) {
+                            return Ok(Some(CompletionResponse::List(list)));
                         }
                     },
                     _ => {}

--- a/server/src/core/tsserver_bridge.rs
+++ b/server/src/core/tsserver_bridge.rs
@@ -1,4 +1,4 @@
-use lsp_types::{CompletionItem, CompletionItemKind, Diagnostic, DiagnosticSeverity, DocumentSymbol, Location, NumberOrString, Position, Range, SymbolKind};
+use lsp_types::{CompletionItemKind, CompletionList, CompletionTriggerKind, Diagnostic, DiagnosticSeverity, DocumentSymbol, Location, NumberOrString, Position, Range, SymbolKind};
 use serde_json::{Value, json};
 use crate::S;
 use crate::features::tsserver_completion::{TsCompletionDetails, entry_to_completion_item, response_to_completion_details};
@@ -237,6 +237,9 @@ impl TsServerBridge {
                 "preferences": {
                     "includeCompletionsForImportStatements": true,
                     "includeCompletionsWithInsertText": true,
+                    // Without it tsserver never resolves a module specifier outside an import
+                    // statement, so no entry carries the `sourceDisplay` shown beside the label.
+                    "allowIncompleteCompletions": true,
                 }
             }),
         ) else {
@@ -674,29 +677,32 @@ impl TsServerBridge {
     /// (import-statement completions) become a `text_edit`; every entry gets
     /// [`TsCompletionResolveData`] so `completionItem/resolve` can fetch its signature and
     /// docs — and, for auto-imports, the import edit.
-    pub fn completion_items_for_content(
+    pub fn completion_list_for_content(
         &mut self,
         file_path: &str,
         line: u32,
         character: u32,
-    ) -> Vec<CompletionItem> {
+        trigger_kind: CompletionTriggerKind,
+    ) -> CompletionList {
 
         let request_seq = match self.send_request(
-            "completions",
+            "completionInfo",
             json!({
                 "file": file_path,
                 "line": line + 1,
                 "offset": character + 1,
                 "includeExternalModuleExports": true,
                 "includeInsertTextCompletions": true,
+                // LSP and tsserver number these alike (no conversion needed)
+                "triggerKind": trigger_kind,
             }),
         ) {
             Ok(seq) => seq,
-            Err(_) => return vec![],
+            Err(_) => return CompletionList::default(),
         };
 
         let Some(response) = self.read_response_for_request(request_seq) else {
-            return vec![];
+            return CompletionList::default();
         };
 
         let success = response
@@ -704,26 +710,24 @@ impl TsServerBridge {
             .and_then(Value::as_bool)
             .unwrap_or(false);
         if !success {
-            return vec![];
+            return CompletionList::default();
         }
 
         let Some(body) = response.get("body") else {
-            return vec![];
+            return CompletionList::default();
         };
 
-        let entries = body
-            .get("entries")
-            .and_then(Value::as_array)
-            .or_else(|| body.as_array());
-
-        let Some(entries) = entries else {
-            return vec![];
+        let Some(entries) = body.get("entries").and_then(Value::as_array) else {
+            return CompletionList::default();
         };
 
-        entries
-            .iter()
-            .map(|entry| entry_to_completion_item(entry, file_path, line, character))
-            .collect()
+        CompletionList {
+            is_incomplete: body.get("isIncomplete").and_then(Value::as_bool).unwrap_or(false),
+            items: entries
+                .iter()
+                .map(|entry| entry_to_completion_item(entry, file_path, line, character))
+                .collect(),
+        }
     }
 
     /// Second half of any completion: the entry's signature and docs, plus — for auto-imports

--- a/server/src/features/owl_virtual.rs
+++ b/server/src/features/owl_virtual.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use lsp_types::{
-    CompletionItem, GotoDefinitionResponse, Hover, HoverContents, Location, MarkupContent,
+    CompletionList, CompletionTriggerKind, GotoDefinitionResponse, Hover, HoverContents, Location, MarkupContent,
     MarkupKind, Position, Range, SemanticTokens,
 };
 use ruff_source_file::{LineIndex, PositionEncoding};
@@ -399,23 +399,24 @@ pub fn completion_xml_owl(
     file_info: &Rc<RefCell<FileInfo>>,
     line: u32,
     character: u32,
-) -> Option<Vec<CompletionItem>> {
+    trigger_kind: CompletionTriggerKind,
+) -> Option<CompletionList> {
     let (doc, v_line, v_char) = open_doc_at_cursor(session, file_info, line, character)?;
-    let mut items = session
+    let mut list = session
         .sync_odoo
         .tsserver_bridge
         .as_mut()?
-        .completion_items_for_content(&doc.virtual_path, v_line, v_char);
+        .completion_list_for_content(&doc.virtual_path, v_line, v_char, trigger_kind);
 
     // Drop edit-bearing entries (their positions address the virtual `.js` the client never
     // saw). Resolve data survives: it points at the still-open virtual doc, and
     // `handle_completion_resolve` keeps only the signature/docs for such paths.
-    items.retain(|item| item.text_edit.is_none());
+    list.items.retain(|item| item.text_edit.is_none());
 
-    if items.is_empty() {
+    if list.items.is_empty() {
         return None;
     }
-    Some(items)
+    Some(list)
 }
 
 /// Go-to-definition for an OWL-template JS expression, delegated to tsserver and triaged by

--- a/server/src/features/tsserver_completion.rs
+++ b/server/src/features/tsserver_completion.rs
@@ -13,7 +13,7 @@ use crate::core::tsserver_bridge::ts_kind_to_lsp_kind;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TsCompletionResolveData {
     pub file: String,
-    /// 0-based, as originally sent to [`TsServerBridge::completion_items_for_content`].
+    /// 0-based, as originally sent to [`TsServerBridge::completion_list_for_content`].
     pub line: u32,
     pub character: u32,
     pub name: String,
@@ -68,7 +68,6 @@ pub fn entry_to_completion_item(entry: &Value, file_path: &str, line: u32, chara
 
     // Where an auto-import would pull the symbol from, shown next to the label.
     let label_details = join_ts_parts(entry.get("sourceDisplay"))
-        .or_else(|| source.map(str::to_string))
         .map(|description| CompletionItemLabelDetails {
             detail: None,
             description: Some(description),
@@ -220,9 +219,14 @@ mod tests {
             "kind": "class",
             "kindModifiers": "export",
             "sortText": "16",
-            "source": "/odoo/addons/web/static/src/core/domain",
+            "source": "@web/core/domain",
+            "sourceDisplay": [{ "text": "@web/core/domain", "kind": "text" }],
             "hasAction": true,
-            "data": { "exportName": "Domain", "fileName": "/odoo/addons/web/static/src/core/domain.js" }
+            "data": {
+                "exportName": "Domain",
+                "fileName": "/odoo/addons/web/static/src/core/domain.js",
+                "moduleSpecifier": "@web/core/domain"
+            }
         })
     }
 
@@ -283,14 +287,15 @@ mod tests {
         assert_eq!(resolve.file, "/a/b.js");
         assert_eq!((resolve.line, resolve.character), (23, 5));
         assert_eq!(resolve.name, "Domain");
-        assert_eq!(resolve.source.as_deref(), Some("/odoo/addons/web/static/src/core/domain"));
+        assert_eq!(resolve.source.as_deref(), Some("@web/core/domain"));
         // tsserver's opaque export-map handle must survive the trip through the client.
         assert_eq!(resolve.data.unwrap()["exportName"], "Domain");
 
-        // Without `sourceDisplay`, the raw `source` names the module in the list.
+        // The module the accepted item would import from, beside the label — the whole point of
+        // `allowIncompleteCompletions`, and it matches the specifier the edit will write.
         assert_eq!(
             item.label_details.and_then(|d| d.description).as_deref(),
-            Some("/odoo/addons/web/static/src/core/domain")
+            Some("@web/core/domain")
         );
     }
 

--- a/server/tests/data/addons/module_owl/static/src/greeting/utils.js
+++ b/server/tests/data/addons/module_owl/static/src/greeting/utils.js
@@ -1,8 +1,15 @@
 import { final_answer } from "./greeting_report";
+import { useChildRef } from "@web/core/utils/hooks";
 
 const half_answer = 21;
 
 export function answer_is_correct(answer) {
     if (answer < half_answer) return false;
     return answer === final_answer();
+}
+
+export function useGreetingRefs() {
+    const ref = useChildRef();
+    const service = useS;
+    return { ref, service };
 }

--- a/server/tests/js_owl_helpers/asserts.rs
+++ b/server/tests/js_owl_helpers/asserts.rs
@@ -49,6 +49,23 @@ pub fn assert_completions(session: &mut SessionInfo, file: &FixtureFile, snippet
     }
 }
 
+/// Assert one completion request at the caret offers every `(label, label_details)`.
+pub fn assert_completions_label_details(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, expected: &[(&str, &str)]) {
+    let items = completions(session, file, snippet);
+    for (label, label_details) in expected {
+        let item = items.iter().find(|item| item.label == *label).unwrap_or_else(|| panic!(
+            "no completion {label:?} at {snippet:?} in {}", file.path
+        ));
+        let item_label_details = item.label_details.as_ref()
+            .unwrap_or_else(|| panic!("no label detail for {label:?} at {snippet:?} in {}", file.path))
+            .description.as_ref()
+            .unwrap_or_else(|| panic!("no label detail description for {label:?} at {snippet:?} in {}", file.path));
+        assert_eq!(item_label_details.as_str(), *label_details,
+            "label details of completion {label:?} at {snippet:?}"
+        );
+    }
+}
+
 /// Assert the references at the caret are exactly `expected`, each given as a caret snippet in the
 /// fixture holding it.
 pub fn assert_references(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, expected: &[(&FixtureFile, &str)]) {

--- a/server/tests/test_js_owl_features.rs
+++ b/server/tests/test_js_owl_features.rs
@@ -44,6 +44,8 @@ fn test_js_owl_features() {
         session.sync_odoo.tsserver_bridge.is_some(),
         "tsserver did not start with TSSERVER={tsserver_command:?}"
     );
+    eprintln!("COMMUNITY_PATH={:?}", std::env::var("COMMUNITY_PATH").expect("setup_server checked it already"));
+    eprintln!("Odoo version={}", session.sync_odoo.version);
 
     let fixtures = Fixtures::init(&mut session);
 
@@ -64,6 +66,7 @@ fn test_js_owl_features() {
     test_completion_in_js(&mut session, &fixtures);
     test_completion_in_template(&mut session, &fixtures);
     test_completion_resolve(&mut session, &fixtures);
+    test_completion_entries_label_details(&mut session, &fixtures);
 
     // References
     test_references_from_declaration(&mut session, &fixtures);
@@ -215,6 +218,14 @@ fn test_completion_resolve(session: &mut SessionInfo, fixtures: &Fixtures) {
     assert!(shout.documentation.is_some(), "resolve should carry shout's JSDoc, got none");
     // Its edits would be in virtual-doc coordinates, which would corrupt the XML if applied.
     assert!(shout.additional_text_edits.is_none(), "a template completion must carry no edits");
+}
+
+fn test_completion_entries_label_details(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js_utils, .. } = fixtures;
+    assert_completions_label_details(session, js_utils, "const service = useS|", &[
+        ("useService", "@web/core/utils/hooks"),
+        ("useSpellCheck", "@web/core/utils/hooks"),
+    ]);
 }
 
 /// Find-references from a member's declaration


### PR DESCRIPTION
 [FIX] missing sourceDisplay in completion items

  The goal is to have the same result of VsCode + TS language server:
  completion items with auto-import have the resolved JS module in the
  label details (CompletionItem::label_details). e.g.:

  User types "useD" and gets completion suggestions:
  ```
          useDateTimePicker       @web/core/datetime/...
          useDeleteRecords        @web/views/view_hook
          etc...
  ```

  This requires tsserver to resolve each completion item's module, which
  is not done by default outside an import statement.

  But it does it if we pass `"allowIncompleteCompletions": true` config -
  that's what VsCode does.

  From typescript's source code:

  ```
  const shouldResolveModuleSpecifier = needsFullResolution
    || preferences.allowIncompleteCompletions && resolvedCount < moduleSpecifierResolutionLimit;
  ```

  `needsFullResolution` is true only inside an import statement, so we
  need `preferences.allowIncompleteCompletions` to make it work elsewhere.
  
   With this setting active we get the resolved JS module in the
  `sourceDisplay` field of the completion response, which we feed to
  our CompletionItem's `label_details` field.

  As a consequence:

  This means we might get an incomplete suggestions list, which might have
  to be refreshed as the user types - and the client/editor must know
  about it.

  For this reason:
  - we change the tsserver command from "completions" to "completionInfo",
    as the latter contains the "isIncomplete" information

  - we change the LSP response type from CompletionResponse::Array to
    CompletionResponse::List, for the same reason: the latter carries the
    information "is_incomplete"

  - we pass the "triggerKind" from the request params to tsserver, which
    allows tsserver to be more efficient when rebuilding the list on a
    re-ask
  