### PR TITLE
[FIX] JS symbol lifecycle

### DIFF
--- a/server/src/core/js_module_scope.rs
+++ b/server/src/core/js_module_scope.rs
@@ -91,9 +91,9 @@ fn dependency_closure(session: &SessionInfo, module: ModuleKey) -> Vec<ModuleKey
         .collect()
 }
 
-/// The module owning `path`. JS lives at `<module>/static/…`
-fn module_of_path(session: &SessionInfo, path: &str) -> Option<ModuleKey> {
-    let mut dir = Path::new(path).parent()?;
+/// The module owning `path`, which may be a file or a directory. JS lives at `<module>/static/…`
+pub fn module_of_path(session: &SessionInfo, path: &str) -> Option<ModuleKey> {
+    let mut dir = Path::new(path);
     loop {
         if dir.file_name() == Some(OsStr::new("static"))
             && let Some(module) = dir.parent().and_then(|parent| module_at(session, parent))

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -860,44 +860,70 @@ impl SyncOdoo {
 
     /// Like `unload_path`, but only unloads a symbol when `should_unload` returns true. Returns whether anything was unloaded.
     pub fn unload_path_if(session: &mut SessionInfo, path: &Path, should_unload: impl Fn(&SymbolTable, SymbolKey) -> bool) -> bool {
+        // file/dir might no longer exist in file system, we can't stat it
         let mut unloaded_any = false;
         let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
         for entry in ep_mgr.borrow().iter_all() {
-            let path_str = path.sanitize_cow();
-            let sym_in_data = entry.borrow().data_file_symbols.get(path_str.as_ref()).copied();
-            if let Some(sym) = sym_in_data {
-                if let Some(sym) = sym.upgrade(session.st())
-                    && should_unload(session.st(), sym.into()) {
-                        SymbolTable::unload(session, sym.into());
-                        unloaded_any = true;
-                    }
-                continue;
-            }
-            let sym_in_js = entry.borrow().js_symbols.get(path_str.as_ref()).cloned();
-            if let Some(sym) = sym_in_js {
-                if let Some(sym) = sym.upgrade(session.st())
-                    && should_unload(session.st(), sym.into()) {
-                        SymbolTable::unload(session, sym.into());
-                        unloaded_any = true;
-                    }
+            // try path as a data or asset file
+            if let Some(data_or_asset) = Self::find_data_or_asset_in_ep(entry, path) {
+                if let Some(sym) = data_or_asset.upgrade(session.st())
+                    && should_unload(session.st(), sym.into())
+                {
+                    SymbolTable::unload(session, sym);
+                    unloaded_any = true;
+                }
                 continue;
             }
             if entry.borrow().is_valid_for(path) {
                 let tree = entry.borrow().get_tree_for_entry(path);
                 let path_symbols = session.st().get_symbol(entry.borrow().root.into(), tree.as_slice(), u32::MAX);
-                let Some(&path_symbol) = path_symbols.first() else {
+                if let Some(&path_symbol) = path_symbols.first()
+                    && let Ok(file_or_dir) = FileSystemSymbolKey::try_from(path_symbol)
+                {
+                    if should_unload(session.st(), path_symbol) {
+                        SymbolTable::unload(session, file_or_dir);
+                        unloaded_any = true;
+                    }
                     continue;
-                };
-                let Ok(file_or_dir) = FileSystemSymbolKey::try_from(path_symbol) else {
-                    continue;
-                };
-                if should_unload(session.st(), path_symbol) {
-                    SymbolTable::unload(session, file_or_dir);
+                }
+            }
+            // try path as a dir holding data or assets
+            for data_or_asset in Self::find_nested_data_and_assets_in_ep(entry, path) {
+                if let Some(sym) = data_or_asset.upgrade(session.st())
+                    && should_unload(session.st(), sym.into())
+                {
+                    SymbolTable::unload(session, sym);
                     unloaded_any = true;
                 }
             }
         }
         unloaded_any
+    }
+
+    /// Finds a data or JS file for a given `path` under `entry`.
+    fn find_data_or_asset_in_ep(entry: &Rc<RefCell<EntryPoint>>, path: &Path) -> Option<Wk<FileSystemSymbolKey>> {
+        let entry_point = entry.borrow();
+        let path_str = path.sanitize_cow();
+        if let Some(&data_sym) = entry_point.data_file_symbols.get(path_str.as_ref()) {
+            return Some(data_sym.map_into());
+        }
+        if let Some(&js_sym) = entry_point.js_symbols.get(path_str.as_ref()) {
+            return Some(js_sym.map_into());
+        }
+        None
+    }
+
+    /// Finds all data and JS files under `entry` whose paths are prefixed with `dir_path`.
+    /// Useful for unloading data/assets under a dir.
+    fn find_nested_data_and_assets_in_ep(entry: &Rc<RefCell<EntryPoint>>, dir_path: &Path) -> Vec<Wk<FileSystemSymbolKey>> {
+        let entry_point = entry.borrow();
+        let data = entry_point.data_file_symbols.iter()
+            .filter(|(p, _)| Path::new(p).starts_with(dir_path))
+            .map(|(_, &sym)| sym.map_into());
+        let js = entry_point.js_symbols.iter()
+            .filter(|(p, _)| Path::new(p).starts_with(dir_path))
+            .map(|(_, &sym)| sym.map_into());
+        data.chain(js).collect()
     }
 
     /// Side effects of unloading a symbol

--- a/server/src/core/odoo.rs
+++ b/server/src/core/odoo.rs
@@ -1961,6 +1961,12 @@ impl Odoo {
                             && !session.sync_odoo.get_main_entry().borrow().data_file_symbols.contains_key(sanitized_path.as_ref())
                             && !session.sync_odoo.get_main_entry().borrow().js_symbols.contains_key(sanitized_path.as_ref()))
                             {
+                                // A didOpen can arrive before didCreate. If path is a new asset,
+                                // load it here so it doesn't become a custom entry point
+                                if ModuleSymbol::load_path_assets(session, &path) {
+                                    BuildScheduler::process_rebuilds(session, false);
+                                    return;
+                                }
                                 //main entry doesn't handle this file. Let's test customs entries, or create a new one
                                 let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
                                 for custom_entry in ep_mgr.borrow().custom_entry_points.iter() {
@@ -2063,8 +2069,13 @@ impl Odoo {
         }
     }
 
-    pub fn search_symbols_to_rebuild(session: &mut SessionInfo, path: &str) {
-        let path_for_tree = Path::new(path).to_tree_path();
+    pub fn on_new_path(session: &mut SessionInfo, path: &str) {
+        ModuleSymbol::load_path_assets(session, Path::new(path));
+        Self::search_symbols_to_rebuild(session, path);
+        Self::create_module_if_in_addons(session, path);
+    }
+
+    fn search_symbols_to_rebuild(session: &mut SessionInfo, path: &str) {
         //search if the path does match a missing file path somewhere
         let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
         let tree = session.sync_odoo.path_to_main_entry_tree(Path::new(path));
@@ -2078,6 +2089,11 @@ impl Odoo {
                 entry.borrow_mut().search_symbols_to_rebuild(session, path, tree);
             }
         }
+    }
+
+    fn create_module_if_in_addons(session: &mut SessionInfo, path: &str) {
+        let ep_mgr = session.sync_odoo.entry_point_mgr.clone();
+        let path_for_tree = Path::new(path).to_tree_path();
         // test if the new path is a new module under odoo/addons namespace.
         let Some(parent_path) = path_for_tree.parent().map(|parent| parent.sanitize_cow().into_owned()) else {
             return;
@@ -2103,7 +2119,7 @@ impl Odoo {
             BuildScheduler::queue(session, BuildableSymbolKey::Module(module_symbol));
         }
     }
-
+ 
     /// Create the module at `path` under `addons`, or replace non-module symbol that already holds
     /// the name - e.g. namespace or a package before `__manifest__.py` existed.
     fn create_or_replace_module(session: &mut SessionInfo, path: &Path, addons: NamespaceKey) -> Option<ModuleKey> {
@@ -2148,7 +2164,7 @@ impl Odoo {
             //2 - create new document
             let new_path_buf = Path::new(&new_path);
             let new_path_updated = new_path_buf.to_tree_path().sanitize();
-            Odoo::search_symbols_to_rebuild(session, &new_path_updated);
+            Odoo::on_new_path(session, &new_path_updated);
             BuildScheduler::process_rebuilds(session, false);
         }
     }
@@ -2161,7 +2177,7 @@ impl Odoo {
             let path = FileMgr::uri2pathname(&f.uri);
             let path_updated = Path::new(&path).to_tree_path().to_str().unwrap().to_string();
             session.log_message(MessageType::INFO, format!("Creating {}", path.clone()));
-            Odoo::search_symbols_to_rebuild(session, &path_updated);
+            Odoo::on_new_path(session, &path_updated);
             session.sync_odoo.entry_point_mgr.borrow_mut().clean_entries(&mut session.sync_odoo.symbol_table);
         }
         BuildScheduler::process_rebuilds(session, false);

--- a/server/src/core/pre_parser.rs
+++ b/server/src/core/pre_parser.rs
@@ -8,9 +8,9 @@
 //! * walks the module dir and pre-parses every `.py`/`.pyi` into an
 //!   [`IndexedModule`] (read + ruff parse + noqa scan),
 //! * reads each file listed in the manifest's `data` list, and
-//! * expands the manifest's `assets` globs, reading the XML files they match and
-//!   parsing the JS ones (read + OXC parse + semantic + lint). The expansion itself
-//!   is memoized for the build thread — see [`PreParseCache::resolve_assets`].
+//! * walks the module's `static/` asset folders, reading the XML files it finds and
+//!   parsing the JS ones (read + OXC parse + semantic + lint). The walk itself is
+//!   memoized for the build thread — see [`PreParseCache::resolve_assets`].
 //!
 //! Both results land in a shared [`PreParseCache`] as a [`PreloadedFile`] payload;
 //! when the build thread reaches a file it slots the payload in instead of
@@ -34,7 +34,7 @@ use crate::core::symbols::ModuleSymbol;
 use crate::core::symbols::symbol_keys::ModuleKey;
 use crate::core::text_document::TextDocument;
 use crate::threads::SessionInfo;
-use crate::utils::{HashMap, HashSet, PathSanitizer};
+use crate::utils::{HashMap, PathSanitizer};
 
 /// Max number of worker threads parsing files ahead of the build. Workers only have to
 /// stay *ahead* of the build thread; past that they merely compete with it for cores,
@@ -64,23 +64,13 @@ const SKIPPED_DIRS: &[&str] = &[
     "i18n", "views", "data", "security", "description", "doc", "docs",
 ];
 
-/// (owner module path, local url)
-/// local url contains globs, not expanded yet
-type AssetEntry = (String, String);
-/// The result of expanding an AssetEntry: the list of files it matches.
-type AssetPaths = Vec<PathBuf>;
-
 /// One unit of work submitted for the worker pool: a module at position
-/// `module_idx` in build order, its on-disk root, the explicit list of
-/// data files, and the manifest asset entries it declares
+/// `module_idx` in build order, its on-disk root, and the explicit list of data files.
+/// Its assets are whatever its `static/` folders hold, so the worker walks for them itself.
 struct Job {
     module_idx: usize,
     module_path: PathBuf,
     data_files: Vec<PathBuf>,
-    /// `(owner module path, local url)` per manifest asset entry, as produced by
-    /// [`ModuleSymbol::asset_entries`]. Still unexpanded: the glob walk happens in
-    /// the worker, off the build thread ([`PreParseCache::resolve_assets`]).
-    asset_entries: Vec<AssetEntry>,
 }
 
 #[derive(Debug, Default)]
@@ -97,11 +87,9 @@ struct IndexedStore {
 #[derive(Debug, Default)]
 pub struct PreParseCache {
     index: Mutex<IndexedStore>,
-    /// Memoized [`ModuleSymbol::assets_path_resolver`] results, keyed by its arguments.
+    /// Memoized [`ModuleSymbol::asset_paths`] results, keyed by module path.
     /// See [`Self::resolve_assets`].
-    resolved_assets: Mutex<HashMap<AssetEntry, Arc<AssetPaths>>>,
-    /// Asset files already taken by a worker. See [`Self::claim`].
-    claimed_assets: Mutex<HashSet<PathBuf>>,
+    resolved_assets: Mutex<HashMap<String, Arc<Vec<PathBuf>>>>,
     /// Counters for end-of-build instrumentation. Inert unless
     /// [`DEBUG_PRE_PARSER`] is set; see [`PreParseStats`].
     stats: PreParseStats,
@@ -115,40 +103,21 @@ impl PreParseCache {
         pre_loaded
     }
 
-    /// Expand one manifest asset entry to the files it matches, memoizing the result.
+    /// Walk one module's asset folders, memoizing the result.
     ///
     /// Called by the workers (ahead of the build) and by the build thread itself
-    /// (`ModuleSymbol::load_assets`). Both go through
-    /// [`ModuleSymbol::asset_entries`], so they always ask for the same keys and the
-    /// build thread's own resolve is a map lookup. Whichever thread misses first pays
-    /// for the walk; a module the workers skipped is resolved by the build thread and
-    /// memoized all the same.
-    pub fn resolve_assets(&self, module_path: &str, data_local_url: &str) -> Arc<Vec<PathBuf>> {
-        let key = (module_path.to_string(), data_local_url.to_string());
-        if let Some(resolved) = self.resolved_assets.lock().unwrap().get(&key) {
+    /// (`ModuleSymbol::load_assets`), so the build thread's own resolve is a map lookup.
+    /// Whichever thread misses first pays for the walk; a module the workers skipped is
+    /// resolved by the build thread and memoized all the same.
+    pub fn resolve_assets(&self, module_path: &str) -> Arc<Vec<PathBuf>> {
+        if let Some(resolved) = self.resolved_assets.lock().unwrap().get(module_path) {
             return resolved.clone();
         }
         // Walk the disk outside the lock: two threads racing on the same key just
         // resolve it twice, which is harmless.
-        let resolved = Arc::new(ModuleSymbol::assets_path_resolver(module_path, data_local_url));
-        self.resolved_assets.lock().unwrap().insert(key, resolved.clone());
+        let resolved = Arc::new(ModuleSymbol::asset_paths(module_path));
+        self.resolved_assets.lock().unwrap().insert(module_path.to_string(), resolved.clone());
         resolved
-    }
-
-    /// Take ownership of an asset file, returning `false` if another job got it first.
-    ///
-    /// Modules routinely list assets they do not own — the standalone webclient bundles
-    /// (`project`, `point_of_sale`, `portal`, …) each re-declare large parts of `web`'s
-    /// core, and the hottest files are claimed by ~10 modules. The build thread loads
-    /// such a file only once, for the first module that reaches it, so preparing it
-    /// twice buys nothing: the second payload is parsed, never consumed, then evicted.
-    /// Measured on community + enterprise, this drops ~24% of the JS parses and ~45%
-    /// of the bytes parsed.
-    ///
-    /// Claiming for a *later* module than the one that ends up consuming the file is
-    /// harmless: payloads are keyed by path, not by module.
-    fn claim(&self, path: &Path) -> bool {
-        self.claimed_assets.lock().unwrap().insert(path.to_path_buf())
     }
 
     /// Drop cached entries whose owning module is `module_idx`.
@@ -188,6 +157,7 @@ struct WorkerCtx {
     cache: Arc<PreParseCache>,
     encoding: PositionEncoding,
     test_mode: bool,
+    javascript_disabled: bool,
 }
 
 /// Owns the worker pool and the job queue. Dropping it joins the workers.
@@ -206,6 +176,7 @@ impl PreParser {
             cache: cache.clone(),
             encoding: session.sync_odoo.encoding,
             test_mode: session.sync_odoo.test_mode,
+            javascript_disabled: session.sync_odoo.config.is_javascript_disabled(),
         };
         let job_queue = Arc::new(Mutex::new(Self::create_job_queue(session, sorted_modules)));
         let n_workers = n_workers();
@@ -258,12 +229,7 @@ impl PreParser {
                 let data_files: Vec<PathBuf> = module.data().iter()
                     .map(|(url, _)| module_path.join(url))
                     .collect();
-                // The owning module of an asset is looked up here, on the build thread:
-                // workers never touch the symbol table.
-                let asset_entries = ModuleSymbol::asset_entries(session, module_key).into_iter()
-                    .map(|(_, owner_path, local_url)| (owner_path, local_url))
-                    .collect();
-                Job { module_idx, module_path, data_files, asset_entries }
+                Job { module_idx, module_path, data_files }
             })
             .collect()
     }
@@ -280,10 +246,10 @@ impl Drop for PreParser {
 }
 
 /// Process one module job: first read every file in its declared `data` list,
-/// then walk the module dir pre-parsing Python sources, then expand and read the
-/// manifest assets.
+/// then walk the module dir pre-parsing Python sources, then walk its `static/`
+/// asset folders.
 fn pre_parse_module(ctx: &WorkerCtx, job: Job) {
-    let Job { module_idx, module_path, data_files, asset_entries } = job;
+    let Job { module_idx, module_path, data_files } = job;
 
     // Pass 1: declared data files
     for path in &data_files {
@@ -295,7 +261,7 @@ fn pre_parse_module(ctx: &WorkerCtx, job: Job) {
     }
 
     // Pass 2: Python sources
-    let mut stack = vec![module_path];
+    let mut stack = vec![module_path.clone()];
     while let Some(dir) = stack.pop() {
         let Ok(entries) = fs::read_dir(&dir) else { continue };
         for entry in entries.flatten() {
@@ -314,32 +280,20 @@ fn pre_parse_module(ctx: &WorkerCtx, job: Job) {
         }
     }
 
-    // Pass 3: expand manifest assets. Expanding them here keeps the glob walk off the build
-    // thread, which finds the result memoized when it reaches this module.
-    // Bundles overlap heavily, both within a manifest and across modules, so each file is
-    // claimed before being prepared — see [`PreParseCache::claim`].
-    let mut xml_assets = vec![];
-    let mut js_assets = vec![];
-    for (owner_path, local_url) in &asset_entries {
-        for path in ctx.cache.resolve_assets(owner_path, local_url).iter() {
-            let extension = path.extension().and_then(|e| e.to_str());
-            if !matches!(extension, Some("xml") | Some("js")) || !ctx.cache.claim(path) {
-                continue;
-            }
-            match extension {
-                Some("xml") => xml_assets.push(path.clone()),
-                _ => js_assets.push(path.clone()),
-            }
-        }
+    // Pass 3: walk the module's asset folders. Walking here keeps it off the build thread,
+    // which finds the result memoized when it reaches this module. A module only ever owns
+    // the files under its own `static/`, so no two jobs prepare the same file.
+    if ctx.javascript_disabled {
+        return;
     }
-
+    let assets = ctx.cache.resolve_assets(&module_path.sanitize_cow());
     // Pass 4: read xml assets
-    for path in &xml_assets {
+    for path in assets.iter().filter(|path| path.extension().is_some_and(|ext| ext == "xml")) {
         pre_load_xml(ctx, module_idx, path);
     }
 
     // Pass 5: read and parse js assets
-    for path in &js_assets {
+    for path in assets.iter().filter(|path| path.extension().is_some_and(|ext| ext == "js")) {
         pre_parse_js(ctx, module_idx, path);
     }
 }

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -5,8 +5,12 @@ use lsp_types::{Diagnostic, Position, Range};
 use tracing::info;
 
 use crate::core::build_scheduler::BuildScheduler;
+use crate::core::js_module_scope;
+use crate::core::js_utils::read_module_header;
 use crate::core::symbols::symbol_keys::JsFileKey;
-use crate::{constants::{BuildSteps, DEBUG_STEPS, DiagnosticSource}, core::{csv_arch_builder::CsvArchBuilder, data_hooks, diagnostics::{DiagnosticCode, create_diagnostic}, file_mgr::FileInfo, symbols::{ModuleSymbol, SymbolTable, XmlFileSymbol, symbol_keys::{ModuleKey, SourceFileKey, XmlFileKey}}, xml_arch_builder::XmlArchBuilder}, threads::SessionInfo, utils::PathSanitizer};
+use crate::{constants::{BuildStatus, BuildSteps, DEBUG_STEPS, DiagnosticSource}, core::{csv_arch_builder::CsvArchBuilder, data_hooks, diagnostics::{DiagnosticCode, create_diagnostic}, file_mgr::FileInfo, symbols::{ModuleSymbol, SymbolTable, XmlFileSymbol, symbol_keys::{BuildableSymbolKey, ModuleKey, SourceFileKey, XmlFileKey}}, xml_arch_builder::XmlArchBuilder}, threads::SessionInfo, utils::PathSanitizer};
+
+const ASSET_FOLDERS: [&str; 3] = ["src", "tests", "lib"];
 
 
 
@@ -105,49 +109,21 @@ impl ModuleSymbol {
         entry.borrow_mut().js_symbols.remove(path);
     }
 
-    /// The asset entries declared by this module's manifest, one per `assets` url,
-    /// as `(owner module, owner module path, local url)`.
-    ///
-    /// An asset url is `<module_name>/<local_url>` and is resolved against the module
-    /// it names, which is not necessarily the one declaring it. Entries naming an
-    /// unknown module are dropped.
-    ///
-    /// Shared by [`Self::load_assets`] and the pre-parse workers so that both feed
-    /// [`crate::core::pre_parser::PreParseCache::resolve_assets`] the exact same keys.
-    pub fn asset_entries(session: &SessionInfo, module: ModuleKey) -> Vec<(ModuleKey, String, String)> {
-        if session.sync_odoo.config.is_javascript_disabled() {
-            return Vec::new();
-        }
-        let mut entries = Vec::new();
-        for (data_url, _data_range) in session.st()[module].assets.iter() {
-            let mut data_url_splitted = data_url.splitn(2, '/');
-            let data_module_name = data_url_splitted.next().unwrap();
-            let Some(data_local_url) = data_url_splitted.next() else {
-                continue;
-            };
-            let Some(data_module) = session.sync_odoo.modules.get(data_module_name) else {
-                continue;
-            };
-            let Some(data_module) = data_module.upgrade(session.st()) else {
-                continue;
-            };
-            entries.push((data_module, session.st()[data_module].path.clone(), data_local_url.to_string()));
-        }
-        entries
-    }
-
     pub fn load_assets(module: ModuleKey, session: &mut SessionInfo) {
+        if session.sync_odoo.config.is_javascript_disabled() {
+            return;
+        }
+        let module_path = session.st()[module].path.clone();
         // Set for the duration of `build_modules` only: outside of it there are no
         // workers to share the walk with, and nothing to invalidate the memo.
         let cache = session.sync_odoo.pre_parse_cache().cloned();
-        for (data_module, module_path, data_local_url) in Self::asset_entries(session, module) {
-            let files_to_imports = match &cache {
-                Some(cache) => cache.resolve_assets(&module_path, &data_local_url),
-                None => Arc::new(ModuleSymbol::assets_path_resolver(&module_path, &data_local_url)),
-            };
-            //xml have to be loaded first
-            Self::load_xml_assets(session, data_module, &files_to_imports);
-            Self::load_js_assets(session, data_module, &files_to_imports);
+        let files_to_imports = match &cache {
+            Some(cache) => cache.resolve_assets(&module_path),
+            None => Arc::new(Self::asset_paths(&module_path)),
+        };
+        //xml have to be loaded first
+        Self::load_xml_assets(session, module, &files_to_imports);
+        Self::load_js_assets(session, module, &files_to_imports);
         }
     }
 
@@ -207,75 +183,69 @@ impl ModuleSymbol {
         }
     }
 
-    /// Recursively collects all descendants of a directory (files and subdirs).
-    /// The directory itself is included (** matches zero levels too).
-    fn collect_recursive(path: &Path, results: &mut Vec<PathBuf>) {
-        results.push(path.to_path_buf()); // ** can match zero segments
-        if let Ok(entries) = std::fs::read_dir(path) {
-            for entry in entries.flatten() {
-                let child = entry.path();
-                if child.is_dir() {
-                    Self::collect_recursive(&child, results); // recurse into subdirs
-                } else {
-                    results.push(child); // include files too
-                }
-            }
-        }
-    }
-
-    /// Expand one asset entry (see [`Self::asset_entries`]) to the files it matches.
+    /// Every asset of the module rooted at `module_path`.
+    ///
     /// Pure but disk-bound: memoized by
     /// [`crate::core::pre_parser::PreParseCache::resolve_assets`] for the duration of
     /// the module build, and called by the pre-parse workers.
-    pub(crate) fn assets_path_resolver(module_path: &str, data_local_url: &str) -> Vec<PathBuf> {
-        let mut results = vec![PathBuf::from(module_path)];
-
-        for component in Path::new(data_local_url).components() {
-            let std::path::Component::Normal(os_str) = component else { continue };
-            let segment = os_str.to_str().unwrap();
-            let mut new_results = vec![];
-
-            match segment {
-                // ** → expand every current path to itself + all descendants
-                "**" => {
-                    for path in &results {
-                        if path.is_dir() {
-                            ModuleSymbol::collect_recursive(path, &mut new_results);
-                        } else {
-                            new_results.push(path.clone());
-                        }
-                    }
-                }
-
-                // * or *.js etc. → list direct children and filter by pattern
-                pattern if pattern.contains('*') => {
-                    for path in &results {
-                        if let Ok(entries) = std::fs::read_dir(path) {
-                            for entry in entries.flatten() {
-                                let name = entry.file_name();
-                                let name_str = name.to_str().unwrap();
-                                if glob::Pattern::new(pattern).map(|p| p.matches(name_str)).unwrap_or(false) {
-                                    new_results.push(entry.path());
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Exact segment → just join and check existence
-                exact => {
-                    for path in &results {
-                        let candidate = path.join(exact);
-                        if candidate.exists() {
-                            new_results.push(candidate);
-                        }
-                    }
-                }
-            }
-
-            results = new_results;
+    pub(crate) fn asset_paths(module_path: &str) -> Vec<PathBuf> {
+        let static_dir = Path::new(module_path).join("static");
+        let mut results = vec![];
+        for folder in ASSET_FOLDERS {
+            collect_assets(&static_dir.join(folder), folder == "lib", &mut results);
         }
-
         results
+    }
+}
+
+/// The asset folder `path` sits in — either as a descendant of it or as the folder itself.
+fn asset_folder_of(module_path: &str, path: &str) -> Option<&'static str> {
+    let relative = path.strip_prefix(module_path)?.strip_prefix("/static/")?;
+    ASSET_FOLDERS.into_iter().find(|folder| {
+        relative == *folder || relative.strip_prefix(folder).is_some_and(|rest| rest.starts_with('/'))
+    })
+}
+
+fn collect_assets(dir: &Path, is_lib: bool, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if entry.file_type().is_ok_and(|typ| typ.is_dir()) {
+            if entry.file_name() != "node_modules" {
+                collect_assets(&path, is_lib, out);
+            }
+        } else if is_asset_file(&path, is_lib) {
+            out.push(path);
+        }
+    }
+}
+
+/// In `static/lib` the `@odoo-module` header is what makes a JS file a module, and no XML
+/// there is ever an asset.
+fn is_asset_file(path: &Path, is_lib: bool) -> bool {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("js") => !is_lib || read_module_header(path).is_some_and(|header| !header.ignore),
+        Some("xml") => !is_lib,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_three_odoo_folders_hold_assets() {
+        let module = "/addons/mod";
+        assert_eq!(asset_folder_of(module, "/addons/mod/static/src/a.js"), Some("src"));
+        assert_eq!(asset_folder_of(module, "/addons/mod/static/tests/deep/a.js"), Some("tests"));
+        // A folder rename delivers the folder itself.
+        assert_eq!(asset_folder_of(module, "/addons/mod/static/lib"), Some("lib"));
+        // A prefix is not a segment.
+        assert_eq!(asset_folder_of(module, "/addons/mod/static/source/a.js"), None);
+        assert_eq!(asset_folder_of(module, "/addons/mod/static/description/icon.png"), None);
+        assert_eq!(asset_folder_of(module, "/addons/mod/tools/a.js"), None);
+        // `mod` must not claim `mod_extra`.
+        assert_eq!(asset_folder_of(module, "/addons/mod_extra/static/src/a.js"), None);
     }
 }

--- a/server/src/core/symbols/manifest_arch_eval.rs
+++ b/server/src/core/symbols/manifest_arch_eval.rs
@@ -124,7 +124,39 @@ impl ModuleSymbol {
         //xml have to be loaded first
         Self::load_xml_assets(session, module, &files_to_imports);
         Self::load_js_assets(session, module, &files_to_imports);
+    }
+
+    /// The module owning `path` as an asset, and the files to load for it. `path` may be a
+    /// directory, which a folder rename delivers as a single event.
+    fn asset_owner(session: &SessionInfo, path: &Path) -> Option<(ModuleKey, Vec<PathBuf>)> {
+        if session.sync_odoo.config.is_javascript_disabled() {
+            return None;
         }
+        let path_str = path.sanitize_cow();
+        let module = js_module_scope::module_of_path(session, &path_str)?;
+        let is_lib = asset_folder_of(&session.st()[module].path, &path_str)? == "lib";
+        if path.is_dir() {
+            let mut files = vec![];
+            collect_assets(path, is_lib, &mut files);
+            return Some((module, files));
+        }
+        is_asset_file(path, is_lib).then(|| (module, vec![path.to_path_buf()]))
+    }
+
+    /// Load `path` as an asset of the module owning it. Returns whether a module owns it.
+    ///
+    /// Files already loaded are skipped, so this is safe to call for every watched event.
+    pub fn load_path_assets(session: &mut SessionInfo, path: &Path) -> bool {
+        let Some((module, files)) = Self::asset_owner(session, path) else {
+            return false;
+        };
+        // A module with pending ARCH_EVAL will load its assets via `load_assets`
+        if session.st().build_status(BuildableSymbolKey::Module(module), BuildSteps::ARCH_EVAL) != BuildStatus::DONE {
+            return true;
+        }
+        Self::load_xml_assets(session, module, &files);
+        Self::load_js_assets(session, module, &files);
+        true
     }
 
     fn load_xml_assets(session: &mut SessionInfo, module: ModuleKey, files_to_imports: &[PathBuf]) {

--- a/server/src/core/symbols/manifest_create.rs
+++ b/server/src/core/symbols/manifest_create.rs
@@ -70,7 +70,7 @@ impl ModuleSymbol {
                             } else if key_str == "data" {
                                 ModuleSymbol::load_manifest_data(session, module_key, &mut res, key_literal, value);
                             } else if key_str == "assets" {
-                                ModuleSymbol::load_manifest_assets(session, module_key, &mut res, key_literal, value);
+                                ModuleSymbol::load_manifest_assets(session, &mut res, key_literal, value);
                             } else if key_str == "active"
                                 && let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS03302, &[]) {
                                     res.push(Diagnostic {
@@ -178,7 +178,7 @@ impl ModuleSymbol {
         }
     }
 
-    fn load_manifest_assets(session: &mut SessionInfo, module_key: ModuleKey, diagnostics: &mut Vec<Diagnostic>, key_literal: &ExprStringLiteral, value: &Expr) {
+    fn load_manifest_assets(session: &mut SessionInfo, diagnostics: &mut Vec<Diagnostic>, key_literal: &ExprStringLiteral, value: &Expr) {
         if !value.is_dict_expr() {
             if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS04013, &[]) {
                 diagnostics.push(Diagnostic {
@@ -213,11 +213,9 @@ impl ModuleSymbol {
                     }
                     continue;
                 }
+                // Nothing is kept: asset discovery is a `static/` walk. Only the shape is checked.
                 for item in data.value.as_list_expr().unwrap().iter() {
-                    let module = &mut session.st_mut()[module_key];
-                    if item.is_string_literal_expr() {
-                        module.assets.push((item.as_string_literal_expr().unwrap().value.to_string(), item.range()));
-                    } else if item.is_tuple_expr() {
+                    if item.is_tuple_expr() {
                         if item.as_tuple_expr().unwrap().elts.is_empty() {
                             if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS04018, &[]) {
                                 diagnostics.push(Diagnostic {
@@ -293,14 +291,13 @@ impl ModuleSymbol {
                                 continue;
                             }
                         }
-                    } else {
-                        if let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS04017, &[]) {
+                    } else if !item.is_string_literal_expr()
+                        && let Some(diagnostic) = create_diagnostic(session, DiagnosticCode::OLS04017, &[]) {
                             diagnostics.push(Diagnostic {
                                 range: Range::new(Position::new(item.range().start().to_u32(), 0), Position::new(item.range().end().to_u32(), 0)),
                                 ..diagnostic
                             });
                         }
-                    }
                 }
             }
         }

--- a/server/src/core/symbols/storage/module_symbol.rs
+++ b/server/src/core/symbols/storage/module_symbol.rs
@@ -28,7 +28,6 @@ pub struct ModuleSymbol {
     pub depends: Vec<(OYarn, TextRange)>,
     pub(in crate::core::symbols) all_depends: HashSet<OYarn>, //computed all depends to avoid too many recomputations
     pub(in crate::core::symbols) data: Vec<(String, TextRange)>,
-    pub(in crate::core::symbols) assets: Vec<(String, TextRange)>,
     pub xml_ids: HashMap<OYarn, WeakSet<XmlId>>, //Reference to xmlNode declaring xml_id. Can be from python or xml file.
     pub (super) current_build_step: BuildSteps,
     pub (super) build_status: BuildStatus,
@@ -82,7 +81,6 @@ impl ModuleSymbol {
             depends,
             all_depends: HashSet::default(),
             data: Vec::new(),
-            assets: Vec::new(),
             parent,
             fs_symbols: HashMap::default(),
             current_build_step: BuildSteps::ARCH,

--- a/server/src/threads.rs
+++ b/server/src/threads.rs
@@ -145,7 +145,7 @@ impl <'a> SessionInfo<'a> {
             return;
         }
         SyncOdoo::unload_path(session, path);
-        Odoo::search_symbols_to_rebuild(session, &path.sanitize_cow());
+        Odoo::on_new_path(session, &path.sanitize_cow());
         if (!forced_delay || session.delayed_process_sender.is_none()) && !session.sync_odoo.need_rebuild
             && BuildScheduler::get_rebuild_queue_size(session) < 10 {
                 BuildScheduler::process_rebuilds(session, false);

--- a/server/tests/test_js_lifecycle.rs
+++ b/server/tests/test_js_lifecycle.rs
@@ -1,10 +1,42 @@
 use std::fs;
+use std::path::PathBuf;
 
-use lsp_types::TextDocumentContentChangeEvent;
+use assert_fs::TempDir;
+use assert_fs::fixture::ChildPath;
+use assert_fs::prelude::*;
+use lsp_types::{
+    CreateFilesParams, DeleteFilesParams, FileCreate, FileDelete, FileRename, RenameFilesParams,
+    TextDocumentContentChangeEvent,
+};
+use odoo_ls_server::constants::OYarn;
+use odoo_ls_server::core::build_scheduler::BuildScheduler;
+use odoo_ls_server::core::config::ConfigKey;
 use odoo_ls_server::core::file_mgr::FileMgr;
+use odoo_ls_server::core::odoo::Odoo;
+use odoo_ls_server::core::symbols::symbol_keys::ModuleKey;
+use odoo_ls_server::threads::SessionInfo;
 use odoo_ls_server::utils::PathSanitizer;
+use odoo_ls_server::{S, Sy};
 
 mod setup;
+
+/// One shared setup.
+/// `test_js_lib_file_no_oxc_diagnostics` drains the session channel, so it runs last.
+#[test]
+fn test_js_lifecycle() {
+    let fixture = build_fixture_addons();
+    let fixture_path = fixture.path().sanitize();
+
+    let (mut odoo, mut config) = setup::setup::setup_server(true);
+    config.set_string_list(ConfigKey::AddonsPaths, [addons_path().sanitize(), fixture_path.clone()]);
+    odoo.get_file_mgr().borrow_mut()
+        .add_workspace_folder(S!("asset_events_addons"), FileMgr::pathname2uri(&fixture_path));
+    let mut session = setup::setup::create_init_session(&mut odoo, config);
+
+    test_asset_events(&mut session, &fixture);
+    test_js_file_lifecycle_with_odoo(&mut session);
+    test_js_lib_file_no_oxc_diagnostics(&mut session);
+}
 
 fn make_js_open_params(uri: lsp_types::Uri, content: &str) -> lsp_types::DidOpenTextDocumentParams {
     lsp_types::DidOpenTextDocumentParams {
@@ -34,28 +66,175 @@ fn make_js_close_params(uri: lsp_types::Uri) -> lsp_types::DidCloseTextDocumentP
     }
 }
 
+// — asset discovery from watched file events —
+
+const FIXTURE: &str = "module_asset_events";
+
+/// A second addons root we can makes changes on
+fn build_fixture_addons() -> TempDir {
+    let fixture = TempDir::new().expect("failed to create the fixture addons dir");
+    let module = fixture.child(FIXTURE);
+    // No `assets` key: discovery must not need one.
+    module.child("__manifest__.py").write_str(
+        "{\n    'name': 'Module Asset Events',\n    'version': '1.0',\n    'depends': [],\n    'installable': True,\n}\n"
+    ).unwrap();
+    module.child("__init__.py").touch().unwrap();
+    module.child("static/src/existing.js").write_str("export const existingHelper = () => 1;\n").unwrap();
+    fixture
+}
+
+fn addons_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("data").join("addons")
+}
+
+fn fixture_module(session: &SessionInfo) -> ModuleKey {
+    session.sync_odoo.modules.get(&Sy!(FIXTURE))
+        .expect("module_asset_events not loaded")
+        .upgrade(session.st())
+        .expect("module_asset_events symbol is dead")
+}
+
+fn has_js_symbol(session: &SessionInfo, path: &str) -> bool {
+    session.st()[fixture_module(session)].js_symbols().contains_key(path)
+}
+
+fn has_data_symbol(session: &SessionInfo, path: &str) -> bool {
+    session.st()[fixture_module(session)].data_file_symbols().contains_key(path)
+}
+
+fn has_custom_entry(session: &SessionInfo, path: &str) -> bool {
+    session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.iter()
+        .any(|ep| ep.borrow().path == path)
+}
+
+/// Writes `relative` under the fixture module and gives back the path the symbol maps are keyed by.
+fn write_asset(module: &ChildPath, relative: &str, content: &str) -> String {
+    let file = module.child(relative);
+    file.write_str(content).expect("failed to write fixture file");
+    file.path().sanitize()
+}
+
+fn did_create(session: &mut SessionInfo, path: &str) {
+    Odoo::handle_did_create(session, CreateFilesParams {
+        files: vec![FileCreate { uri: FileMgr::pathname2uri(path).to_string() }],
+    });
+}
+
+fn did_rename(session: &mut SessionInfo, old_path: &str, new_path: &str) {
+    Odoo::handle_did_rename(session, RenameFilesParams {
+        files: vec![FileRename {
+            old_uri: FileMgr::pathname2uri(old_path).to_string(),
+            new_uri: FileMgr::pathname2uri(new_path).to_string(),
+        }],
+    });
+}
+
+fn did_delete(session: &mut SessionInfo, path: &str) {
+    Odoo::handle_did_delete(session, DeleteFilesParams {
+        files: vec![FileDelete { uri: FileMgr::pathname2uri(path).to_string() }],
+    });
+}
+
+/// Assets are discovered by walking `static/{src,tests,lib}`, never from the manifest — the
+/// fixture module declares no `assets` at all. These bodies drive the watched-file events that
+/// have to keep that walk up to date.
+fn test_asset_events(session: &mut SessionInfo, fixture: &TempDir) {
+    let module = fixture.child(FIXTURE);
+    let src_dir = module.path().join("static").join("src");
+    let sub_dir = src_dir.join("sub");
+    let renamed_sub_dir = src_dir.join("sub2");
+
+    // 1. a new file under static/src joins the module, instead of getting an entry point of its own
+    let created = write_asset(&module, "static/src/created.js", "export const created = () => 1;\n");
+    did_create(session, &created);
+    assert!(has_js_symbol(session, &created), "a created static/src JS file must join the module");
+    assert!(!has_custom_entry(session, &created), "a module asset must not get a custom entry point");
+
+    // 2. a didOpen that beats the create event must reach the same state
+    let opened_content = "export const opened = () => 2;\n";
+    let opened = write_asset(&module, "static/src/opened.js", opened_content);
+    let opened_uri = FileMgr::pathname2uri(&opened);
+    Odoo::handle_did_open(session, make_js_open_params(opened_uri.clone(), opened_content));
+    assert!(has_js_symbol(session, &opened), "didOpen alone must load a new asset into its module");
+    assert!(!has_custom_entry(session, &opened), "didOpen must not race the create event to a custom entry point");
+    Odoo::handle_did_close(session, make_js_close_params(opened_uri));
+
+    // 3. XML too. Driven through `on_new_path` alone, without the `process_rebuilds`
+    // that follows it in `handle_did_create`: nothing depends on a file that did not exist, so the
+    // hook is the only thing that can have loaded it.
+    let created_xml = write_asset(
+        &module,
+        "static/src/created.xml",
+        "<templates xml:space=\"preserve\">\n    <t t-name=\"module_asset_events.Created\">\n        <div/>\n    </t>\n</templates>\n",
+    );
+    Odoo::on_new_path(session, &created_xml);
+    assert!(has_data_symbol(session, &created_xml), "a created static/src XML asset must be loaded by the hook, not by a module rebuild");
+    BuildScheduler::process_rebuilds(session, false);
+
+    // 4. in static/lib the @odoo-module header is what makes a file an asset
+    let plain_lib = write_asset(&module, "static/lib/plain.js", "window.plain = 1;\n");
+    did_create(session, &plain_lib);
+    assert!(!has_js_symbol(session, &plain_lib), "a headerless static/lib file is not an asset");
+
+    // 5.
+    let headed_lib = write_asset(&module, "static/lib/headed.js", "/** @odoo-module */\nexport const headed = () => 5;\n");
+    did_create(session, &headed_lib);
+    assert!(has_js_symbol(session, &headed_lib), "a headed static/lib file is an asset");
+
+    // 6. only src, tests and lib hold assets
+    let outside = write_asset(&module, "static/description/ignored.js", "export const ignored = () => 6;\n");
+    did_create(session, &outside);
+    assert!(!has_js_symbol(session, &outside), "static/description is not an asset folder");
+
+    // 7. file rename
+    let renamed = src_dir.join("renamed.js").sanitize();
+    fs::rename(&created, &renamed).expect("failed to rename the JS file");
+    did_rename(session, &created, &renamed);
+    assert!(!has_js_symbol(session, &created), "the old path must be gone after a rename");
+    assert!(has_js_symbol(session, &renamed), "the new path must be loaded after a rename");
+
+    // 8. a folder rename arrives as ONE event naming the folder, never its children
+    let nested = write_asset(&module, "static/src/sub/nested.js", "export const nested = () => 8;\n");
+    let nested_xml = write_asset(
+        &module,
+        "static/src/sub/nested.xml",
+        "<templates xml:space=\"preserve\">\n    <t t-name=\"module_asset_events.Nested\">\n        <div/>\n    </t>\n</templates>\n",
+    );
+    did_create(session, &nested);
+    did_create(session, &nested_xml);
+    assert!(has_js_symbol(session, &nested));
+    assert!(has_data_symbol(session, &nested_xml));
+
+    fs::rename(&sub_dir, &renamed_sub_dir).expect("failed to rename the asset folder");
+    did_rename(session, &sub_dir.sanitize(), &renamed_sub_dir.sanitize());
+
+    let moved_js = renamed_sub_dir.join("nested.js").sanitize();
+    let moved_xml = renamed_sub_dir.join("nested.xml").sanitize();
+    assert!(!has_js_symbol(session, &nested), "every JS file under the old folder must be gone");
+    assert!(!has_data_symbol(session, &nested_xml), "every XML file under the old folder must be gone");
+    assert!(has_js_symbol(session, &moved_js), "every JS file under the new folder must be loaded");
+    assert!(has_data_symbol(session, &moved_xml), "every XML file under the new folder must be loaded");
+
+    // 9. a folder delete arrives the same way
+    fs::remove_dir_all(&renamed_sub_dir).expect("failed to delete the asset folder");
+    did_delete(session, &renamed_sub_dir.sanitize());
+    assert!(!has_js_symbol(session, &moved_js), "a folder delete must drop the JS files under it");
+    assert!(!has_data_symbol(session, &moved_xml), "a folder delete must drop the XML files under it");
+}
+
 /// Full JS file lifecycle: open → edit → close → rename → reopen.
-/// Uses with_odoo=true to match the expected runtime environment for JS files.
-#[test]
-fn test_js_file_lifecycle_with_odoo() {
-    let (mut odoo, config) = setup::setup::setup_server(true);
-    let mut session = setup::setup::create_init_session(&mut odoo, config);
+fn test_js_file_lifecycle_with_odoo(session: &mut SessionInfo) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
-    let temp_dir = std::env::temp_dir().join(format!("odoo_ls_js_test_{}", std::process::id()));
-    fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
-
-    let js_file = temp_dir.join("test_component.js");
+    let js_file = temp_dir.child("test_component.js");
     let initial_content = "/** @odoo-module */\nexport class TestComponent {}\n";
-    fs::write(&js_file, initial_content).expect("Failed to write JS file");
+    js_file.write_str(initial_content).expect("Failed to write JS file");
 
-    let js_path = js_file.sanitize();
+    let js_path = js_file.path().sanitize();
     let js_uri = FileMgr::pathname2uri(&js_path);
 
     // — open —
-    odoo_ls_server::core::odoo::Odoo::handle_did_open(
-        &mut session,
-        make_js_open_params(js_uri.clone(), initial_content),
-    );
+    Odoo::handle_did_open(session, make_js_open_params(js_uri.clone(), initial_content));
 
     assert!(
         session.sync_odoo.opened_files.contains(&js_path),
@@ -65,16 +244,13 @@ fn test_js_file_lifecycle_with_odoo() {
         session.sync_odoo.get_file_mgr().borrow().get_file_info(&js_path).is_some(),
         "FileInfo should exist after didOpen"
     );
-    let has_custom_entry = session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.iter()
+    let has_entry = session.sync_odoo.entry_point_mgr.borrow().custom_entry_points.iter()
         .any(|ep| ep.borrow().path.contains("test_component"));
-    assert!(has_custom_entry, "Custom entry point should be created for the JS file");
+    assert!(has_entry, "Custom entry point should be created for the JS file");
 
     // — edit —
     let edited_content = "/** @odoo-module */\nexport class TestComponent { setup() {} }\n";
-    odoo_ls_server::core::odoo::Odoo::handle_did_change(
-        &mut session,
-        make_js_change_params(js_uri.clone(), 2, edited_content),
-    );
+    Odoo::handle_did_change(session, make_js_change_params(js_uri.clone(), 2, edited_content));
 
     assert!(
         session.sync_odoo.opened_files.contains(&js_path),
@@ -92,10 +268,7 @@ fn test_js_file_lifecycle_with_odoo() {
     }
 
     // — close —
-    odoo_ls_server::core::odoo::Odoo::handle_did_close(
-        &mut session,
-        make_js_close_params(js_uri.clone()),
-    );
+    Odoo::handle_did_close(session, make_js_close_params(js_uri.clone()));
 
     assert!(
         !session.sync_odoo.opened_files.contains(&js_path),
@@ -106,21 +279,18 @@ fn test_js_file_lifecycle_with_odoo() {
     assert!(!entry_after_close, "Custom entry for original JS file should be removed after didClose");
 
     // — rename on disk —
-    let new_js_file = temp_dir.join("test_component_renamed.js");
-    fs::rename(&js_file, &new_js_file).expect("Failed to rename JS file on disk");
+    let new_js_file = temp_dir.child("test_component_renamed.js");
+    fs::rename(js_file.path(), new_js_file.path()).expect("Failed to rename JS file on disk");
 
-    let new_js_path = new_js_file.sanitize();
+    let new_js_path = new_js_file.path().sanitize();
     let new_js_uri = FileMgr::pathname2uri(&new_js_path);
 
-    odoo_ls_server::core::odoo::Odoo::handle_did_rename(
-        &mut session,
-        lsp_types::RenameFilesParams {
-            files: vec![lsp_types::FileRename {
-                old_uri: js_uri.to_string(),
-                new_uri: new_js_uri.to_string(),
-            }],
-        },
-    );
+    Odoo::handle_did_rename(session, lsp_types::RenameFilesParams {
+        files: vec![lsp_types::FileRename {
+            old_uri: js_uri.to_string(),
+            new_uri: new_js_uri.to_string(),
+        }],
+    });
 
     assert!(
         !session.sync_odoo.opened_files.contains(&js_path),
@@ -128,10 +298,7 @@ fn test_js_file_lifecycle_with_odoo() {
     );
 
     // — open renamed file —
-    odoo_ls_server::core::odoo::Odoo::handle_did_open(
-        &mut session,
-        make_js_open_params(new_js_uri.clone(), edited_content),
-    );
+    Odoo::handle_did_open(session, make_js_open_params(new_js_uri.clone(), edited_content));
 
     assert!(
         session.sync_odoo.opened_files.contains(&new_js_path),
@@ -147,10 +314,7 @@ fn test_js_file_lifecycle_with_odoo() {
 
     // — edit renamed file —
     let final_content = "/** @odoo-module */\nexport class TestComponent { setup() {} destroy() {} }\n";
-    odoo_ls_server::core::odoo::Odoo::handle_did_change(
-        &mut session,
-        make_js_change_params(new_js_uri.clone(), 2, final_content),
-    );
+    Odoo::handle_did_change(session, make_js_change_params(new_js_uri.clone(), 2, final_content));
     {
         let file_mgr = session.sync_odoo.get_file_mgr();
         let file_mgr = file_mgr.borrow();
@@ -163,44 +327,31 @@ fn test_js_file_lifecycle_with_odoo() {
     }
 
     // — close renamed file —
-    odoo_ls_server::core::odoo::Odoo::handle_did_close(
-        &mut session,
-        make_js_close_params(new_js_uri.clone()),
-    );
+    Odoo::handle_did_close(session, make_js_close_params(new_js_uri.clone()));
 
     assert!(
         !session.sync_odoo.opened_files.contains(&new_js_path),
         "Renamed JS file should be removed from opened_files after final close"
     );
 
-    fs::remove_dir_all(&temp_dir).ok();
 }
 
 /// A JS file inside a static/lib/ path should not get OXC diagnostics.
 /// Ensures the is_lib exclusion works end-to-end.
-#[test]
-fn test_js_lib_file_no_oxc_diagnostics() {
-    let (mut odoo, config) = setup::setup::setup_server(true);
-    let mut session = setup::setup::create_init_session(&mut odoo, config);
+fn test_js_lib_file_no_oxc_diagnostics(session: &mut SessionInfo) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
-    let temp_dir = std::env::temp_dir().join(format!("odoo_ls_js_lib_test_{}", std::process::id()));
-    let lib_dir = temp_dir.join("static").join("lib");
-    fs::create_dir_all(&lib_dir).expect("Failed to create static/lib dir");
-
-    let lib_js = lib_dir.join("external_lib.js");
+    let lib_js = temp_dir.child("static/lib/external_lib.js");
     // Deliberately invalid JS — OXC would flag it if not excluded
     let bad_js = "this is not valid javascript @@@;\n";
-    fs::write(&lib_js, bad_js).expect("Failed to write lib JS");
+    lib_js.write_str(bad_js).expect("Failed to write lib JS");
 
-    let lib_path = lib_js.sanitize();
+    let lib_path = lib_js.path().sanitize();
     let lib_uri = FileMgr::pathname2uri(&lib_path);
 
-    odoo_ls_server::core::odoo::Odoo::handle_did_open(
-        &mut session,
-        make_js_open_params(lib_uri.clone(), bad_js),
-    );
+    Odoo::handle_did_open(session, make_js_open_params(lib_uri.clone(), bad_js));
 
-    let diagnostics = setup::setup::get_diagnostics_for_path(&mut session, &lib_path);
+    let diagnostics = setup::setup::get_diagnostics_for_path(session, &lib_path);
     let oxc_diagnostics: Vec<_> = diagnostics.iter().filter(|d| {
         matches!(&d.source, Some(s) if s.contains("oxc") || s.contains("OXC"))
     }).collect();
@@ -210,10 +361,5 @@ fn test_js_lib_file_no_oxc_diagnostics() {
         oxc_diagnostics
     );
 
-    odoo_ls_server::core::odoo::Odoo::handle_did_close(
-        &mut session,
-        make_js_close_params(lib_uri),
-    );
-
-    fs::remove_dir_all(&temp_dir).ok();
+    Odoo::handle_did_close(session, make_js_close_params(lib_uri));
 }


### PR DESCRIPTION
Before this PR:
JS symbols that at were assets did not support didChange: they were unloaded and never reloaded.
They also did not support creation/rename under module's file tree: they were created as custom entry point.

After: JS symbols under a module's static dir are always assets, and children of the ModuleSymbol.