### PR TITLE
[REF] Ast::Pending

### DIFF
--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -308,8 +308,7 @@ impl Ast {
     pub fn is_built(&self) -> bool {
         match self {
             Ast::PythonAst(py_ast) => py_ast.indexed_module.is_some(),
-            Ast::JsAst(js_ast) => !js_ast.js_template_refs.is_empty() || !js_ast.js_component_descriptors.is_empty(),
-            Ast::XmlAst | Ast::CsvAst => true,
+            Ast::JsAst(_) | Ast::XmlAst | Ast::CsvAst => true,
         }
     }
 }

--- a/server/src/core/file_mgr.rs
+++ b/server/src/core/file_mgr.rs
@@ -219,21 +219,7 @@ pub fn parse_js_inner(contents: &str, path: &str) -> ParsedJs {
 
 #[derive(Debug, Clone)]
 pub struct PythonAst {
-    pub indexed_module: Option<Arc<IndexedModule>>,
-}
-
-impl Default for PythonAst {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PythonAst {
-    pub fn new() -> Self {
-        Self {
-            indexed_module: None,
-        }
-    }
+    pub indexed_module: Arc<IndexedModule>,
 }
 
 #[derive(Debug, Clone)]
@@ -274,6 +260,7 @@ impl JsAst {
 
 #[derive(Debug, Clone)]
 pub enum Ast {
+    Pending,
     PythonAst(PythonAst),
     XmlAst,
     CsvAst,
@@ -287,29 +274,14 @@ impl Ast {
             _ => panic!("Expected PythonAst, found {:?}", self),
         }
     }
-    pub fn as_py_ast_mut(&mut self) -> &mut PythonAst {
-        match self {
-            Ast::PythonAst(py_ast) => py_ast,
-            _ => panic!("Expected PythonAst, found {:?}", self),
-        }
-    }
     pub fn as_js_ast(&self) -> &JsAst {
         match self {
             Ast::JsAst(js_ast) => js_ast,
             _ => panic!("Expected JsAst, found {:?}", self),
         }
     }
-    pub fn as_js_ast_mut(&mut self) -> &mut JsAst {
-        match self {
-            Ast::JsAst(js_ast) => js_ast,
-            _ => panic!("Expected JsAst, found {:?}", self),
-        }
-    }
     pub fn is_built(&self) -> bool {
-        match self {
-            Ast::PythonAst(py_ast) => py_ast.indexed_module.is_some(),
-            Ast::JsAst(_) | Ast::XmlAst | Ast::CsvAst => true,
-        }
+        !matches!(self, Ast::Pending)
     }
 }
 
@@ -326,7 +298,7 @@ impl FileInfoAst {
     pub fn get_stmts(&self) -> Option<&[Stmt]> {
         match &self.ast {
             Ast::PythonAst(python_ast) => {
-                python_ast.indexed_module.as_ref().map(|module| module.parsed.syntax().body.as_slice())
+                Some(python_ast.indexed_module.parsed.syntax().body.as_slice())
             },
             _ => None
         }
@@ -360,7 +332,7 @@ impl FileInfo {
             file_info_ast: Rc::new(RefCell::new(FileInfoAst {
                 text_hash: 0,
                 text_document: None,
-                ast: Ast::PythonAst(PythonAst::new()),
+                ast: Ast::Pending,
             })),
             diagnostics: HashMap::default(),
             noqas_blocs: HashMap::default(),
@@ -455,7 +427,6 @@ impl FileInfo {
                 self.file_info_ast.borrow_mut().ast = Ast::CsvAst;
             }
             Some("js") | Some("ts") => {
-                self.file_info_ast.borrow_mut().ast = Ast::JsAst(JsAst::new());
                 self.build_js_ast(session, is_external);
             }
             _ => {
@@ -477,7 +448,7 @@ impl FileInfo {
         }
         let (valid, diagnostics) = Self::syntax_diagnostics(session, &parsed.indexed_module.parsed);
         self.valid = valid;
-        self.file_info_ast.borrow_mut().ast.as_py_ast_mut().indexed_module = Some(parsed.indexed_module);
+        self.file_info_ast.borrow_mut().ast = Ast::PythonAst(PythonAst { indexed_module: parsed.indexed_module });
         self.replace_diagnostics(DiagnosticSource::PY_SYNTAX, diagnostics);
     }
 
@@ -519,7 +490,7 @@ impl FileInfo {
                     let mut fia = self.file_info_ast.borrow_mut();
                     fia.text_hash = text_hash;
                     fia.text_document = Some(text_document);
-                    fia.ast = Ast::PythonAst(PythonAst { indexed_module: Some(parsed.indexed_module) });
+                    fia.ast = Ast::PythonAst(PythonAst { indexed_module: parsed.indexed_module });
                 }
                 self.replace_diagnostics(DiagnosticSource::PY_SYNTAX, diagnostics);
             }
@@ -534,7 +505,6 @@ impl FileInfo {
                     let mut fia = self.file_info_ast.borrow_mut();
                     fia.text_hash = text_hash;
                     fia.text_document = Some(text_document);
-                    fia.ast = Ast::JsAst(JsAst::new());
                 }
                 self.apply_parsed_js(session, parsed);
             }
@@ -554,19 +524,15 @@ impl FileInfo {
     /// the file was parsed inline ([`Self::build_js_ast`]) or by a pre-parse worker
     /// ([`Self::apply_preloaded`]), so `js_arch_builder::build` keeps seeing files in
     /// build order either way.
-    ///
-    /// Expects [`Ast::JsAst`] to be in place already.
     fn apply_parsed_js(&mut self, session: &mut SessionInfo, parsed: ParsedJs) {
         js_arch_builder::build(session, &parsed.template_refs, &parsed.component_descriptors);
-        {
-            let mut fia = self.file_info_ast.borrow_mut();
-            let js_ast = fia.ast.as_js_ast_mut();
-            js_ast.js_template_refs = parsed.template_refs;
-            js_ast.js_component_descriptors = parsed.component_descriptors;
-            js_ast.js_decls = parsed.decls;
-            js_ast.js_imports = parsed.imports;
-            js_ast.js_reexports = parsed.reexports;
-        }
+        self.file_info_ast.borrow_mut().ast = Ast::JsAst(JsAst {
+            js_template_refs: parsed.template_refs,
+            js_component_descriptors: parsed.component_descriptors,
+            js_decls: parsed.decls,
+            js_imports: parsed.imports,
+            js_reexports: parsed.reexports,
+        });
         self.replace_diagnostics(DiagnosticSource::JS_OXC, parsed.diagnostics); //OXC will use SYNTAX. others are reserved to tsserver
     }
 

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1532,10 +1532,9 @@ impl Odoo {
                 }
                 let ast_type = file_info.borrow().file_info_ast.borrow().ast.clone();
                 match ast_type {
+                    Ast::Pending => return Ok(None),
                     Ast::PythonAst(_) => {
-                        if file_info.borrow_mut().file_info_ast.borrow().ast.as_py_ast().indexed_module.is_some() {
-                            return Ok(HoverFeature::hover_python(session, file_symbol, &file_info, params.text_document_position_params.position.line, params.text_document_position_params.position.character));
-                        }
+                        return Ok(HoverFeature::hover_python(session, file_symbol, &file_info, params.text_document_position_params.position.line, params.text_document_position_params.position.character));
                     },
                     Ast::XmlAst => {
                         let Position { line, character } = params.text_document_position_params.position;
@@ -1594,10 +1593,8 @@ impl Odoo {
                         if session.sync_odoo.config.is_semantic_tokens_python_disabled() {
                             return Ok(None);
                         }
-                        if file_info.borrow().file_info_ast.borrow().ast.as_py_ast().indexed_module.is_some() {
-                            let tokens = SemanticTokensFeature::tokens_python(session, file_symbol, &file_info);
-                            return Ok(Some(SemanticTokensResult::Tokens(tokens)));
-                        }
+                        let tokens = SemanticTokensFeature::tokens_python(session, file_symbol, &file_info);
+                        return Ok(Some(SemanticTokensResult::Tokens(tokens)));
                     },
                     Ast::JsAst(_) => {
                         if session.sync_odoo.config.is_semantic_tokens_javascript_disabled() {
@@ -1672,9 +1669,6 @@ impl Odoo {
             if let Some(file_info) = file_info {
                 if !file_info.borrow().file_info_ast.borrow().ast.is_built() {
                     file_info.borrow_mut().prepare_ast(session);
-                }
-                if !file_info.borrow().file_info_ast.borrow().ast.is_built() {
-                    return Ok(None);
                 }
                 return match is_declaration {
                     false => {
@@ -1780,16 +1774,16 @@ impl Odoo {
                             return Ok(Some(CompletionResponse::Array(items)));
                         }
                     },
+                    Ast::PythonAst(_) => {
+                        return Ok(CompletionFeature::autocomplete(session,
+                            file_symbol,
+                            &file_info,
+                            params.context,
+                            params.text_document_position.position.line,
+                            params.text_document_position.position.character
+                        ));
+                    },
                     _ => {}
-                }
-                if matches!(file_info.borrow_mut().file_info_ast.borrow().ast, Ast::PythonAst(_)) && file_info.borrow_mut().file_info_ast.borrow().ast.as_py_ast().indexed_module.is_some() {
-                    return Ok(CompletionFeature::autocomplete(session,
-                        file_symbol,
-                        &file_info,
-                        params.context,
-                        params.text_document_position.position.line,
-                        params.text_document_position.position.character
-                    ));
                 }
             }
         }

--- a/server/src/core/python_arch_builder.rs
+++ b/server/src/core/python_arch_builder.rs
@@ -15,6 +15,7 @@ use crate::constants::{
 };
 use crate::core::build_scheduler::BuildScheduler;
 use crate::core::evaluation::{Evaluation, EvaluationValue};
+use crate::core::file_mgr::Ast;
 use crate::core::import_resolver::resolve_import_stmt;
 use crate::core::python_arch_builder_hooks::PythonArchBuilderHooks;
 use crate::core::python_utils;
@@ -95,14 +96,15 @@ impl PythonArchBuilder {
         }
         let file_info = file_info_rc.borrow();
         let file_info_ast_rc = file_info.file_info_ast.clone();
-        let file_noqa =if self.file_mode {
+        let file_noqa = if self.file_mode {
              file_info.noqas_blocs.get(&0).cloned()
         } else {
             None
         };
         drop(file_info);
         let file_info_ast= file_info_ast_rc.borrow();
-        if let Some(indexed_module) = &file_info_ast.ast.as_py_ast().indexed_module {
+        if let Ast::PythonAst(py_ast) = &file_info_ast.ast {
+            let indexed_module = &py_ast.indexed_module;
             let ast = if self.file_mode {
                 file_info_ast.get_stmts().unwrap()
             } else {

--- a/server/src/core/python_arch_eval.rs
+++ b/server/src/core/python_arch_eval.rs
@@ -1,5 +1,6 @@
 use crate::core::build_scheduler::BuildScheduler;
 use crate::core::evaluation_utils::DeepFieldEvalWalker;
+use crate::core::file_mgr::Ast;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::vec;
@@ -79,7 +80,7 @@ impl PythonArchEval {
             ModuleSymbol::load_data(m, session);
             ModuleSymbol::load_assets(m, session);
         }
-        if file_info_ast.borrow().ast.as_py_ast().indexed_module.is_some() {
+        if matches!(file_info_ast.borrow().ast, Ast::PythonAst(_)) {
             let file_info_ast_bw  = file_info_ast.borrow();
             //  If the file has been re-parsed since, those indexes address another tree.
             if file_info_ast_bw.text_hash != session.st().get_processed_text_hash(self.file) {
@@ -97,7 +98,7 @@ impl PythonArchEval {
                         // Function has no body or is dynamically created from a hook
                         (Default::default(), None) // essentially skip evaluation
                     } else {
-                        let func_stmt = file_info_ast_bw.ast.as_py_ast().indexed_module.as_ref().unwrap().get_by_index(fun_index);
+                        let func_stmt = file_info_ast_bw.ast.as_py_ast().indexed_module.get_by_index(fun_index);
                         match func_stmt {
                             AnyRootNodeRef::Stmt(Stmt::FunctionDef(func_stmt)) => {
                                 (func_stmt.body.as_slice(), Some(func_stmt))

--- a/server/src/core/python_validator.rs
+++ b/server/src/core/python_validator.rs
@@ -8,6 +8,7 @@ use lsp_types::{Diagnostic, Position, Range};
 use crate::core::build_scheduler::BuildScheduler;
 use crate::core::diagnostics::{create_diagnostic, DiagnosticCode};
 use crate::core::evaluation_context::{ContextKey, ContextValue};
+use crate::core::file_mgr::Ast;
 use crate::core::symbols::storage::SymbolTable;
 use crate::core::symbols::storage::xml::xml_field_symbol::XmlFieldName;
 use crate::core::symbols::symbol_keys::{ClassKey, ModelSymbolKey, ModuleKey, PythonBuildableSymbolKey, SourceFileKey, SymbolKey};
@@ -83,7 +84,7 @@ impl PythonValidator {
                 let file_info_ast_rc = file_info.file_info_ast.clone();
                 let file_info_ast = file_info_ast_rc.borrow();
                 drop(file_info);
-                if file_info_ast.ast.as_py_ast().indexed_module.is_some() {
+                if let Ast::PythonAst(_) = &file_info_ast.ast {
                     let old_noqa = session.current_noqa.clone();
                     session.current_noqa = session.st().get_noqas(symbol);
                     self.validate_body(session, file_info_ast.get_stmts().as_ref().unwrap());
@@ -121,7 +122,8 @@ impl PythonValidator {
                 let file_info_ast_rc = file_info.file_info_ast.clone();
                 let file_info_ast = file_info_ast_rc.borrow();
                 drop(file_info);
-                if let Some(indexed_module) = &file_info_ast.ast.as_py_ast().indexed_module {
+                if let Ast::PythonAst(py_ast) = &file_info_ast.ast {
+                    let indexed_module = &py_ast.indexed_module;
                     let func_index = session.st()[f].node_index.load();
                     if func_index != NodeIndex::NONE {
                         let stmt = indexed_module.get_by_index(func_index);
@@ -171,17 +173,19 @@ impl PythonValidator {
                     if let Some(manifest_file) = session.sync_odoo.get_file_mgr().borrow().get_file_info(&manifest_path.sanitize_cow())
                         && !manifest_file.borrow().opened {
                             let manifest_file = manifest_file.borrow();
-                            manifest_file.file_info_ast.borrow_mut().ast.as_py_ast_mut().indexed_module = None;
-                            manifest_file.file_info_ast.borrow_mut().text_document = None;
-                            manifest_file.file_info_ast.borrow_mut().text_hash = 0;
+                            let mut fi_ast = manifest_file.file_info_ast.borrow_mut();
+                            fi_ast.ast = Ast::Pending;
+                            fi_ast.text_document = None;
+                            fi_ast.text_hash = 0;
                         }
                 }
                 if let Some(file) = self.file_info.as_ref()
                     && ! file.borrow().opened {
                         let f = file.borrow();
-                        f.file_info_ast.borrow_mut().ast.as_py_ast_mut().indexed_module = None;
-                        f.file_info_ast.borrow_mut().text_document = None;
-                        f.file_info_ast.borrow_mut().text_hash = 0;
+                        let mut fi_ast = f.file_info_ast.borrow_mut();
+                        fi_ast.ast = Ast::Pending;
+                        fi_ast.text_document = None;
+                        fi_ast.text_hash = 0;
                     }
             }
         }

--- a/server/src/core/symbols/manifest_create.rs
+++ b/server/src/core/symbols/manifest_create.rs
@@ -18,7 +18,7 @@ impl ModuleSymbol {
         }
         let (_, manifest_file_info) = session.sync_odoo.get_file_mgr().borrow_mut().update_file_info(session, &manifest_path.sanitize_cow(), None, None, false);
         let mut manifest_file_info = (*manifest_file_info).borrow_mut();
-        if manifest_file_info.file_info_ast.borrow().ast.as_py_ast().indexed_module.is_none() {
+        if !manifest_file_info.file_info_ast.borrow().ast.is_built() {
             return;
         }
         let diags = ModuleSymbol::load_manifest(session, module_key, &manifest_file_info);

--- a/server/src/core/symbols/storage/lifecycle.rs
+++ b/server/src/core/symbols/storage/lifecycle.rs
@@ -201,7 +201,7 @@ impl SymbolTable {
         Ok(xml_field_key)
     }
 
-    pub fn add_new_xml_template(&mut self, parent: XmlFileKey, name: Option<OYarn>, t_name: Option<OYarn>, range: TextRange, is_web: bool) -> XmlTemplateKey {
+    pub fn add_new_xml_template(&mut self, parent: XmlFileKey, name: Option<OYarn>, t_name: Option<(OYarn, TextRange)>, range: TextRange, is_web: bool) -> XmlTemplateKey {
         let is_external = self.is_external(parent.into());
         let xml_template_sym = XmlTemplateSymbol::new(name, t_name, range, parent.into(), is_web, is_external);
         let xml_template_key = self.xml_templates.insert(xml_template_sym);

--- a/server/src/core/symbols/storage/xml/xml_template_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_template_symbol.rs
@@ -9,10 +9,10 @@ pub struct XmlTemplateSymbol {
     pub is_web: bool,
     pub is_external: bool,
     pub range: TextRange,
-    /// (template_name, attribute_range) for each t-call found in this template body
+    /// (template_name, value_range) for each t-call found in this template body (quotes exclued)
     pub t_calls: Vec<(OYarn, TextRange)>,
-    /// (template_name, value_range) of the `t-inherit` this template extends, if any.
-    /// A template element carries at most one `t-inherit`. The range excludes the quotes.
+    /// (template_name, value_range) of the `t-inherit` this template extends, if any (quotes excluded).
+    /// A template element carries at most one `t-inherit`.
     pub t_inherit: Option<(OYarn, TextRange)>,
 
     parent: XmlDataParent,

--- a/server/src/core/symbols/storage/xml/xml_template_symbol.rs
+++ b/server/src/core/symbols/storage/xml/xml_template_symbol.rs
@@ -5,7 +5,8 @@ use crate::{constants::OYarn, core::symbols::storage::XmlDataParent};
 #[derive(Debug)]
 pub struct XmlTemplateSymbol {
     pub xml_id: Option<OYarn>,
-    pub t_name: Option<OYarn>,
+    /// (template_name, value_range) of `t-name`, if any (quotes excluded).
+    pub t_name: Option<(OYarn, TextRange)>,
     pub is_web: bool,
     pub is_external: bool,
     pub range: TextRange,
@@ -19,7 +20,7 @@ pub struct XmlTemplateSymbol {
 }
 
 impl XmlTemplateSymbol {
-    pub fn new(xml_id: Option<OYarn>, t_name: Option<OYarn>, range: TextRange, parent: XmlDataParent, is_web: bool, is_external: bool) -> Self {
+    pub fn new(xml_id: Option<OYarn>, t_name: Option<(OYarn, TextRange)>, range: TextRange, parent: XmlDataParent, is_web: bool, is_external: bool) -> Self {
         Self { xml_id, t_name, range, t_calls: vec![], t_inherit: None, parent, is_web, is_external }
     }
 

--- a/server/src/core/xml_arch_builder_rng_validation.rs
+++ b/server/src/core/xml_arch_builder_rng_validation.rs
@@ -509,9 +509,10 @@ impl XmlArchBuilder {
         for desc in node.descendants() {
             if !desc.is_element() { continue; }
             if let Some(attr) = desc.attribute_node("t-call") {
+                let r = attr.range_value();
                 result.push((
                     oyarn!("{}", attr.value()),
-                    TextRange::new(TextSize::new(attr.range().start as u32), TextSize::new(attr.range().end as u32))
+                    TextRange::new(TextSize::new(r.start as u32), TextSize::new(r.end as u32))
                 ));
             }
         }

--- a/server/src/core/xml_arch_builder_rng_validation.rs
+++ b/server/src/core/xml_arch_builder_rng_validation.rs
@@ -504,6 +504,15 @@ impl XmlArchBuilder {
         true
     }
 
+    fn collect_t_name(node: &Node) -> Option<(OYarn, TextRange)> {
+        let t_name_attr = node.attribute_node("t-name")?;
+        let r = t_name_attr.range_value();
+        Some((
+            oyarn!("{}", t_name_attr.value()),
+            TextRange::new(TextSize::new(r.start as u32), TextSize::new(r.end as u32)),
+        ))
+    }
+
     fn collect_t_calls(node: &Node) -> Vec<(OYarn, TextRange)> {
         let mut result = vec![];
         for desc in node.descendants() {
@@ -529,8 +538,7 @@ impl XmlArchBuilder {
     }
 
     fn load_qweb_template(&mut self, session: &mut SessionInfo, node: &Node, found_id: Option<String>, for_web: bool, diagnostics: &mut Vec<Diagnostic>) -> bool {
-        let found_t_name_node = node.attribute_node("t-name");
-        let found_t_name = found_t_name_node.map(|n| n.value().to_string());
+        let found_t_name = Self::collect_t_name(node);
         let found_inherit = node.attribute("t-inherit").is_some();
         if found_id.is_none() && found_t_name.is_none() && !found_inherit {
             return false;
@@ -538,7 +546,7 @@ impl XmlArchBuilder {
         let data = session.st_mut().add_new_xml_template(
             self.xml_symbol,
             found_id.as_ref().map(|id| oyarn!("{}", id)),
-            found_t_name.as_ref().map(|t_name| oyarn!("{}", t_name)),
+            found_t_name.clone(),
             TextRange::new(TextSize::new(node.range().start as u32), TextSize::new(node.range().end as u32)),
             for_web
         );
@@ -550,16 +558,17 @@ impl XmlArchBuilder {
         if let Some(t_inherit) = Self::collect_t_inherit(node) {
             session.st_mut()[data].t_inherit = Some(t_inherit);
         }
-        if let Some(found_t_name_node) = found_t_name_node && let Some(found_t_name) = &found_t_name
-            && !found_t_name.contains(".")
+        if let Some((t_name, range)) = &found_t_name
+            && !t_name.contains(".")
             && let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS05071, &[])
         {
             diagnostics.push(Diagnostic {
-                range: Range { start: Position::new(found_t_name_node.range().start as u32, 0), end: Position::new(found_t_name_node.range().end as u32, 0) },
-                ..diagnostic.clone()
+                range: Range { start: Position::new(range.start().into(), 0), end: Position::new(range.end().into(), 0) },
+                ..diagnostic
             });
         }
-        self.on_operation_creation(session, found_id, found_t_name, node, data.into(), diagnostics);
+        let t_name_string = found_t_name.map(|(t_name, _)| t_name.to_string());
+        self.on_operation_creation(session, found_id, t_name_string, node, data.into(), diagnostics);
         true
     }
 

--- a/server/src/features/declaration.rs
+++ b/server/src/features/declaration.rs
@@ -20,6 +20,7 @@ impl DeclarationFeature {
     ) -> Option<GotoDeclarationResponse> {
         let ast_type = file_info.borrow().file_info_ast.borrow().ast.clone();
         let definitions_sources = match ast_type {
+            Ast::Pending => return None,
             Ast::PythonAst(_) => GotoUtils::get_symbols(session, GotoRequest::Declaration, file_symbol, file_info, line, character),
             Ast::XmlAst => GotoUtils::get_symbols_xml(session, file_symbol, file_info, line, character),
             Ast::CsvAst => GotoUtils::get_symbols_csv(session, file_symbol, file_info, line, character),

--- a/server/src/features/definition.rs
+++ b/server/src/features/definition.rs
@@ -23,6 +23,7 @@ impl DefinitionFeature {
     ) -> Option<GotoDefinitionResponse> {
         let ast_type = file_info.borrow().file_info_ast.borrow().ast.clone();
         let definitions_sources = match ast_type {
+            Ast::Pending => return None,
             Ast::PythonAst(_) => GotoUtils::get_symbols(session, GotoRequest::Definition, file_symbol, file_info, line, character),
             Ast::XmlAst => GotoUtils::get_symbols_xml(session, file_symbol, file_info, line, character),
             Ast::CsvAst => GotoUtils::get_symbols_csv(session, file_symbol, file_info, line, character),

--- a/server/src/features/js_references.rs
+++ b/server/src/features/js_references.rs
@@ -136,10 +136,11 @@ fn declaring_js_files(files: impl IntoIterator<Item = String>) -> Vec<String> {
     out
 }
 
-/// Build and stage (not commit) the virtual docs of every transitive subclass of a
-/// component defined in `anchor_files`, so a references query on the real member also sees
-/// inherited template uses. Anchoring at the *declaring* file reaches the cousin case
-/// (member in ancestor `A`, cursor in `B`, use in sibling subclass `C`'s template).
+/// Build and stage (not commit) the virtual docs of every component defined in `anchor_files`
+/// and of its transitive subclasses, so a references query on the real member also sees the
+/// declaring component's own template uses and the inherited ones. Anchoring at the
+/// *declaring* file reaches the cousin case (member in ancestor `A`, cursor in `B`, use in
+/// sibling subclass `C`'s template).
 fn stage_subclass_docs(session: &mut SessionInfo, anchor_files: &[String]) -> Vec<InheritedDoc> {
     let anchor_classes: Vec<String> = session
         .sync_odoo
@@ -154,8 +155,9 @@ fn stage_subclass_docs(session: &mut SessionInfo, anchor_files: &[String]) -> Ve
     let super_of = build_super_of(session);
     let subclasses = collect_subclasses(&super_of, &anchor_classes);
 
-    // Distinct `.js` files defining those subclasses (one file may define several).
-    let mut sub_paths: Vec<String> = vec![];
+    // The anchors' own templates plus the distinct `.js` files defining those subclasses (one
+    // file may define several).
+    let mut sub_paths: Vec<String> = anchor_files.to_vec();
     for class in &subclasses {
         if let Some(desc) = session.sync_odoo.component_descriptors.get(class)
             && !sub_paths.contains(&desc.file_path)

--- a/server/src/features/references.rs
+++ b/server/src/features/references.rs
@@ -334,8 +334,6 @@ impl ReferenceFeature {
             let XmlDataParent::XmlFile(xml_file) = tmpl.parent() else { continue; };
             for (name, range) in tmpl.t_calls.iter() {
                 if name.as_str() == template_name {
-                    // `t_calls` stores the whole-attribute range, `t_inherit` the value-only
-                    // range; both are acceptable highlights.
                     xml_hits.push((xml_file, *range));
                 }
             }

--- a/server/src/features/references.rs
+++ b/server/src/features/references.rs
@@ -66,6 +66,7 @@ impl ReferenceFeature {
         //We want to search for references of the definition, and not the current symbol. Let's use definition feature for that
         BuildScheduler::process_rebuilds(session, false);
         let def_sources = match file_info.borrow().file_info_ast.borrow().ast {
+            Ast::Pending => return None,
             Ast::PythonAst(_) => {
                 GotoUtils::get_symbols(session, GotoRequest::Definition, file_symbol, file_info, line, character)
             },

--- a/server/src/features/references.rs
+++ b/server/src/features/references.rs
@@ -316,9 +316,9 @@ impl ReferenceFeature {
         after_start && before_end
     }
 
-    /// Collect every reference to an OWL/QWeb template *name*: JS `static template` sites,
-    /// XML `t-call` / `t-inherit` sites. Dynamic `t-call="{{…}}"` values never string-equal
-    /// a literal name; the `<t t-name>` declaration itself is the target, not a reference.
+    /// Collect every reference to an OWL/QWeb template *name*: the `<t t-name>` declaration,
+    /// JS `static template` sites, XML `t-call` / `t-inherit` sites. Dynamic `t-call="{{…}}"`
+    /// values never string-equal a literal name.
     fn collect_template_name_references(session: &mut SessionInfo, template_name: &str) -> Vec<Location> {
         let encoding = session.sync_odoo.encoding;
         let mut locations = Vec::new();
@@ -332,6 +332,9 @@ impl ReferenceFeature {
         // `iter_xml_templates` method and use the index here.
         for (_key, tmpl) in session.st().iter_xml_templates() {
             let XmlDataParent::XmlFile(xml_file) = tmpl.parent() else { continue; };
+            if let Some((name, range)) = tmpl.t_name.as_ref() && name == template_name {
+                xml_hits.push((xml_file, *range));
+            }
             for (name, range) in tmpl.t_calls.iter() {
                 if name.as_str() == template_name {
                     xml_hits.push((xml_file, *range));

--- a/server/tests/data/addons/module_owl/__manifest__.py
+++ b/server/tests/data/addons/module_owl/__manifest__.py
@@ -9,6 +9,7 @@
             'module_owl/static/src/greeting/greeting.js',
             'module_owl/static/src/greeting/greeting.xml',
             'module_owl/static/src/greeting/greeting_ext.xml',
+            'module_owl/static/src/greeting/utils.js',
             'module_owl/static/src/greeting/greeting_report.js',
             'module_owl/static/src/greeting/loud_greeting.js',
             'module_owl/static/src/greeting/loud_greeting.xml',

--- a/server/tests/data/addons/module_owl/__manifest__.py
+++ b/server/tests/data/addons/module_owl/__manifest__.py
@@ -6,6 +6,13 @@
         'web.assets_backend': [
             'module_owl/static/src/counter/counter.js',
             'module_owl/static/src/counter/counter.xml',
+            'module_owl/static/src/greeting/greeting.js',
+            'module_owl/static/src/greeting/greeting.xml',
+            'module_owl/static/src/greeting/greeting_ext.xml',
+            'module_owl/static/src/greeting/greeting_report.js',
+            'module_owl/static/src/greeting/loud_greeting.js',
+            'module_owl/static/src/greeting/loud_greeting.xml',
+            'module_owl/static/src/greeting/quiet_greeting.js',
         ],
     },
     'installable': True,

--- a/server/tests/data/addons/module_owl/static/src/greeting/greeting.js
+++ b/server/tests/data/addons/module_owl/static/src/greeting/greeting.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+import { Component, props, t } from "@odoo/owl";
+import { clamp } from "@web/core/utils/numbers";
+import { capitalize } from "@web/core/utils/strings";
+
+export class Greeting extends Component {
+    static template = "module_owl.Greeting";
+
+    props = props({
+        name: t.string(),
+        exclamations: t.number().optional(1),
+    });
+
+    separator = ", ";
+
+    setup() {
+        this.punctuation = "!";
+    }
+
+    get title() {
+        return capitalize(this.props.name);
+    }
+
+    /** Repeats the punctuation, clamped to a sane length. */
+    shout(count) {
+        return this.punctuation.repeat(clamp(count, 1, 5));
+    }
+
+    onClick() {
+        this.punctuation = "?";
+    }
+}

--- a/server/tests/data/addons/module_owl/static/src/greeting/greeting.xml
+++ b/server/tests/data/addons/module_owl/static/src/greeting/greeting.xml
@@ -1,0 +1,11 @@
+<templates>
+    <t t-name="module_owl.Greeting">
+        <div class="o_greeting" t-on-click="() => this.onClick()">
+            <span t-out="this.title"/>
+            <span t-out="this.props.name"/>
+            <span t-out="this.separator"/>
+            <span t-out="this.punctuation"/>
+            <span t-out="this.shout(this.props.exclamations)"/>
+        </div>
+    </t>
+</templates>

--- a/server/tests/data/addons/module_owl/static/src/greeting/greeting_ext.xml
+++ b/server/tests/data/addons/module_owl/static/src/greeting/greeting_ext.xml
@@ -1,0 +1,12 @@
+<templates>
+    <t t-name="module_owl.GreetingCall">
+        <div class="o_greeting_call">
+            <t t-call="module_owl.Greeting"/>
+        </div>
+    </t>
+    <t t-name="module_owl.GreetingExt" t-inherit="module_owl.Greeting" t-inherit-mode="primary">
+        <xpath expr="//span" position="after">
+            <span class="o_greeting_ext"/>
+        </xpath>
+    </t>
+</templates>

--- a/server/tests/data/addons/module_owl/static/src/greeting/greeting_report.js
+++ b/server/tests/data/addons/module_owl/static/src/greeting/greeting_report.js
@@ -5,3 +5,7 @@ import { Greeting } from "./greeting";
 export function announce(greeting) {
     return greeting.shout(2) + greeting.separator;
 }
+
+export function final_answer() {
+    return 42;
+}

--- a/server/tests/data/addons/module_owl/static/src/greeting/greeting_report.js
+++ b/server/tests/data/addons/module_owl/static/src/greeting/greeting_report.js
@@ -1,0 +1,7 @@
+/** @odoo-module **/
+import { Greeting } from "./greeting";
+
+/** @param {Greeting} greeting */
+export function announce(greeting) {
+    return greeting.shout(2) + greeting.separator;
+}

--- a/server/tests/data/addons/module_owl/static/src/greeting/loud_greeting.js
+++ b/server/tests/data/addons/module_owl/static/src/greeting/loud_greeting.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+import { Greeting } from "./greeting";
+
+export class LoudGreeting extends Greeting {
+    static template = "module_owl.LoudGreeting";
+
+    volume = 3;
+
+    banner() {
+        return this.separator.repeat(this.volume);
+    }
+}

--- a/server/tests/data/addons/module_owl/static/src/greeting/loud_greeting.xml
+++ b/server/tests/data/addons/module_owl/static/src/greeting/loud_greeting.xml
@@ -1,0 +1,10 @@
+<templates>
+    <t t-name="module_owl.LoudGreeting">
+        <div class="o_loud_greeting">
+            <span t-out="this.title"/>
+            <span t-out="this.punctuation"/>
+            <span t-out="this.props.name"/>
+            <span t-out="this.shout(this.volume)"/>
+        </div>
+    </t>
+</templates>

--- a/server/tests/data/addons/module_owl/static/src/greeting/quiet_greeting.js
+++ b/server/tests/data/addons/module_owl/static/src/greeting/quiet_greeting.js
@@ -1,0 +1,8 @@
+/** @odoo-module **/
+import { Greeting } from "./greeting";
+
+export class QuietGreeting extends Greeting {
+    mute() {
+        return this.shout(1);
+    }
+}

--- a/server/tests/data/addons/module_owl/static/src/greeting/utils.js
+++ b/server/tests/data/addons/module_owl/static/src/greeting/utils.js
@@ -1,0 +1,8 @@
+import { final_answer } from "./greeting_report";
+
+const half_answer = 21;
+
+export function answer_is_correct(answer) {
+    if (answer < half_answer) return false;
+    return answer === final_answer();
+}

--- a/server/tests/js_owl_helpers/asserts.rs
+++ b/server/tests/js_owl_helpers/asserts.rs
@@ -1,0 +1,73 @@
+use lsp_types::{
+    CompletionItem, CompletionItemKind,
+};
+use odoo_ls_server::threads::SessionInfo;
+
+use crate::js_owl_helpers::requests::*;
+
+use super::fixture::FixtureFile;
+
+/// Assert the hover at the caret contains `expected`. Only the `name: type` half of tsserver's
+/// output is worth asserting: the `(property)` / `(getter)` prefix moves between TS versions.
+pub fn assert_hover(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, expected: &str) {
+    let hover = hover(session, file, snippet);
+    assert!(
+        hover.contains(expected),
+        "hover at {snippet:?} is {hover:?}, expected it to contain {expected:?}"
+    );
+}
+
+/// Assert the definition at the caret lands in `target`, on the line holding `target_snippet`.
+pub fn assert_definition(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, target: &FixtureFile, target_snippet: &str) {
+    let expected = (target.path.clone(), target.caret(target_snippet).line);
+    let found = definitions(session, file, snippet);
+    assert!(
+        found.contains(&expected),
+        "definition of {snippet:?} is {found:?}, expected {expected:?} ({target_snippet:?})"
+    );
+}
+
+/// Assert the definition at the caret lands in a file whose path ends with `path_suffix`.
+pub fn assert_definition_in(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, path_suffix: &str) {
+    let found = definitions(session, file, snippet);
+    assert!(
+        found.iter().any(|(path, _)| path.ends_with(path_suffix)),
+        "definition of {snippet:?} is {found:?}, expected a target in {path_suffix:?}"
+    );
+}
+
+/// Assert one completion request at the caret offers every `(label, kind)`. The kind matters as
+/// much as the label: clients render `TEXT` as a plain word suggestion, so a symbol whose kind
+/// went unmapped looks like editor noise.
+pub fn assert_completions(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, expected: &[(&str, CompletionItemKind)]) {
+    let items = completions(session, file, snippet);
+    for (label, kind) in expected {
+        let item = items.iter().find(|item| item.label == *label).unwrap_or_else(|| panic!(
+            "no completion {label:?} at {snippet:?} in {}", file.path
+        ));
+        assert_eq!(item.kind, Some(*kind), "kind of completion {label:?} at {snippet:?}");
+    }
+}
+
+/// Assert the references at the caret are exactly `expected`, each given as a caret snippet in the
+/// fixture holding it.
+pub fn assert_references(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, expected: &[(&FixtureFile, &str)]) {
+    let mut expected: Vec<(String, u32, u32)> = expected.iter().map(|(target, target_snippet)| {
+        let position = target.caret(target_snippet);
+        (target.path.clone(), position.line, position.character)
+    }).collect();
+    expected.sort();
+    let mut found = references(session, file, snippet);
+    found.sort();
+    assert_eq!(found, expected, "references of {snippet:?} in {}", file.path);
+}
+
+/// Assert the `detail` field of a completion item contains `expected`.
+pub fn assert_detail(item: &CompletionItem, expected: &str) {
+    let detail = item.detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains(expected),
+        "detail of completion {:?} is {detail:?}, expected it to contain {expected:?}",
+        item.label
+    );
+}

--- a/server/tests/js_owl_helpers/fixture.rs
+++ b/server/tests/js_owl_helpers/fixture.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+
+use lsp_types::{
+    Position,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Uri,
+};
+use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::Odoo;
+use odoo_ls_server::threads::SessionInfo;
+use odoo_ls_server::utils::PathSanitizer;
+
+pub struct Fixtures {
+    // Opened fixtures: the test opens them, so tsserver holds them as roots
+    /// greeting.js, home of Greeting component
+    pub js: FixtureFile,
+    /// greeting.xml, home of Greeting template
+    pub xml: FixtureFile,
+    /// loud_greeting.js, home of LoudGreeting component, which extends Greeting
+    pub sub_js: FixtureFile,
+    /// loud_greeting.xml, home of LoudGreeting template
+    pub sub_xml: FixtureFile,
+    
+    // Unopened fixtures: the test never opens them, so they are never a tsserver root of their own.
+    /// unopened: quiet_greeting.js, home of QuietGreeting component, which extends Greeting
+    pub quiet_js: FixtureFile,
+    /// unopened: greeting_report.js, no component, imports Greeting
+    pub report_js: FixtureFile,
+    /// unopened: greeting_ext.xml, templates that t-calls and t-inherits Greeting template
+    pub ext_xml: FixtureFile,
+}
+
+impl Fixtures {
+    pub fn init(session: &mut SessionInfo) -> Self {
+        let js = FixtureFile::open(session, &["greeting", "greeting.js"]);
+        let xml = FixtureFile::open(session, &["greeting", "greeting.xml"]);
+        let sub_js = FixtureFile::open(session, &["greeting", "loud_greeting.js"]);
+        let sub_xml = FixtureFile::open(session, &["greeting", "loud_greeting.xml"]);
+        let quiet_js = FixtureFile::unopened(&["greeting", "quiet_greeting.js"]);
+        let report_js = FixtureFile::unopened(&["greeting", "greeting_report.js"]);
+        let ext_xml = FixtureFile::unopened(&["greeting", "greeting_ext.xml"]);
+        Fixtures { js, xml, sub_js, sub_xml, quiet_js, report_js, ext_xml }
+    }
+}
+
+
+/// A fixture file of `module_owl`
+pub struct FixtureFile {
+    pub path: String,
+    uri: Uri,
+    content: String,
+}
+
+impl FixtureFile {
+    /// `didOpen` the file the way a client would: tsserver then holds its content and pins it
+    /// as a project root
+    fn open(session: &mut SessionInfo, relative: &[&str]) -> Self {
+        let fixture = FixtureFile::unopened(relative);
+        let language_id = if fixture.path.ends_with(".xml") { "xml" } else { "javascript" };
+        Odoo::handle_did_open(session, lsp_types::DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: fixture.uri.clone(),
+                language_id: language_id.to_string(),
+                version: 1,
+                text: fixture.content.clone(),
+            },
+        });
+        fixture
+    }
+
+    /// A fixture the test never opens, so it is never a tsserver root of its own: only the
+    /// reference-root expansion can reach it.
+    fn unopened(relative: &[&str]) -> Self {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests").join("data").join("addons").join("module_owl").join("static").join("src");
+        for part in relative {
+            path = path.join(part);
+        }
+        let path = path.sanitize();
+        let content = std::fs::read_to_string(&path).expect("fixture file should be readable");
+        let uri = FileMgr::pathname2uri(&path);
+        FixtureFile { path, uri, content }
+    }
+
+    /// Position of the `|` caret in `snippet`, which must occur exactly once in the file.
+    pub fn caret(&self, snippet: &str) -> Position {
+        let caret = snippet.find('|').expect("snippet should carry a `|` caret");
+        let text = snippet.replace('|', "");
+        let mut occurrences = self.content.match_indices(&text);
+        let Some((start, _)) = occurrences.next() else {
+            panic!("{snippet:?} not found in {}", self.path)
+        };
+        assert!(
+            occurrences.next().is_none(),
+            "{snippet:?} occurs more than once in {}",
+            self.path
+        );
+        // `text[..caret]` is `snippet[..caret]` byte for byte, so the caret offset carries over.
+        let offset = start + caret;
+        let line_start = self.content[..offset].rfind('\n').map_or(0, |nl| nl + 1);
+        Position::new(
+            self.content[..offset].matches('\n').count() as u32,
+            self.content[line_start..offset].encode_utf16().count() as u32,
+        )
+    }
+
+    pub fn position_params(&self, snippet: &str) -> TextDocumentPositionParams {
+        TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: self.uri.clone() },
+            position: self.caret(snippet),
+        }
+    }
+}

--- a/server/tests/js_owl_helpers/fixture.rs
+++ b/server/tests/js_owl_helpers/fixture.rs
@@ -19,6 +19,8 @@ pub struct Fixtures {
     pub sub_js: FixtureFile,
     /// loud_greeting.xml, home of LoudGreeting template
     pub sub_xml: FixtureFile,
+    /// utils.js, no component, imports from report_js
+    pub js_utils: FixtureFile,
     
     // Unopened fixtures: the test never opens them, so they are never a tsserver root of their own.
     /// unopened: quiet_greeting.js, home of QuietGreeting component, which extends Greeting
@@ -35,10 +37,11 @@ impl Fixtures {
         let xml = FixtureFile::open(session, &["greeting", "greeting.xml"]);
         let sub_js = FixtureFile::open(session, &["greeting", "loud_greeting.js"]);
         let sub_xml = FixtureFile::open(session, &["greeting", "loud_greeting.xml"]);
+        let js_utils =  FixtureFile::open(session, &["greeting", "utils.js"]);
         let quiet_js = FixtureFile::unopened(&["greeting", "quiet_greeting.js"]);
         let report_js = FixtureFile::unopened(&["greeting", "greeting_report.js"]);
         let ext_xml = FixtureFile::unopened(&["greeting", "greeting_ext.xml"]);
-        Fixtures { js, xml, sub_js, sub_xml, quiet_js, report_js, ext_xml }
+        Fixtures { js, xml, sub_js, sub_xml, js_utils, quiet_js, report_js, ext_xml }
     }
 }
 

--- a/server/tests/js_owl_helpers/mod.rs
+++ b/server/tests/js_owl_helpers/mod.rs
@@ -1,0 +1,3 @@
+pub mod fixture;
+pub mod requests;
+pub mod asserts;

--- a/server/tests/js_owl_helpers/requests.rs
+++ b/server/tests/js_owl_helpers/requests.rs
@@ -1,0 +1,106 @@
+use lsp_types::{
+    CompletionItem, CompletionParams, CompletionResponse, GotoDefinitionParams,
+    GotoDefinitionResponse, HoverContents, HoverParams, ReferenceContext, ReferenceParams,
+};
+use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::Odoo;
+use odoo_ls_server::threads::SessionInfo;
+
+use super::fixture::FixtureFile;
+
+/// The hover contents at the caret.
+pub fn hover(session: &mut SessionInfo, file: &FixtureFile, snippet: &str) -> String {
+    let params = HoverParams {
+        text_document_position_params: file.position_params(snippet),
+        work_done_progress_params: Default::default(),
+    };
+    let hover = Odoo::handle_hover(session, params)
+        .expect("hover request failed")
+        .unwrap_or_else(|| panic!("no hover at {snippet:?} in {}", file.path));
+    match hover.contents {
+        HoverContents::Markup(markup) => markup.value,
+        contents => panic!("unexpected hover contents at {snippet:?}: {contents:?}"),
+    }
+}
+
+/// Definition targets at the caret, as `(path, start line)`.
+pub fn definitions(session: &mut SessionInfo, file: &FixtureFile, snippet: &str) -> Vec<(String, u32)> {
+    let params = GotoDefinitionParams {
+        text_document_position_params: file.position_params(snippet),
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let response = Odoo::handle_goto_definition(session, params)
+        .expect("definition request failed")
+        .unwrap_or_else(|| panic!("no definition at {snippet:?} in {}", file.path));
+    let targets = match response {
+        GotoDefinitionResponse::Scalar(location) => vec![(location.uri, location.range)],
+        GotoDefinitionResponse::Array(locations) => {
+            locations.into_iter().map(|l| (l.uri, l.range)).collect()
+        }
+        GotoDefinitionResponse::Link(links) => {
+            links.into_iter().map(|l| (l.target_uri, l.target_range)).collect()
+        }
+    };
+    targets
+        .into_iter()
+        .map(|(uri, range)| (FileMgr::uri2pathname(uri.as_str()), range.start.line))
+        .collect()
+}
+
+/// The items offered at the caret.
+pub fn completions(session: &mut SessionInfo, file: &FixtureFile, snippet: &str) -> Vec<CompletionItem> {
+    let params = CompletionParams {
+        text_document_position: file.position_params(snippet),
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+        context: None,
+    };
+    let response = Odoo::handle_autocomplete(session, params)
+        .expect("completion request failed")
+        .unwrap_or_else(|| panic!("no completion at {snippet:?} in {}", file.path));
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+}
+
+/// The item labelled `label` at the caret, after the `completionItem/resolve` round trip a client
+/// makes on the item it highlights.
+pub fn resolved_completion(session: &mut SessionInfo, file: &FixtureFile, snippet: &str, label: &str) -> CompletionItem {
+    let item = completions(session, file, snippet).into_iter().find(|item| item.label == label)
+        .unwrap_or_else(|| panic!("no completion {label:?} at {snippet:?} in {}", file.path));
+    Odoo::handle_completion_resolve(session, item).expect("completion resolve failed")
+}
+
+
+
+/// Reference locations at the caret, as `(path, start line, start character)`.
+/// Two invariants hold of every reference set, so they are checked here instead
+/// of case by case: no location may point into an OWL virtual doc or shim,
+/// which the client would fail to open, and none may repeat
+pub fn references(session: &mut SessionInfo, file: &FixtureFile, snippet: &str) -> Vec<(String, u32, u32)> {
+    let params = ReferenceParams {
+        text_document_position: file.position_params(snippet),
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+        context: ReferenceContext { include_declaration: true },
+    };
+    let locations = Odoo::handle_references(session, params)
+        .expect("references request failed")
+        .unwrap_or_else(|| panic!("no references at {snippet:?} in {}", file.path));
+    let found: Vec<(String, u32, u32)> = locations.into_iter()
+        .map(|l| (FileMgr::uri2pathname(l.uri.as_str()), l.range.start.line, l.range.start.character))
+        .collect();
+    for (path, ..) in found.iter() {
+        assert!(
+            !path.contains("__ols_owl__") && !path.contains("__ols_shim__"),
+            "references at {snippet:?} leaked the internal path {path:?}"
+        );
+    }
+    let mut deduped = found.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(deduped.len(), found.len(), "references at {snippet:?} repeat a location: {found:?}");
+    found
+}

--- a/server/tests/setup/setup.rs
+++ b/server/tests/setup/setup.rs
@@ -13,7 +13,7 @@ use lsp_types::notification::{Notification, PublishDiagnostics};
 use odoo_ls_server::S;
 use odoo_ls_server::core::file_mgr::FileMgr;
 use odoo_ls_server::utils::get_python_command;
-use odoo_ls_server::{core::{config::{ConfigKey, ConfigEntry}, entry_point::EntryPointMgr, odoo::SyncOdoo}, threads::SessionInfo, utils::PathSanitizer as _};
+use odoo_ls_server::{core::{config::{ConfigKey, ConfigEntry}, entry_point::EntryPointMgr, odoo::SyncOdoo}, threads::{SessionInfo, ThreadMessage}, utils::PathSanitizer as _};
 
 use tracing::{info, level_filters::LevelFilter};
 use tracing_appender::rolling::RollingFileAppender;
@@ -70,6 +70,19 @@ pub fn create_init_session<'a>(odoo: &'a mut SyncOdoo, config: ConfigEntry) -> S
     session.sync_odoo.test_mode = true;
     SyncOdoo::init(&mut session, config);
     session
+}
+
+/// Same as [`create_init_session`], but with the channel to the main thread the tsserver bridge
+/// needs: `SyncOdoo::init` only starts tsserver when the session can send to it. The returned
+/// receiver carries the diagnostics tsserver pushes; keep it alive for as long as the session,
+/// since dropping it makes the bridge's reader thread fail on every send.
+pub fn create_init_session_with_tsserver<'a>(odoo: &'a mut SyncOdoo, config: ConfigEntry) -> (SessionInfo<'a>, crossbeam_channel::Receiver<ThreadMessage>) {
+    let (s, r) = crossbeam_channel::unbounded();
+    let (sender_to_main, receiver_from_threads) = crossbeam_channel::unbounded();
+    let mut session = SessionInfo::new_from_custom_channel(s.clone(), r.clone(), Some(sender_to_main), odoo);
+    session.sync_odoo.test_mode = true;
+    SyncOdoo::init(&mut session, config);
+    (session, receiver_from_threads)
 }
 
 pub fn prepare_custom_entry_point(session: &mut SessionInfo, path: &str){

--- a/server/tests/test_js_owl_features.rs
+++ b/server/tests/test_js_owl_features.rs
@@ -45,4 +45,234 @@ fn test_js_owl_features() {
         "tsserver did not start with TSSERVER={tsserver_command:?}"
     );
 
+    let fixtures = Fixtures::init(&mut session);
+
+    // Hover
+    test_hover_in_js(&mut session, &fixtures);
+    test_hover_in_template(&mut session, &fixtures);
+    test_hover_in_subclass_template(&mut session, &fixtures);
+
+    // Definition
+    test_definition_in_js(&mut session, &fixtures);
+    test_definition_in_template(&mut session, &fixtures);
+    test_definition_in_subclass_template(&mut session, &fixtures);
+    test_definition_for_template(&mut session, &fixtures);
+    test_definition_for_template_jump_to_component(&mut session, &fixtures);
+
+    // Completion
+    test_completion_in_js(&mut session, &fixtures);
+    test_completion_in_template(&mut session, &fixtures);
+    test_completion_resolve(&mut session, &fixtures);
+
+    // References
+    test_references_from_declaration(&mut session, &fixtures);
+    test_references_with_unopened_files(&mut session, &fixtures);
+    test_references_from_usage(&mut session, &fixtures);
+    test_references_to_template(&mut session, &fixtures);
+}
+
+/// Hover in the component's own `.js`: a class field, a member assigned in `setup()` (which only
+/// resolves because we hand tsserver `.js`, not `.ts`), a prop, and a helper imported from `web`.
+fn test_hover_in_js(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, .. } = fixtures;
+    assert_hover(session, js, "|separator = \", \"", "separator: string");
+    assert_hover(session, js, "this.|punctuation.repeat", "punctuation: string");
+    assert_hover(session, js, "capitalize(this.props.|name)", "name: string");
+    assert_hover(session, js, "return |capitalize(", "capitalize(str: string): string");
+}
+
+/// Hover in the template, where every expression is typed through the component's virtual doc.
+fn test_hover_in_template(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { xml, .. } = fixtures;
+    assert_hover(session, xml, "t-out=\"this.props.|name\"", "name: string");
+    assert_hover(session, xml, "t-out=\"this.|title\"", "title: string");
+    assert_hover(session, xml, "t-out=\"this.|separator\"", "separator: string");
+    assert_hover(session, xml, "t-out=\"this.|punctuation\"", "punctuation: string");
+    assert_hover(session, xml, "this.|shout(", "shout(count: any): string");
+    assert_hover(session, xml, "this.shout(this.props.|exclamations)", "exclamations: number");
+    assert_hover(session, xml, "t-out=\"th|is.title\"", "this: Greeting");
+}
+
+/// Hover in a subclass' template, on members inherited from a base component in another file.
+fn test_hover_in_subclass_template(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { sub_xml, .. } = fixtures;
+    assert_hover(session, sub_xml, "t-out=\"this.|title\"", "title: string");
+    assert_hover(session, sub_xml, "t-out=\"this.|punctuation\"", "punctuation: string");
+    assert_hover(session, sub_xml, "t-out=\"this.props.|name\"", "name: string");
+    assert_hover(session, sub_xml, "this.|shout(", "shout(count: any): string");
+    assert_hover(session, sub_xml, "this.shout(this.|volume)", "volume: number");
+    assert_hover(session, sub_xml, "t-out=\"th|is.title\"", "this: LoudGreeting");
+}
+
+/// Definition in the `.js`: imports resolved through the `@web/*` alias map
+fn test_definition_in_js(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, .. } = fixtures;
+    assert_definition_in(session, js, "import { |capitalize }", "web/static/src/core/utils/strings.js");
+    assert_definition_in(session, js, "|clamp(count, 1, 5)", "web/static/src/core/utils/numbers.js");
+}
+
+/// Definition from a template expression back into the component `.js`.
+fn test_definition_in_template(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, xml, .. } = fixtures;
+    assert_definition(session, xml, "t-out=\"this.|title\"", js, "get |title()");
+    assert_definition(session, xml, "t-out=\"this.|separator\"", js, "|separator = \", \"");
+    assert_definition(session, xml, "t-out=\"this.|punctuation\"", js, "this.|punctuation = \"!\"");
+    assert_definition(session, xml, "this.|shout(", js, "|shout(count)");
+    assert_definition(session, xml, "() => this.|onClick()", js, "|onClick() {");
+    // A bare `this` is asked as a *type* definition: `@this` types it but declares nothing.
+    assert_definition(session, xml, "t-out=\"th|is.title\"", js, "export class |Greeting");
+}
+
+/// Definition from a subclass' template: inherited members land in the base component's file,
+/// the subclass' own in its own.
+fn test_definition_in_subclass_template(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, sub_js, sub_xml, .. } = fixtures;
+    assert_definition(session, sub_xml, "t-out=\"this.|title\"", js, "get |title()");
+    assert_definition(session, sub_xml, "t-out=\"this.|punctuation\"", js, "this.|punctuation = \"!\"");
+    assert_definition(session, sub_xml, "this.|shout(", js, "|shout(count)");
+    assert_definition(session, sub_xml, "this.shout(this.|volume)", sub_js, "|volume = 3");
+    assert_definition(session, sub_xml, "t-out=\"th|is.title\"", sub_js, "export class |LoudGreeting");
+}
+
+/// `static template` → `<t t-name>` jump
+/// t-call / t-inherit → `<t t-name>` jump
+fn test_definition_for_template(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, xml, ext_xml, .. } = fixtures;
+    let target_snippet = "|<t t-name=\"module_owl.Greeting\">";
+    assert_definition(session, js, "static template = \"|module_owl.Greeting\"", xml, target_snippet);
+    assert_definition(session, ext_xml, "t-call=\"|module_owl.Greeting\"", xml, target_snippet);
+    assert_definition(session, ext_xml, "t-inherit=\"|module_owl.Greeting\"", xml, target_snippet);
+}
+
+/// Non-LSP behavior: asking for definition of a template at its definition site
+/// leads to the matching component
+fn test_definition_for_template_jump_to_component(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, xml , .. } = fixtures;
+    assert_definition(session, xml, "<t t-name=\"|module_owl.Greeting\">", js, "export class |Greeting extends Component");
+}
+
+/// Completion after `this.` and `this.props.` in the component's own `.js`.
+fn test_completion_in_js(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, .. } = fixtures;
+    assert_completions(session, js, "this.|punctuation.repeat", &[
+        ("separator", CompletionItemKind::PROPERTY),
+        ("punctuation", CompletionItemKind::PROPERTY),
+        ("title", CompletionItemKind::PROPERTY),
+        ("shout", CompletionItemKind::METHOD),
+        ("onClick", CompletionItemKind::METHOD),
+    ]);
+    assert_completions(session, js, "capitalize(this.props.|name)", &[
+        ("name", CompletionItemKind::PROPERTY),
+        ("exclamations", CompletionItemKind::PROPERTY),
+    ]);
+}
+
+/// Completion inside template expressions, including the members a subclass inherits
+fn test_completion_in_template(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { xml, sub_xml, .. } = fixtures;
+    assert_completions(session, xml, "t-out=\"this.|title\"", &[
+        ("separator", CompletionItemKind::PROPERTY),
+        ("punctuation", CompletionItemKind::PROPERTY),
+        ("title", CompletionItemKind::PROPERTY),
+        ("shout", CompletionItemKind::METHOD),
+    ]);
+    assert_completions(session, xml, "t-out=\"this.props.|name\"", &[
+        ("name", CompletionItemKind::PROPERTY),
+        ("exclamations", CompletionItemKind::PROPERTY),
+    ]);
+    assert_completions(session, sub_xml, "t-out=\"this.|title\"", &[
+        ("volume", CompletionItemKind::PROPERTY),
+        ("punctuation", CompletionItemKind::PROPERTY),
+        ("title", CompletionItemKind::PROPERTY),
+        ("shout", CompletionItemKind::METHOD),
+    ]);
+}
+
+/// Assert the signature and docs of a completion, which reach the client only through a
+/// `completionItem/resolve` round trip
+fn test_completion_resolve(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, xml, .. } = fixtures;
+    let shout = resolved_completion(session, js, "this.|punctuation.repeat", "shout");
+    assert_detail(&shout, "shout(count: any): string");
+    assert!(shout.documentation.is_some(), "resolve should carry shout's JSDoc, got none");
+
+    let shout = resolved_completion(session, xml, "t-out=\"this.|title\"", "shout");
+    assert_detail(&shout, "shout(count: any): string");
+    assert!(shout.documentation.is_some(), "resolve should carry shout's JSDoc, got none");
+    // Its edits would be in virtual-doc coordinates, which would corrupt the XML if applied.
+    assert!(shout.additional_text_edits.is_none(), "a template completion must carry no edits");
+}
+
+/// Find-references from a member's declaration
+fn test_references_from_declaration(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, xml, sub_xml, .. } = fixtures;
+    assert_references(session, js, "this.|punctuation = \"!\"", &[
+        (js, "this.|punctuation = \"!\""), // declaration site is a reference too
+        (js, "this.|punctuation.repeat"),
+        (js, "this.|punctuation = \"?\""),
+        (xml, "t-out=\"this.|punctuation\""),
+        (sub_xml, "t-out=\"this.|punctuation\""),
+    ]);
+}
+
+/// Find-references from a member's declarations.
+/// Some of the references are in files that the test never opens (nor are
+/// imported by the opened files), so they are not part of tsserver's project
+/// until the import graph stages them.
+fn test_references_with_unopened_files(session: &mut SessionInfo, fixtures:
+&Fixtures) {
+    let Fixtures { js, xml, sub_xml, quiet_js, report_js, .. } = fixtures;
+    assert_references(session, js, "|shout(count) {", &[
+        (js, "|shout(count) {"), // declaration site is a reference too
+        (xml, "this.|shout("),
+        (sub_xml, "this.|shout("),
+        // unopened files
+        (quiet_js, "this.|shout(1)"),
+        (report_js, "greeting.|shout(2)"),
+    ]);
+}
+
+/// Find-references requested at usage sites (not at declaration)
+fn test_references_from_usage(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, xml, sub_js, sub_xml, quiet_js, report_js, .. } = fixtures;
+    assert_references(session, js, "this.|punctuation.repeat", &[
+        (js, "this.|punctuation = \"!\""), // declaration site
+        (js, "this.|punctuation.repeat"),
+        (js, "this.|punctuation = \"?\""),
+        (xml, "t-out=\"this.|punctuation\""),
+        (sub_xml, "t-out=\"this.|punctuation\""),
+    ]);
+    assert_references(session, xml, "t-out=\"this.|separator\"", &[
+        (js, "|separator = \", \""), // declaration site
+        (xml, "t-out=\"this.|separator\""),
+        (sub_js, "this.|separator.repeat"),
+        (report_js, "greeting.|separator"),
+    ]);
+    assert_references(session, sub_js, "this.|separator.repeat", &[
+        (js, "|separator = \", \""),
+        (xml, "t-out=\"this.|separator\""),
+        (sub_js, "this.|separator.repeat"),
+        (report_js, "greeting.|separator"),
+    ]);
+    assert_references(session, sub_xml, "this.|shout(", &[
+        (js, "|shout(count)"), // declaration site
+        (xml, "this.|shout("),
+        (sub_xml, "this.|shout("),
+        (quiet_js, "this.|shout(1)"),
+        (report_js, "greeting.|shout(2)"),
+    ]);
+}
+
+/// References to a template name.
+/// The file carrying the two latter sites is never opened.
+fn test_references_to_template(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js, xml, ext_xml, .. } = fixtures;
+    let sites: &[(&FixtureFile, &str)] = &[
+        (xml, "t-name=\"|module_owl.Greeting\""), // definition site
+        (js, "static template = \"|module_owl.Greeting\""),
+        (ext_xml, "t-call=\"|module_owl.Greeting\""),
+        (ext_xml, "t-inherit=\"|module_owl.Greeting\""),
+    ];
+    assert_references(session, js, "static template = \"|module_owl.Greeting\"", sites);
+    assert_references(session, xml, "t-name=\"|module_owl.Greeting\"", sites);
 }

--- a/server/tests/test_js_owl_features.rs
+++ b/server/tests/test_js_owl_features.rs
@@ -58,6 +58,7 @@ fn test_js_owl_features() {
     test_definition_in_subclass_template(&mut session, &fixtures);
     test_definition_for_template(&mut session, &fixtures);
     test_definition_for_template_jump_to_component(&mut session, &fixtures);
+    test_definition_in_js_without_component(&mut session, &fixtures);
 
     // Completion
     test_completion_in_js(&mut session, &fixtures);
@@ -149,6 +150,19 @@ fn test_definition_for_template(session: &mut SessionInfo, fixtures: &Fixtures) 
 fn test_definition_for_template_jump_to_component(session: &mut SessionInfo, fixtures: &Fixtures) {
     let Fixtures { js, xml , .. } = fixtures;
     assert_definition(session, xml, "<t t-name=\"|module_owl.Greeting\">", js, "export class |Greeting extends Component");
+}
+
+/// Definition should work in JS files that have no Component definitions
+fn test_definition_in_js_without_component(session: &mut SessionInfo, fixtures: &Fixtures) {
+    let Fixtures { js_utils, report_js, .. } = fixtures;
+    // definition location in same file
+    assert_definition(session,
+        js_utils, "if (answer < |half_answer)",
+        js_utils, "const |half_answer = 21" );
+    // definition location in imported file
+    assert_definition(session,
+        js_utils, "answer === final|_answer()",
+        report_js, "export function |final_answer()" );
 }
 
 /// Completion after `this.` and `this.props.` in the component's own `.js`.

--- a/server/tests/test_js_owl_features.rs
+++ b/server/tests/test_js_owl_features.rs
@@ -1,0 +1,48 @@
+//! Intergration tests of LSP features for JavaScript files and the OWL templates that back them.
+//!
+//! Most features require tsserver, so the suite is gated on a `TSSERVER` environment
+//! variable holding the command that starts one:
+//! 
+//! `TSSERVER=tsserver cargo test --test test_js_owl_features`
+//! 
+//! Without it the test skips instead of failing, so `cargo test`
+//! stays green on a machine with no TypeScript installed. `COMMUNITY_PATH` is required too.
+
+use lsp_types::CompletionItemKind;
+use odoo_ls_server::core::config::ConfigKey;
+use odoo_ls_server::threads::SessionInfo;
+
+mod setup;
+mod js_owl_helpers;
+use js_owl_helpers::fixture::*;
+use js_owl_helpers::requests::*;
+use js_owl_helpers::asserts::*;
+
+/// The command to start tsserver with, or `None` when the suite should be skipped.
+fn tsserver_command() -> Option<String> {
+    match std::env::var("TSSERVER") {
+        Ok(command) if !command.trim().is_empty() => Some(command),
+        _ => None,
+    }
+}
+
+#[test]
+/// Test suite with a single server setup.
+/// Requires env var `TSSERVER`, otherwise skipped.
+fn test_js_owl_features() {
+    let Some(tsserver_command) = tsserver_command() else {
+        eprintln!("skipping test_js_owl_features: set TSSERVER to the tsserver command to run it");
+        return;
+    };
+
+    let (mut odoo, mut config) = setup::setup::setup_server(true);
+    config.set_str(ConfigKey::TsServerCommand, tsserver_command.clone());
+    let (mut session, _tsserver_events) = setup::setup::create_init_session_with_tsserver(&mut odoo, config);
+
+    // Check that tsserver started successfully
+    assert!(
+        session.sync_odoo.tsserver_bridge.is_some(),
+        "tsserver did not start with TSSERVER={tsserver_command:?}"
+    );
+
+}


### PR DESCRIPTION
Probably better to wait for https://github.com/odoo/odoo-ls/pull/717 to land then rebase.

-------------------
Adds a "Pending" variant to FileMgr::Ast.

Before:
FileInfo initialized with a dummy PythonAst.
So a file_info_ast of PythonAst could mean 2 things: not yet done (but not necessarily related to a .py file), or an actual Python Ast. Which is rather confusing and error-prone.

After:
- Ast::PythonAst can only mean a Python ast - and done (not pending).
- Option around indexed_module removed. If it's a Ast::PythonAst, it contains an indexed_module.
- The only way to represent a pending ast is... Ast::Pending (!)
- is_built is simply: not Pending.
- No more default initialization of PythonAst and JsAst (fields set to empty vectors or None): these are only constructed with the actual parsed data.

Potential bug avoided:
`get_references` was called without confirmation that the Ast was really built after calling prepare_ast. It ast build failed, it would follow the Python arm and panic on file_info_ast.get_stmts().unwrap(). Now the Pending variant is handled (meaning not built) and this is avoided.